### PR TITLE
feat: add batch section creation workflow

### DIFF
--- a/docs/batch-section-creation-recording-recipe.md
+++ b/docs/batch-section-creation-recording-recipe.md
@@ -1,0 +1,68 @@
+# Batch section creation recording recipe
+
+The batch section-creation feature deliberately contains no guessed Edvibe mutation endpoints. Its read-side discovery uses established repository APIs, while writes are enabled only when a reviewed recipe derived from an Action Recorder export is assigned to `window.EdVibeBatchSectionCreationRecipe` before `src/main.js` runs.
+
+## Required top-level fields
+
+```js
+window.EdVibeBatchSectionCreationRecipe = {
+    version: 1,
+    reviewedDynamicFields: true,
+    steps: [/* recorded creation requests */],
+    cleanupSteps: [/* optional recorded safe deletion requests */]
+};
+```
+
+`reviewedDynamicFields` must be set only after every captured identifier has been classified as fixed, generated, captured from a prior response, or supplied by the current marathon, lesson, section, or block.
+
+## Request step
+
+```js
+{
+    id: 'descriptive-step-name',
+    controller: 'ControllerFromRecording',
+    method: 'MethodFromRecording',
+    projectName: 'ProjectFromRecording',
+    valueTemplate: {
+        LessonId: '{{lesson.lessonId}}',
+        MarathonId: '{{marathonId}}',
+        SectionName: '{{section.name}}',
+        ClientId: '{{generated.sectionClientId}}'
+    },
+    capture: {
+        sectionId: 'Value.SectionId'
+    },
+    marksSectionCreated: true
+}
+```
+
+A step may use `forEach: 'blocks'`. Consecutive block steps are expanded in the user's configured block order. `blockTypes` can restrict a step to `image`, `text`, or `link` blocks.
+
+## Supported template tokens
+
+- `{{marathonId}}`
+- `{{lesson.lessonId}}`, `{{lesson.marathonLessonId}}`, `{{lesson.number}}`, `{{lesson.name}}`
+- `{{section.name}}`
+- `{{block.id}}`, `{{block.type}}`, and the fields belonging to that block type
+- `{{blockIndex}}`
+- `{{captured.<name>}}` for values captured from earlier responses
+- `{{generated.<name>}}` for UUIDs generated at execution time; block-scoped tokens are unique per block
+
+A string containing only a token preserves the resolved value's original type. Other strings are treated as literals.
+
+## Captures and partial creation
+
+`capture` maps a stable recipe name to a dot-separated response path. Set `marksSectionCreated: true` on the first request whose confirmed success means a section now exists and later failure must be reported as `partially_created`.
+
+Optional `cleanupSteps` use the same template rules. They are attempted only after a partial creation and only when the reviewed recording proves deletion is safe. Without cleanup steps, partial results remain visible for manual review.
+
+## Review checklist
+
+1. Record one representative manual creation containing every supported block type.
+2. Remove or redact session data and credentials.
+3. Identify every marathon-, lesson-, section-, block-, request-, and session-specific value.
+4. Replace dynamic values with tokens and retain only truly stable literals.
+5. Verify response capture paths against the recording.
+6. Confirm block request order and any required delays.
+7. Add cleanup steps only when the recorded API safely deletes the newly created section.
+8. Run the automated tests with the reviewed recipe fixture, then manually verify on a disposable lesson.

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
                 "src/components/action-recorder-dialog.css",
                 "src/components/export-progress-dialog.css",
                 "src/components/batch-lesson-access-dialog.css",
-                "src/components/batch-user-management-dialog.css"
+                "src/components/batch-user-management-dialog.css",
+                "src/components/batch-section-creation-dialog.css"
             ],
             "matches": [
                 "*://*.edvibe.com/*"
@@ -55,11 +56,13 @@
                 "src/components/export-progress-dialog.js",
                 "src/components/batch-lesson-access-dialog.js",
                 "src/components/batch-user-management-dialog.js",
+                "src/components/batch-section-creation-dialog.js",
                 "src/features/reset-lessons.js",
                 "src/features/marathon-export.js",
                 "src/features/action-recorder.js",
                 "src/features/batch-lesson-access.js",
                 "src/features/batch-user-management.js",
+                "src/features/batch-section-creation.js",
                 "src/main.js"
             ],
             "run_at": "document_start",

--- a/manifest.json
+++ b/manifest.json
@@ -62,6 +62,7 @@
                 "src/features/action-recorder.js",
                 "src/features/batch-lesson-access.js",
                 "src/features/batch-user-management.js",
+                "src/features/batch-section-creation-recipe.js",
                 "src/features/batch-section-creation.js",
                 "src/main.js"
             ],

--- a/popup.js
+++ b/popup.js
@@ -39,6 +39,16 @@ const TOOL_DEFINITIONS = Object.freeze([
         closeOnSuccess: true
     }),
     Object.freeze({
+        id: 'batch-section-creation',
+        group: 'management',
+        title: 'Создать раздел в уроках',
+        description: 'Добавить один раздел в несколько выбранных уроков.',
+        command: 'OPEN_BATCH_SECTION_CREATION',
+        requirement: 'marathon',
+        busyLabel: 'Открывается…',
+        closeOnSuccess: true
+    }),
+    Object.freeze({
         id: 'batch-user-management',
         group: 'management',
         title: 'Управление пользователями',

--- a/src/components/batch-section-creation-dialog.css
+++ b/src/components/batch-section-creation-dialog.css
@@ -1,0 +1,557 @@
+:host {
+    all: initial;
+}
+
+.edvibe-batch-section-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    box-sizing: border-box;
+    background: rgba(15, 23, 42, .68);
+    color: #1f2937;
+    font-family: "Segoe UI", Arial, sans-serif;
+}
+
+.edvibe-batch-section-overlay *,
+.edvibe-batch-section-overlay *::before,
+.edvibe-batch-section-overlay *::after {
+    box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+.edvibe-batch-section-card {
+    display: flex;
+    flex-direction: column;
+    width: min(1120px, calc(100vw - 36px));
+    max-height: min(900px, calc(100vh - 36px));
+    overflow: hidden;
+    border: 1px solid rgba(148, 163, 184, .32);
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 30px 100px rgba(15, 23, 42, .46);
+}
+
+.edvibe-batch-section-header,
+.edvibe-batch-section-footer,
+.edvibe-batch-section-heading-row,
+.edvibe-batch-section-selection-actions,
+.edvibe-batch-section-block header,
+.edvibe-batch-section-block-actions,
+.edvibe-batch-section-add-actions {
+    display: flex;
+    align-items: center;
+}
+
+.edvibe-batch-section-header {
+    flex: 0 0 auto;
+    justify-content: space-between;
+    gap: 22px;
+    padding: 22px 24px;
+    border-bottom: 1px solid #e5e7eb;
+    background: linear-gradient(135deg, #f8fafc, #eff6ff);
+}
+
+.edvibe-batch-section-eyebrow {
+    margin: 0 0 4px;
+    color: #2563eb;
+    font-size: 11px;
+    font-weight: 750;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+}
+
+.edvibe-batch-section-header h2,
+.edvibe-batch-section-heading-row h3,
+.edvibe-batch-section-preview h3,
+.edvibe-batch-section-summary h3,
+.edvibe-batch-section-results h3,
+.edvibe-batch-section-errors h3 {
+    margin: 0;
+    color: #111827;
+}
+
+.edvibe-batch-section-header h2 {
+    font-size: 22px;
+    line-height: 1.25;
+}
+
+.edvibe-batch-section-description,
+.edvibe-batch-section-heading-row p {
+    margin: 5px 0 0;
+    color: #64748b;
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.edvibe-batch-section-close {
+    flex: 0 0 auto;
+    padding: 4px 9px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: #64748b;
+    font-size: 25px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.edvibe-batch-section-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    padding: 22px 24px 0;
+}
+
+.edvibe-batch-section-grid {
+    display: grid;
+    grid-template-columns: minmax(280px, .82fr) minmax(380px, 1.18fr);
+    gap: 22px;
+}
+
+.edvibe-batch-section-column {
+    min-width: 0;
+}
+
+.edvibe-batch-section-field {
+    display: grid;
+    gap: 7px;
+    color: #374151;
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.edvibe-batch-section-field input,
+.edvibe-batch-section-field textarea {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #cbd5e1;
+    border-radius: 9px;
+    background: #fff;
+    color: #111827;
+    font: 400 14px/1.45 "Segoe UI", Arial, sans-serif;
+    outline: none;
+}
+
+.edvibe-batch-section-field textarea {
+    resize: vertical;
+    min-height: 92px;
+}
+
+.edvibe-batch-section-field input:focus,
+.edvibe-batch-section-field textarea:focus,
+.edvibe-batch-section-lesson:focus-within,
+.edvibe-batch-section-overlay button:focus-visible {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, .14);
+    outline: none;
+}
+
+.edvibe-batch-section-heading-row {
+    justify-content: space-between;
+    gap: 14px;
+    margin: 20px 0 10px;
+}
+
+.edvibe-batch-section-heading-row h3,
+.edvibe-batch-section-preview h3 {
+    font-size: 14px;
+}
+
+.edvibe-batch-section-selection-actions,
+.edvibe-batch-section-add-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.edvibe-batch-section-selection-actions button,
+.edvibe-batch-section-add-actions button,
+.edvibe-batch-section-block-actions button {
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+    color: #334155;
+    font: 650 12px/1.2 "Segoe UI", Arial, sans-serif;
+    cursor: pointer;
+}
+
+.edvibe-batch-section-selection-actions button,
+.edvibe-batch-section-add-actions button {
+    padding: 8px 10px;
+}
+
+.edvibe-batch-section-add-actions {
+    justify-content: flex-start;
+    margin-bottom: 10px;
+}
+
+.edvibe-batch-section-add-actions button {
+    border-color: #bfdbfe;
+    background: #eff6ff;
+    color: #1d4ed8;
+}
+
+.edvibe-batch-section-lessons {
+    overflow: auto;
+    max-height: 390px;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: #fff;
+}
+
+.edvibe-batch-section-lesson {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 11px 12px;
+    border-bottom: 1px solid #f1f5f9;
+    color: #1f2937;
+    font-size: 13px;
+    line-height: 1.4;
+    cursor: pointer;
+}
+
+.edvibe-batch-section-lesson:last-child {
+    border-bottom: 0;
+}
+
+.edvibe-batch-section-lesson:hover {
+    background: #f8fafc;
+}
+
+.edvibe-batch-section-lesson input {
+    flex: 0 0 auto;
+    margin-top: 2px;
+}
+
+.edvibe-batch-section-blocks {
+    display: grid;
+    gap: 10px;
+}
+
+.edvibe-batch-section-block {
+    padding: 13px;
+    border: 1px solid #dbeafe;
+    border-radius: 12px;
+    background: #f8fbff;
+}
+
+.edvibe-batch-section-block header {
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 11px;
+}
+
+.edvibe-batch-section-block strong {
+    color: #1e3a8a;
+    font-size: 13px;
+}
+
+.edvibe-batch-section-block > .edvibe-batch-section-field + .edvibe-batch-section-field {
+    margin-top: 10px;
+}
+
+.edvibe-batch-section-block-actions {
+    gap: 5px;
+}
+
+.edvibe-batch-section-block-actions button {
+    min-width: 31px;
+    padding: 6px 8px;
+}
+
+.edvibe-batch-section-block-actions button[data-block-action="remove"] {
+    border-color: #fecaca;
+    color: #b91c1c;
+}
+
+.edvibe-batch-section-preview {
+    margin-top: 14px;
+    padding: 14px;
+    border: 1px dashed #94a3b8;
+    border-radius: 12px;
+    background: #f8fafc;
+}
+
+.edvibe-batch-section-preview-name {
+    margin: 8px 0;
+    color: #0f172a;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.edvibe-batch-section-preview ol,
+.edvibe-batch-section-summary ul,
+.edvibe-batch-section-errors ul {
+    margin: 8px 0 0;
+    padding-left: 20px;
+}
+
+.edvibe-batch-section-preview li,
+.edvibe-batch-section-summary li,
+.edvibe-batch-section-errors li {
+    margin: 4px 0;
+    overflow-wrap: anywhere;
+}
+
+.edvibe-batch-section-protocol,
+.edvibe-batch-section-errors,
+.edvibe-batch-section-summary,
+.edvibe-batch-section-results {
+    margin-top: 18px;
+    padding: 14px 16px;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    font-size: 13px;
+    line-height: 1.48;
+}
+
+.edvibe-batch-section-protocol {
+    border-color: #fcd34d;
+    background: #fffbeb;
+    color: #92400e;
+}
+
+.edvibe-batch-section-protocol p {
+    margin: 5px 0 0;
+}
+
+.edvibe-batch-section-errors {
+    border-color: #fecaca;
+    background: #fef2f2;
+    color: #991b1b;
+}
+
+.edvibe-batch-section-summary {
+    border-color: #bfdbfe;
+    background: #eff6ff;
+    color: #1e3a8a;
+}
+
+.edvibe-batch-section-summary-group {
+    margin-top: 13px;
+    padding-top: 11px;
+    border-top: 1px solid rgba(37, 99, 235, .18);
+}
+
+.edvibe-batch-section-summary-group h4 {
+    margin: 0;
+    color: #1e3a8a;
+    font-size: 13px;
+}
+
+.edvibe-batch-section-result-list {
+    display: grid;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.edvibe-batch-section-result {
+    display: grid;
+    grid-template-columns: minmax(160px, 1fr) auto;
+    gap: 4px 12px;
+    padding: 11px 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #fff;
+}
+
+.edvibe-batch-section-result strong {
+    color: #111827;
+}
+
+.edvibe-batch-section-result > span {
+    color: #475569;
+    font-weight: 700;
+}
+
+.edvibe-batch-section-result p,
+.edvibe-batch-section-result small {
+    grid-column: 1 / -1;
+    margin: 0;
+    color: #64748b;
+    overflow-wrap: anywhere;
+}
+
+.edvibe-batch-section-result.is-created {
+    border-color: #bbf7d0;
+    background: #f0fdf4;
+}
+
+.edvibe-batch-section-result.is-failed,
+.edvibe-batch-section-result.is-partially_created {
+    border-color: #fed7aa;
+    background: #fff7ed;
+}
+
+.edvibe-batch-section-result.is-rejected,
+.edvibe-batch-section-result.is-not_attempted {
+    background: #f8fafc;
+}
+
+.edvibe-batch-section-fatal-note {
+    margin: 12px 0 0;
+    padding: 10px 12px;
+    border-radius: 9px;
+    background: #fef2f2;
+    color: #991b1b;
+    font-weight: 650;
+}
+
+.edvibe-batch-section-empty {
+    margin: 0;
+    padding: 14px;
+    color: #64748b;
+    font-size: 13px;
+    text-align: center;
+}
+
+.edvibe-batch-section-live-region {
+    flex: 0 0 auto;
+    padding: 14px 24px 0;
+}
+
+.edvibe-batch-section-spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 7px;
+    border: 2px solid #bfdbfe;
+    border-top-color: #2563eb;
+    border-radius: 50%;
+    vertical-align: -3px;
+    animation: edvibe-batch-section-spin .8s linear infinite;
+}
+
+@keyframes edvibe-batch-section-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.edvibe-batch-section-status {
+    min-height: 19px;
+    margin: 0;
+    color: #475569;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.edvibe-batch-section-status[data-state="error"] {
+    color: #b91c1c;
+}
+
+.edvibe-batch-section-status[data-state="warning"] {
+    color: #a16207;
+}
+
+.edvibe-batch-section-progress {
+    display: block;
+    width: 100%;
+    height: 10px;
+    margin-top: 9px;
+    overflow: hidden;
+    border: 0;
+    border-radius: 999px;
+    background: #e5e7eb;
+    appearance: none;
+}
+
+.edvibe-batch-section-progress::-webkit-progress-bar {
+    background: #e5e7eb;
+}
+
+.edvibe-batch-section-progress::-webkit-progress-value {
+    border-radius: 999px;
+    background: linear-gradient(90deg, #2563eb, #16a34a);
+}
+
+.edvibe-batch-section-footer {
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 18px 24px 22px;
+}
+
+.edvibe-batch-section-footer button {
+    padding: 10px 16px;
+    border: 1px solid #cbd5e1;
+    border-radius: 9px;
+    background: #fff;
+    color: #334155;
+    font: 650 13px/1.2 "Segoe UI", Arial, sans-serif;
+    cursor: pointer;
+}
+
+.edvibe-batch-section-preflight,
+.edvibe-batch-section-confirm {
+    border-color: #2563eb !important;
+    background: #2563eb !important;
+    color: #fff !important;
+}
+
+.edvibe-batch-section-overlay button:hover:not(:disabled) {
+    filter: brightness(.97);
+}
+
+.edvibe-batch-section-overlay button:disabled,
+.edvibe-batch-section-overlay input:disabled,
+.edvibe-batch-section-overlay textarea:disabled {
+    cursor: not-allowed;
+    opacity: .56;
+}
+
+@media (max-width: 820px) {
+    .edvibe-batch-section-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .edvibe-batch-section-lessons {
+        max-height: 260px;
+    }
+}
+
+@media (max-width: 560px) {
+    .edvibe-batch-section-overlay {
+        padding: 8px;
+    }
+
+    .edvibe-batch-section-card {
+        width: 100%;
+        max-height: calc(100vh - 16px);
+        border-radius: 13px;
+    }
+
+    .edvibe-batch-section-header,
+    .edvibe-batch-section-body,
+    .edvibe-batch-section-live-region,
+    .edvibe-batch-section-footer {
+        padding-left: 16px;
+        padding-right: 16px;
+    }
+
+    .edvibe-batch-section-heading-row {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .edvibe-batch-section-selection-actions {
+        justify-content: flex-start;
+    }
+
+    .edvibe-batch-section-footer button {
+        flex: 1 1 170px;
+    }
+
+    .edvibe-batch-section-result {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/components/batch-section-creation-dialog.js
+++ b/src/components/batch-section-creation-dialog.js
@@ -1,0 +1,776 @@
+(function initializeBatchSectionCreationDialog(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], () => factory(root));
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(root);
+    } else {
+        root.EdVibeBatchSectionCreationDialog = factory(root);
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createComponent(root) {
+    'use strict';
+
+    const BATCH_SECTION_DIALOG_TAG = 'edvibe-toolbox-batch-section-creation-dialog';
+    const BATCH_SECTION_OVERLAY_ID = 'edvibe-toolbox-batch-section-creation-overlay';
+    const HTMLElementBase = root.HTMLElement || class {};
+    const template = root.document?.createElement?.('template') || null;
+
+    if (template) {
+        template.innerHTML = `
+            <link class="edvibe-batch-section-stylesheet" rel="stylesheet">
+            <div class="edvibe-batch-section-overlay">
+                <section class="edvibe-batch-section-card" role="dialog" aria-modal="true"
+                    aria-labelledby="edvibe-batch-section-title">
+                    <header class="edvibe-batch-section-header">
+                        <div>
+                            <p class="edvibe-batch-section-eyebrow">Edvibe Toolbox</p>
+                            <h2 id="edvibe-batch-section-title">Создать раздел в нескольких уроках</h2>
+                            <p class="edvibe-batch-section-description">
+                                Соберите раздел один раз, проверьте план и примените его к выбранным урокам.
+                            </p>
+                        </div>
+                        <button class="edvibe-batch-section-close" type="button"
+                            aria-label="Закрыть">&times;</button>
+                    </header>
+                    <div class="edvibe-batch-section-body">
+                        <section class="edvibe-batch-section-configure">
+                            <div class="edvibe-batch-section-grid">
+                                <div class="edvibe-batch-section-column">
+                                    <label class="edvibe-batch-section-field">
+                                        <span>Название раздела</span>
+                                        <input class="edvibe-batch-section-name" type="text"
+                                            maxlength="200" autocomplete="off"
+                                            placeholder="Например, Летняя акция">
+                                    </label>
+                                    <div class="edvibe-batch-section-heading-row">
+                                        <div>
+                                            <h3>Уроки</h3>
+                                            <p>Выберите все уроки, куда нужно добавить раздел.</p>
+                                        </div>
+                                        <div class="edvibe-batch-section-selection-actions">
+                                            <button class="edvibe-batch-section-select-all" type="button">Выбрать все</button>
+                                            <button class="edvibe-batch-section-clear-all" type="button">Очистить</button>
+                                        </div>
+                                    </div>
+                                    <div class="edvibe-batch-section-lessons"
+                                        aria-label="Список уроков"></div>
+                                </div>
+                                <div class="edvibe-batch-section-column">
+                                    <div class="edvibe-batch-section-heading-row">
+                                        <div>
+                                            <h3>Конструктор</h3>
+                                            <p>Порядок блоков сохранится при выполнении.</p>
+                                        </div>
+                                    </div>
+                                    <div class="edvibe-batch-section-add-actions" role="group"
+                                        aria-label="Добавить блок">
+                                        <button type="button" data-add-block="image">+ Баннер</button>
+                                        <button type="button" data-add-block="text">+ Текст</button>
+                                        <button type="button" data-add-block="link">+ Ссылка</button>
+                                    </div>
+                                    <div class="edvibe-batch-section-blocks"></div>
+                                    <section class="edvibe-batch-section-preview" aria-live="polite">
+                                        <h3>Предпросмотр структуры</h3>
+                                        <p class="edvibe-batch-section-preview-name">Название не задано</p>
+                                        <ol class="edvibe-batch-section-preview-blocks"></ol>
+                                    </section>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="edvibe-batch-section-protocol" hidden></section>
+                        <section class="edvibe-batch-section-errors" aria-live="polite" hidden></section>
+                        <section class="edvibe-batch-section-summary" aria-live="polite" hidden></section>
+                        <section class="edvibe-batch-section-results" aria-live="polite" hidden></section>
+                    </div>
+                    <div class="edvibe-batch-section-live-region">
+                        <span class="edvibe-batch-section-spinner" role="img"
+                            aria-label="Выполняется операция" hidden></span>
+                        <p class="edvibe-batch-section-status" role="status" aria-live="polite"></p>
+                        <progress class="edvibe-batch-section-progress" max="0" value="0" hidden></progress>
+                    </div>
+                    <footer class="edvibe-batch-section-footer">
+                        <button class="edvibe-batch-section-copy" type="button" hidden>Копировать отчёт</button>
+                        <button class="edvibe-batch-section-restart" type="button" hidden>Создать другой раздел</button>
+                        <button class="edvibe-batch-section-confirm" type="button" hidden>Подтвердить создание</button>
+                        <button class="edvibe-batch-section-preflight" type="button" disabled>Проверить план</button>
+                    </footer>
+                </section>
+            </div>
+        `;
+    }
+
+    class BatchSectionCreationDialog extends HTMLElementBase {
+        constructor() {
+            super();
+            this.stylesheetUrl = '';
+            this.lessons = [];
+            this.selectedLessonIds = new Set();
+            this.blocks = [];
+            this.nextBlockId = 1;
+            this.mode = 'initializing';
+            this.recipeReady = false;
+            this.recipeErrors = [];
+            this.currentPlan = null;
+            this.connected = false;
+            this.rendered = false;
+
+            if (typeof this.attachShadow !== 'function' || !template) {
+                return;
+            }
+            const shadow = this.attachShadow({ mode: 'open' });
+            shadow.append(template.content.cloneNode(true));
+            this.cacheElements();
+            this.rendered = true;
+            this.renderState();
+        }
+
+        connectedCallback() {
+            if (!this.id) {
+                this.id = BATCH_SECTION_OVERLAY_ID;
+            }
+            this.connectListeners();
+            this.renderState();
+        }
+
+        disconnectedCallback() {
+            this.disconnectListeners();
+        }
+
+        configure(options = {}) {
+            if (options.stylesheetUrl !== undefined) {
+                this.stylesheetUrl = String(options.stylesheetUrl || '');
+                this.elements?.stylesheet?.setAttribute('href', this.stylesheetUrl);
+            }
+            return this;
+        }
+
+        cacheElements() {
+            const find = (selector) => this.shadowRoot.querySelector(selector);
+            this.elements = {
+                stylesheet: find('.edvibe-batch-section-stylesheet'),
+                backdrop: find('.edvibe-batch-section-overlay'),
+                configure: find('.edvibe-batch-section-configure'),
+                name: find('.edvibe-batch-section-name'),
+                lessons: find('.edvibe-batch-section-lessons'),
+                selectAll: find('.edvibe-batch-section-select-all'),
+                clearAll: find('.edvibe-batch-section-clear-all'),
+                addActions: find('.edvibe-batch-section-add-actions'),
+                blocks: find('.edvibe-batch-section-blocks'),
+                previewName: find('.edvibe-batch-section-preview-name'),
+                previewBlocks: find('.edvibe-batch-section-preview-blocks'),
+                protocol: find('.edvibe-batch-section-protocol'),
+                errors: find('.edvibe-batch-section-errors'),
+                summary: find('.edvibe-batch-section-summary'),
+                results: find('.edvibe-batch-section-results'),
+                spinner: find('.edvibe-batch-section-spinner'),
+                status: find('.edvibe-batch-section-status'),
+                progress: find('.edvibe-batch-section-progress'),
+                close: find('.edvibe-batch-section-close'),
+                preflight: find('.edvibe-batch-section-preflight'),
+                confirm: find('.edvibe-batch-section-confirm'),
+                copy: find('.edvibe-batch-section-copy'),
+                restart: find('.edvibe-batch-section-restart')
+            };
+            this.elements.stylesheet.setAttribute('href', this.stylesheetUrl);
+        }
+
+        connectListeners() {
+            if (!this.rendered || this.connected) {
+                return;
+            }
+            this.connected = true;
+            this.onInput = this.onInput.bind(this);
+            this.onLessonChange = this.onLessonChange.bind(this);
+            this.onSelectAll = this.onSelectAll.bind(this);
+            this.onClearAll = this.onClearAll.bind(this);
+            this.onAddBlock = this.onAddBlock.bind(this);
+            this.onBlockClick = this.onBlockClick.bind(this);
+            this.onPreflight = this.onPreflight.bind(this);
+            this.onConfirm = this.onConfirm.bind(this);
+            this.onCopy = this.onCopy.bind(this);
+            this.onRestart = this.onRestart.bind(this);
+            this.close = this.close.bind(this);
+            this.onBackdrop = this.onBackdrop.bind(this);
+            this.onKeydown = this.onKeydown.bind(this);
+
+            this.elements.name.addEventListener('input', this.onInput);
+            this.elements.lessons.addEventListener('change', this.onLessonChange);
+            this.elements.selectAll.addEventListener('click', this.onSelectAll);
+            this.elements.clearAll.addEventListener('click', this.onClearAll);
+            this.elements.addActions.addEventListener('click', this.onAddBlock);
+            this.elements.blocks.addEventListener('input', this.onInput);
+            this.elements.blocks.addEventListener('click', this.onBlockClick);
+            this.elements.preflight.addEventListener('click', this.onPreflight);
+            this.elements.confirm.addEventListener('click', this.onConfirm);
+            this.elements.copy.addEventListener('click', this.onCopy);
+            this.elements.restart.addEventListener('click', this.onRestart);
+            this.elements.close.addEventListener('click', this.close);
+            this.elements.backdrop.addEventListener('click', this.onBackdrop);
+            this.ownerDocument?.addEventListener('keydown', this.onKeydown);
+        }
+
+        disconnectListeners() {
+            if (!this.connected) {
+                return;
+            }
+            this.connected = false;
+            this.elements.name.removeEventListener('input', this.onInput);
+            this.elements.lessons.removeEventListener('change', this.onLessonChange);
+            this.elements.selectAll.removeEventListener('click', this.onSelectAll);
+            this.elements.clearAll.removeEventListener('click', this.onClearAll);
+            this.elements.addActions.removeEventListener('click', this.onAddBlock);
+            this.elements.blocks.removeEventListener('input', this.onInput);
+            this.elements.blocks.removeEventListener('click', this.onBlockClick);
+            this.elements.preflight.removeEventListener('click', this.onPreflight);
+            this.elements.confirm.removeEventListener('click', this.onConfirm);
+            this.elements.copy.removeEventListener('click', this.onCopy);
+            this.elements.restart.removeEventListener('click', this.onRestart);
+            this.elements.close.removeEventListener('click', this.close);
+            this.elements.backdrop.removeEventListener('click', this.onBackdrop);
+            this.ownerDocument?.removeEventListener('keydown', this.onKeydown);
+        }
+
+        showLoading(message = 'Загрузка…') {
+            this.mode = 'loading';
+            this.clearMessages();
+            this.setStatus(message);
+            this.renderState();
+            return this;
+        }
+
+        showConfigure({ lessons = this.lessons, recipeReady = false, recipeErrors = [] } = {}) {
+            this.mode = 'configure';
+            this.lessons = Array.isArray(lessons) ? lessons : [];
+            this.recipeReady = Boolean(recipeReady);
+            this.recipeErrors = Array.isArray(recipeErrors) ? recipeErrors : [];
+            this.selectedLessonIds.clear();
+            this.currentPlan = null;
+            this.clearMessages();
+            this.renderLessons();
+            this.renderBlocks();
+            this.renderPreview();
+            this.renderRecipeState();
+            this.setStatus('Настройте раздел и выберите уроки.');
+            this.renderState();
+            return this;
+        }
+
+        showValidationErrors(errors = []) {
+            this.mode = 'validation-error';
+            this.renderErrors(errors);
+            this.setStatus('Исправьте ошибки и повторите проверку.', 'error');
+            this.renderState();
+            return this;
+        }
+
+        showConfirmation(plan) {
+            this.mode = 'confirm';
+            this.currentPlan = plan;
+            this.clearMessages();
+            this.renderSummary(plan);
+            this.renderRecipeState();
+            this.setStatus(plan.eligible.length
+                ? 'Проверка завершена. Подтвердите создание.'
+                : 'Нет уроков, подходящих для создания.', 'warning');
+            this.renderState();
+            return this;
+        }
+
+        showExecution(progress = {}) {
+            this.mode = 'executing';
+            const completed = Math.max(0, Number(progress.completed) || 0);
+            const total = Math.max(0, Number(progress.total) || 0);
+            this.elements.progress.hidden = false;
+            this.elements.progress.max = total;
+            this.elements.progress.value = completed;
+            const lesson = progress.lesson
+                ? ` Сейчас: ${progress.lesson.number}. ${progress.lesson.name}.`
+                : '';
+            this.setStatus(`Выполнено ${completed} из ${total}.${lesson}`);
+            this.renderState();
+            return this;
+        }
+
+        showComplete(result = {}, fatalError = null) {
+            this.mode = 'complete';
+            this.clearMessages();
+            this.renderResults(result, fatalError);
+            this.setStatus(fatalError
+                ? 'Операция остановлена. Частичный результат сохранён.'
+                : 'Пакетная операция завершена.', fatalError ? 'error' : '');
+            this.renderState();
+            return this;
+        }
+
+        showFatalError(error) {
+            this.mode = 'fatal-error';
+            this.clearMessages();
+            this.renderErrors([error]);
+            this.setStatus('Не удалось открыть инструмент.', 'error');
+            this.renderState();
+            return this;
+        }
+
+        clearMessages() {
+            for (const element of [
+                this.elements.errors,
+                this.elements.summary,
+                this.elements.results
+            ]) {
+                element.replaceChildren();
+                element.hidden = true;
+            }
+        }
+
+        renderRecipeState() {
+            const section = this.elements.protocol;
+            section.replaceChildren();
+            section.hidden = this.recipeReady;
+            if (this.recipeReady) {
+                return;
+            }
+            const document = this.ownerDocument || root.document;
+            const strong = document.createElement('strong');
+            strong.textContent = 'Запись WebSocket ещё не подключена.';
+            const text = document.createElement('p');
+            text.textContent = this.recipeErrors[0]?.message
+                || 'Создание будет заблокировано, пока запись не преобразована в проверенный рецепт.';
+            section.append(strong, text);
+        }
+
+        renderLessons() {
+            const document = this.ownerDocument || root.document;
+            this.elements.lessons.replaceChildren();
+            if (this.lessons.length === 0) {
+                const empty = document.createElement('p');
+                empty.className = 'edvibe-batch-section-empty';
+                empty.textContent = 'Уроки не найдены.';
+                this.elements.lessons.appendChild(empty);
+                return;
+            }
+            for (const lesson of this.lessons) {
+                const label = document.createElement('label');
+                label.className = 'edvibe-batch-section-lesson';
+                const input = document.createElement('input');
+                input.type = 'checkbox';
+                input.value = String(lesson.lessonId);
+                input.checked = this.selectedLessonIds.has(Number(lesson.lessonId));
+                const text = document.createElement('span');
+                text.textContent = `${lesson.number || '?'}. ${lesson.name}`;
+                label.append(input, text);
+                this.elements.lessons.appendChild(label);
+            }
+        }
+
+        createBlock(type) {
+            const block = { id: `block-${this.nextBlockId++}`, type };
+            if (type === 'image') {
+                return { ...block, url: '', alt: '' };
+            }
+            if (type === 'text') {
+                return { ...block, text: '' };
+            }
+            return { ...block, label: '', url: '' };
+        }
+
+        blockLabel(type) {
+            return { image: 'Баннер', text: 'Текст', link: 'Ссылка' }[type] || type;
+        }
+
+        appendField(container, labelText, field, value, multiline = false) {
+            const document = this.ownerDocument || root.document;
+            const label = document.createElement('label');
+            label.className = 'edvibe-batch-section-field';
+            const title = document.createElement('span');
+            title.textContent = labelText;
+            const input = document.createElement(multiline ? 'textarea' : 'input');
+            if (!multiline) {
+                input.type = 'text';
+            }
+            input.dataset.blockField = field;
+            input.value = value || '';
+            label.append(title, input);
+            container.appendChild(label);
+        }
+
+        renderBlocks() {
+            const document = this.ownerDocument || root.document;
+            this.elements.blocks.replaceChildren();
+            if (this.blocks.length === 0) {
+                const empty = document.createElement('p');
+                empty.className = 'edvibe-batch-section-empty';
+                empty.textContent = 'Добавьте баннер, текст или ссылку.';
+                this.elements.blocks.appendChild(empty);
+                return;
+            }
+            this.blocks.forEach((block, index) => {
+                const article = document.createElement('article');
+                article.className = 'edvibe-batch-section-block';
+                article.dataset.blockId = block.id;
+                const header = document.createElement('header');
+                const title = document.createElement('strong');
+                title.textContent = `${index + 1}. ${this.blockLabel(block.type)}`;
+                const actions = document.createElement('div');
+                actions.className = 'edvibe-batch-section-block-actions';
+                for (const [action, label, disabled] of [
+                    ['up', '↑', index === 0],
+                    ['down', '↓', index === this.blocks.length - 1],
+                    ['remove', 'Удалить', false]
+                ]) {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.dataset.blockAction = action;
+                    button.dataset.originalDisabled = disabled ? 'true' : 'false';
+                    button.disabled = disabled;
+                    button.textContent = label;
+                    actions.appendChild(button);
+                }
+                header.append(title, actions);
+                article.appendChild(header);
+
+                if (block.type === 'image') {
+                    this.appendField(article, 'URL изображения', 'url', block.url);
+                    this.appendField(article, 'Альтернативный текст', 'alt', block.alt);
+                } else if (block.type === 'text') {
+                    this.appendField(article, 'Текст или HTML', 'text', block.text, true);
+                } else {
+                    this.appendField(article, 'Подпись кнопки', 'label', block.label);
+                    this.appendField(article, 'URL', 'url', block.url);
+                }
+                this.elements.blocks.appendChild(article);
+            });
+        }
+
+        renderPreview() {
+            const document = this.ownerDocument || root.document;
+            this.elements.previewName.textContent = this.elements.name.value.trim()
+                || 'Название не задано';
+            this.elements.previewBlocks.replaceChildren();
+            if (this.blocks.length === 0) {
+                const item = document.createElement('li');
+                item.textContent = 'Блоки не добавлены';
+                this.elements.previewBlocks.appendChild(item);
+                return;
+            }
+            this.blocks.forEach((block, index) => {
+                const item = document.createElement('li');
+                const detail = block.type === 'image'
+                    ? block.url || 'URL не указан'
+                    : block.type === 'text'
+                        ? block.text || 'Текст не указан'
+                        : `${block.label || 'Без подписи'} → ${block.url || 'URL не указан'}`;
+                item.textContent = `${index + 1}. ${this.blockLabel(block.type)}: ${detail}`;
+                this.elements.previewBlocks.appendChild(item);
+            });
+        }
+
+        renderErrors(errors) {
+            const document = this.ownerDocument || root.document;
+            const section = this.elements.errors;
+            section.replaceChildren();
+            section.hidden = false;
+            const title = document.createElement('h3');
+            title.textContent = 'Что нужно исправить';
+            const list = document.createElement('ul');
+            for (const error of errors) {
+                const item = document.createElement('li');
+                item.textContent = `${error?.code || 'ERROR'}: ${error?.message || String(error)}`;
+                list.appendChild(item);
+            }
+            section.append(title, list);
+        }
+
+        renderSummary(plan) {
+            const document = this.ownerDocument || root.document;
+            const section = this.elements.summary;
+            section.replaceChildren();
+            section.hidden = false;
+            const title = document.createElement('h3');
+            title.textContent = 'Предварительный план';
+            const overview = document.createElement('ul');
+            for (const text of [
+                `Выбрано уроков: ${plan.selectedLessonIds.length}`,
+                `Готово к созданию: ${plan.eligible.length}`,
+                `Отклонено проверкой: ${plan.rejected.length}`,
+                `Раздел: ${plan.definition.name}`,
+                `Блоков: ${plan.definition.blocks.length}`
+            ]) {
+                const item = document.createElement('li');
+                item.textContent = text;
+                overview.appendChild(item);
+            }
+            section.append(title, overview);
+            section.appendChild(this.createSummaryGroup(
+                'Будут обработаны',
+                plan.eligible,
+                (lesson) => `${lesson.number}. ${lesson.name}`
+            ));
+            section.appendChild(this.createSummaryGroup(
+                'Отклонены',
+                plan.rejected,
+                (lesson) => `${lesson.number}. ${lesson.name} — ${lesson.code}: ${lesson.message}`
+            ));
+        }
+
+        createSummaryGroup(titleText, lessons, format) {
+            const document = this.ownerDocument || root.document;
+            const group = document.createElement('div');
+            group.className = 'edvibe-batch-section-summary-group';
+            const title = document.createElement('h4');
+            title.textContent = `${titleText} (${lessons.length})`;
+            const list = document.createElement('ul');
+            if (lessons.length === 0) {
+                const empty = document.createElement('li');
+                empty.textContent = 'Нет';
+                list.appendChild(empty);
+            } else {
+                lessons.forEach((lesson) => {
+                    const item = document.createElement('li');
+                    item.textContent = format(lesson);
+                    list.appendChild(item);
+                });
+            }
+            group.append(title, list);
+            return group;
+        }
+
+        renderResults(result, fatalError) {
+            const document = this.ownerDocument || root.document;
+            const section = this.elements.results;
+            section.replaceChildren();
+            section.hidden = false;
+            const title = document.createElement('h3');
+            title.textContent = fatalError ? 'Частичный результат' : 'Результат';
+            section.appendChild(title);
+            const list = document.createElement('div');
+            list.className = 'edvibe-batch-section-result-list';
+            for (const entry of result.results || []) {
+                const row = document.createElement('article');
+                row.className = `edvibe-batch-section-result is-${entry.status}`;
+                const heading = document.createElement('strong');
+                heading.textContent = `${entry.lessonNumber || '?'}. ${entry.lessonName}`;
+                const status = document.createElement('span');
+                status.textContent = this.resultStatusLabel(entry.status);
+                const message = document.createElement('p');
+                message.textContent = entry.code
+                    ? `${entry.code}: ${entry.message || ''}`
+                    : entry.message || 'Готово';
+                row.append(heading, status, message);
+                if (entry.cleanup) {
+                    const cleanup = document.createElement('small');
+                    cleanup.textContent = `Очистка: ${entry.cleanup.status}`;
+                    row.appendChild(cleanup);
+                }
+                list.appendChild(row);
+            }
+            section.appendChild(list);
+            if (fatalError) {
+                const fatal = document.createElement('p');
+                fatal.className = 'edvibe-batch-section-fatal-note';
+                fatal.textContent = `${fatalError.code || 'INTERNAL_ERROR'}: ${fatalError.message}`;
+                section.appendChild(fatal);
+            }
+        }
+
+        resultStatusLabel(status) {
+            return {
+                created: 'Создано',
+                rejected: 'Отклонено',
+                failed: 'Ошибка',
+                partially_created: 'Нужна ручная проверка',
+                not_attempted: 'Не выполнено'
+            }[status] || status;
+        }
+
+        setStatus(message, state = '') {
+            this.elements.status.textContent = message;
+            this.elements.status.dataset.state = state;
+        }
+
+        collectDefinition() {
+            return {
+                name: this.elements.name.value,
+                blocks: this.blocks.map((block) => ({ ...block }))
+            };
+        }
+
+        onInput(event) {
+            const article = event.target.closest?.('[data-block-id]');
+            const field = event.target.dataset?.blockField;
+            if (article && field) {
+                const block = this.blocks.find((entry) => entry.id === article.dataset.blockId);
+                if (block) {
+                    block[field] = event.target.value;
+                }
+            }
+            this.renderPreview();
+            this.renderState();
+        }
+
+        onLessonChange(event) {
+            if (event.target.type !== 'checkbox') {
+                return;
+            }
+            const lessonId = Number(event.target.value);
+            if (event.target.checked) {
+                this.selectedLessonIds.add(lessonId);
+            } else {
+                this.selectedLessonIds.delete(lessonId);
+            }
+            this.renderState();
+        }
+
+        onSelectAll() {
+            this.selectedLessonIds = new Set(this.lessons.map((lesson) => Number(lesson.lessonId)));
+            this.renderLessons();
+            this.renderState();
+        }
+
+        onClearAll() {
+            this.selectedLessonIds.clear();
+            this.renderLessons();
+            this.renderState();
+        }
+
+        onAddBlock(event) {
+            const type = event.target.dataset?.addBlock;
+            if (!type) {
+                return;
+            }
+            this.blocks.push(this.createBlock(type));
+            this.renderBlocks();
+            this.renderPreview();
+            this.renderState();
+        }
+
+        onBlockClick(event) {
+            const action = event.target.dataset?.blockAction;
+            const article = event.target.closest?.('[data-block-id]');
+            if (!action || !article) {
+                return;
+            }
+            const index = this.blocks.findIndex((block) => block.id === article.dataset.blockId);
+            if (index < 0) {
+                return;
+            }
+            if (action === 'remove') {
+                this.blocks.splice(index, 1);
+            } else if (action === 'up' && index > 0) {
+                const [block] = this.blocks.splice(index, 1);
+                this.blocks.splice(index - 1, 0, block);
+            } else if (action === 'down' && index < this.blocks.length - 1) {
+                const [block] = this.blocks.splice(index, 1);
+                this.blocks.splice(index + 1, 0, block);
+            }
+            this.renderBlocks();
+            this.renderPreview();
+            this.renderState();
+        }
+
+        onPreflight() {
+            this.dispatchEvent(new root.CustomEvent('edvibe-batch-section-preflight', {
+                bubbles: true,
+                composed: true,
+                detail: {
+                    definition: this.collectDefinition(),
+                    selectedLessonIds: [...this.selectedLessonIds]
+                }
+            }));
+        }
+
+        onConfirm() {
+            this.dispatchEvent(new root.CustomEvent('edvibe-batch-section-confirm', {
+                bubbles: true,
+                composed: true
+            }));
+        }
+
+        onCopy() {
+            this.dispatchEvent(new root.CustomEvent('edvibe-batch-section-copy', {
+                bubbles: true,
+                composed: true
+            }));
+        }
+
+        onRestart() {
+            this.elements.name.value = '';
+            this.blocks = [];
+            this.selectedLessonIds.clear();
+            this.dispatchEvent(new root.CustomEvent('edvibe-batch-section-restart', {
+                bubbles: true,
+                composed: true
+            }));
+        }
+
+        close() {
+            this.dispatchEvent(new root.CustomEvent('edvibe-dialog-close', {
+                bubbles: true,
+                composed: true
+            }));
+            this.remove?.();
+        }
+
+        onBackdrop(event) {
+            if (event.target === this.elements.backdrop && !this.isBusy()) {
+                this.close();
+            }
+        }
+
+        onKeydown(event) {
+            if (event.key === 'Escape' && !this.isBusy()) {
+                this.close();
+            }
+        }
+
+        isBusy() {
+            return ['loading', 'executing'].includes(this.mode);
+        }
+
+        renderState() {
+            if (!this.rendered) {
+                return;
+            }
+            const configurable = ['configure', 'validation-error'].includes(this.mode);
+            const busy = this.isBusy();
+            const canPreflight = configurable
+                && this.selectedLessonIds.size > 0
+                && this.elements.name.value.trim().length > 0
+                && this.blocks.length > 0;
+
+            this.elements.spinner.hidden = !busy;
+            this.elements.configure.hidden = !configurable;
+            this.elements.name.disabled = !configurable;
+            this.elements.selectAll.disabled = !configurable;
+            this.elements.clearAll.disabled = !configurable;
+            this.elements.lessons.querySelectorAll('input').forEach((input) => {
+                input.disabled = !configurable;
+            });
+            this.elements.addActions.querySelectorAll('button').forEach((button) => {
+                button.disabled = !configurable;
+            });
+            this.elements.blocks.querySelectorAll('input, textarea, button').forEach((control) => {
+                const boundaryDisabled = control.dataset?.originalDisabled === 'true';
+                control.disabled = !configurable || boundaryDisabled;
+            });
+            this.elements.preflight.hidden = !configurable;
+            this.elements.preflight.disabled = !canPreflight;
+            this.elements.confirm.hidden = this.mode !== 'confirm';
+            this.elements.confirm.disabled = !this.recipeReady || !this.currentPlan?.eligible?.length;
+            this.elements.copy.hidden = this.mode !== 'complete';
+            this.elements.restart.hidden = this.mode !== 'complete';
+            this.elements.close.disabled = busy;
+            if (this.mode !== 'executing') {
+                this.elements.progress.hidden = true;
+            }
+        }
+    }
+
+    if (root.customElements && !root.customElements.get(BATCH_SECTION_DIALOG_TAG)) {
+        root.customElements.define(BATCH_SECTION_DIALOG_TAG, BatchSectionCreationDialog);
+    }
+
+    return {
+        BatchSectionCreationDialog,
+        BATCH_SECTION_DIALOG_TAG,
+        BATCH_SECTION_OVERLAY_ID
+    };
+});

--- a/src/features/batch-section-creation-recipe.js
+++ b/src/features/batch-section-creation-recipe.js
@@ -1,0 +1,105 @@
+(function installBatchSectionCreationRecipe(root) {
+    'use strict';
+
+    const clientTime = new Date().toISOString();
+
+    // Derived from the WebSocket recording captured on 2026-08-05.
+    // V1 intentionally reuses the single recorded Edvibe image asset.
+    root.EdVibeBatchSectionCreationRecipe = Object.freeze({
+        version: 1,
+        reviewedDynamicFields: true,
+        steps: Object.freeze([
+            Object.freeze({
+                id: 'create-section',
+                controller: 'LessonSectionWsController',
+                method: 'AddStageSection',
+                projectName: 'Books',
+                valueTemplate: Object.freeze({
+                    LessonId: '{{lesson.lessonId}}',
+                    StageSectionName: '{{section.name}}',
+                    SortId: 4
+                }),
+                capture: Object.freeze({ sectionId: 'Value.StageSectionId' }),
+                marksSectionCreated: true
+            }),
+            Object.freeze({
+                id: 'confirm-section-name',
+                controller: 'LessonSectionWsController',
+                method: 'EditStageSection',
+                projectName: 'Books',
+                valueTemplate: Object.freeze({
+                    LessonId: '{{lesson.lessonId}}',
+                    StageSectionId: '{{captured.sectionId}}',
+                    StageSectionName: '{{section.name}}',
+                    SortId: 4
+                })
+            }),
+            Object.freeze({
+                id: 'save-image',
+                controller: 'SaveExerciseWsController',
+                method: 'SaveExercise',
+                projectName: 'Exercises',
+                forEach: 'blocks',
+                blockTypes: Object.freeze(['image']),
+                valueTemplate: Object.freeze({
+                    ClassId: null,
+                    Domain: 'edvibe.com',
+                    ExerciseView: Object.freeze({
+                        Id: 0,
+                        Number: '{{blockIndex}}',
+                        Name: '',
+                        IsHidePupil: false,
+                        Type: 27,
+                        HomeworkLessonId: null,
+                        PersonalMaterialId: null,
+                        LessonSectionId: '{{captured.sectionId}}',
+                        Descriptions: Object.freeze(['']),
+                        ChangeExerciseImages: Object.freeze([
+                            Object.freeze({
+                                ImageId: 687640222,
+                                FullImageId: 687640223,
+                                ImageUrl: 'https://media-y.edvibe.com/files/LessonExerciseImages/b455a98f-ef63-49b5-a6f4-2111c7edebc6.png',
+                                FullImageUrl: 'https://media-y.edvibe.com/files/LessonExerciseImages/035f9f67-1474-4eb3-8359-5eb93ea68a2e.png',
+                                cropped: false
+                            })
+                        ])
+                    }),
+                    AiUsed: false,
+                    UsedNewConstructor: true,
+                    ClientTime: clientTime,
+                    DeviceType: 'desktop'
+                })
+            }),
+            Object.freeze({
+                id: 'save-cta',
+                controller: 'SaveExerciseWsController',
+                method: 'SaveExercise',
+                projectName: 'Exercises',
+                forEach: 'blocks',
+                blockTypes: Object.freeze(['link']),
+                valueTemplate: Object.freeze({
+                    ClassId: null,
+                    Domain: 'edvibe.com',
+                    ExerciseView: Object.freeze({
+                        Id: 0,
+                        Number: '{{blockIndex}}',
+                        Name: '',
+                        IsHidePupil: false,
+                        Type: 29,
+                        HomeworkLessonId: null,
+                        PersonalMaterialId: null,
+                        LessonSectionId: '{{captured.sectionId}}',
+                        Button: Object.freeze({
+                            Link: '{{block.url}}',
+                            Text: '{{block.label}}'
+                        })
+                    }),
+                    AiUsed: false,
+                    UsedNewConstructor: true,
+                    ClientTime: clientTime,
+                    DeviceType: 'desktop'
+                })
+            })
+        ])
+    });
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/src/features/batch-section-creation.js
+++ b/src/features/batch-section-creation.js
@@ -1,0 +1,820 @@
+(function initializeBatchSectionCreation(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.EdVibeBatchSectionCreation = factory();
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule() {
+    'use strict';
+
+    const DIALOG_TAG = 'edvibe-toolbox-batch-section-creation-dialog';
+    const OVERLAY_ID = 'edvibe-toolbox-batch-section-creation-overlay';
+    const TRANSIENT_CODES = new Set(['WS_UNAVAILABLE', 'REQUEST_TIMEOUT', 'SEND_FAILED']);
+    const EXPECTED_WRITE_CODES = new Set([
+        ...TRANSIENT_CODES,
+        'SERVER_REJECTED',
+        'INVALID_RESPONSE'
+    ]);
+    const TOKEN_PATTERN = /\{\{\s*([^{}]+?)\s*\}\}/g;
+
+    function createFeatureError(code, message, details = {}) {
+        const error = new Error(message);
+        error.code = code;
+        Object.assign(error, details);
+        return error;
+    }
+
+    function parseMarathonId(url) {
+        const match = String(url || '').match(/\/marathon\/(\d+)(?:\/|$)/);
+        return match ? Number(match[1]) : null;
+    }
+
+    function normalizeUrl(value) {
+        const text = String(value || '').trim();
+        if (!text) {
+            return '';
+        }
+        try {
+            const url = new URL(text);
+            return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : '';
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function normalizeBlock(block, index) {
+        const type = String(block?.type || '').trim();
+        const id = String(block?.id || `block-${index + 1}`).trim();
+        if (type === 'image') {
+            return Object.freeze({
+                id,
+                type,
+                url: String(block?.url || '').trim(),
+                alt: String(block?.alt || '').trim()
+            });
+        }
+        if (type === 'text') {
+            return Object.freeze({ id, type, text: String(block?.text || '').trim() });
+        }
+        if (type === 'link') {
+            return Object.freeze({
+                id,
+                type,
+                label: String(block?.label || '').trim(),
+                url: String(block?.url || '').trim()
+            });
+        }
+        return Object.freeze({ id, type });
+    }
+
+    function validateSectionDefinition(input = {}) {
+        const errors = [];
+        const name = String(input?.name || '').trim();
+        const blocks = Array.isArray(input?.blocks)
+            ? input.blocks.map(normalizeBlock)
+            : [];
+        const seenIds = new Set();
+
+        if (!name) {
+            errors.push(createFeatureError('SECTION_NAME_REQUIRED', 'Section name is required.'));
+        }
+        if (blocks.length === 0) {
+            errors.push(createFeatureError('SECTION_BLOCK_REQUIRED', 'Add at least one section block.'));
+        }
+
+        for (const [index, block] of blocks.entries()) {
+            if (seenIds.has(block.id)) {
+                errors.push(createFeatureError(
+                    'DUPLICATE_BLOCK_ID',
+                    `Block ${index + 1} has a duplicate ID.`
+                ));
+            }
+            seenIds.add(block.id);
+
+            if (block.type === 'image') {
+                if (!normalizeUrl(block.url)) {
+                    errors.push(createFeatureError(
+                        'IMAGE_URL_REQUIRED',
+                        `Image block ${index + 1} requires an HTTP(S) URL.`
+                    ));
+                }
+            } else if (block.type === 'text') {
+                if (!block.text) {
+                    errors.push(createFeatureError(
+                        'TEXT_REQUIRED',
+                        `Text block ${index + 1} cannot be empty.`
+                    ));
+                }
+            } else if (block.type === 'link') {
+                if (!block.label) {
+                    errors.push(createFeatureError(
+                        'LINK_LABEL_REQUIRED',
+                        `Link block ${index + 1} requires a label.`
+                    ));
+                }
+                if (!normalizeUrl(block.url)) {
+                    errors.push(createFeatureError(
+                        'LINK_URL_REQUIRED',
+                        `Link block ${index + 1} requires an HTTP(S) URL.`
+                    ));
+                }
+            } else {
+                errors.push(createFeatureError(
+                    'UNSUPPORTED_BLOCK_TYPE',
+                    `Block ${index + 1} has unsupported type "${block.type || 'unknown'}".`
+                ));
+            }
+        }
+
+        return {
+            definition: Object.freeze({ name, blocks: Object.freeze(blocks) }),
+            errors
+        };
+    }
+
+    function reorderBlocks(blocks, fromIndex, toIndex) {
+        const next = (Array.isArray(blocks) ? blocks : []).map((block) => ({ ...block }));
+        if (
+            !Number.isInteger(fromIndex)
+            || !Number.isInteger(toIndex)
+            || fromIndex < 0
+            || toIndex < 0
+            || fromIndex >= next.length
+            || toIndex >= next.length
+            || fromIndex === toIndex
+        ) {
+            return next;
+        }
+        const [block] = next.splice(fromIndex, 1);
+        next.splice(toIndex, 0, block);
+        return next;
+    }
+
+    function normalizeLesson(node, index = 0) {
+        const lessonId = node?.LessonId ?? node?.lessonId ?? node?.Id;
+        const marathonLessonId = node?.MarathonLessonId ?? node?.marathonLessonId ?? node?.Id;
+        return Object.freeze({
+            lessonId: Number(lessonId),
+            marathonLessonId: Number(marathonLessonId),
+            number: Number(node?.Number ?? node?.number ?? index) + (node?.Number !== undefined ? 1 : 0),
+            name: String(node?.Name ?? node?.name ?? `Lesson ${index + 1}`)
+        });
+    }
+
+    function extractNormalSections(structure) {
+        const value = structure?.Value ?? structure;
+        if (!value || !Array.isArray(value.Sections)) {
+            throw createFeatureError(
+                'INVALID_LESSON_RESPONSE',
+                'The lesson response did not contain a normal sections array.'
+            );
+        }
+        return value.Sections;
+    }
+
+    function freezeEntries(entries) {
+        return Object.freeze(entries.map((entry) => Object.freeze({ ...entry })));
+    }
+
+    function buildPreflightPlan({ lessons, selectedLessonIds, definition, inspectionsByLessonId }) {
+        const validated = validateSectionDefinition(definition);
+        if (validated.errors.length > 0) {
+            throw createFeatureError('INVALID_SECTION_DEFINITION', 'The section definition is invalid.', {
+                validationErrors: validated.errors
+            });
+        }
+        const selected = new Set((selectedLessonIds || []).map(Number));
+        const eligible = [];
+        const rejected = [];
+
+        for (const lesson of (lessons || []).filter((entry) => selected.has(Number(entry.lessonId)))) {
+            const inspection = inspectionsByLessonId.get(Number(lesson.lessonId));
+            if (!inspection || inspection.error) {
+                const error = inspection?.error || createFeatureError(
+                    'INVALID_LESSON_RESPONSE',
+                    'The lesson was not inspected.'
+                );
+                rejected.push({
+                    ...lesson,
+                    code: error.code || 'INVALID_LESSON_RESPONSE',
+                    message: error.message || 'The lesson could not be inspected.'
+                });
+                continue;
+            }
+            try {
+                const sections = extractNormalSections(inspection.structure);
+                const collision = sections.some((section) =>
+                    String(section?.Name || '').trim() === validated.definition.name
+                );
+                if (collision) {
+                    rejected.push({
+                        ...lesson,
+                        code: 'SECTION_NAME_COLLISION',
+                        message: `A section named "${validated.definition.name}" already exists.`
+                    });
+                } else {
+                    eligible.push({ ...lesson });
+                }
+            } catch (error) {
+                rejected.push({
+                    ...lesson,
+                    code: error.code || 'INVALID_LESSON_RESPONSE',
+                    message: error.message
+                });
+            }
+        }
+
+        const blockSummary = validated.definition.blocks.map((block, index) =>
+            Object.freeze({ index, type: block.type, id: block.id })
+        );
+        return Object.freeze({
+            definition: validated.definition,
+            selectedLessonIds: Object.freeze([...selected]),
+            eligible: freezeEntries(eligible),
+            rejected: freezeEntries(rejected),
+            blockSummary: Object.freeze(blockSummary)
+        });
+    }
+
+    function readPath(source, path) {
+        return String(path || '').split('.').filter(Boolean).reduce(
+            (value, key) => value == null ? undefined : value[key],
+            source
+        );
+    }
+
+    function resolveToken(path, context) {
+        if (path.startsWith('generated.')) {
+            const key = path.slice('generated.'.length);
+            const store = context.block
+                ? context.blockGenerated
+                : context.generated;
+            if (!(key in store)) {
+                store[key] = context.createId();
+            }
+            return store[key];
+        }
+        return readPath(context, path);
+    }
+
+    function resolveTemplate(value, context) {
+        if (Array.isArray(value)) {
+            return value.map((entry) => resolveTemplate(entry, context));
+        }
+        if (value && typeof value === 'object') {
+            return Object.fromEntries(Object.entries(value).map(([key, entry]) => [
+                key,
+                resolveTemplate(entry, context)
+            ]));
+        }
+        if (typeof value !== 'string') {
+            return value;
+        }
+        const exact = value.match(/^\{\{\s*([^{}]+?)\s*\}\}$/);
+        if (exact) {
+            return resolveToken(exact[1], context);
+        }
+        return value.replace(TOKEN_PATTERN, (_match, path) => {
+            const resolved = resolveToken(path, context);
+            return resolved == null ? '' : String(resolved);
+        });
+    }
+
+    function validateRecipe(recipe) {
+        const errors = [];
+        if (!recipe || recipe.version !== 1) {
+            errors.push(createFeatureError('RECIPE_MISSING', 'A version 1 recording recipe is required.'));
+        }
+        if (recipe && recipe.reviewedDynamicFields !== true) {
+            errors.push(createFeatureError(
+                'RECIPE_NOT_REVIEWED',
+                'The recording recipe must explicitly confirm reviewed dynamic fields.'
+            ));
+        }
+        if (recipe && !Array.isArray(recipe.steps)) {
+            errors.push(createFeatureError('RECIPE_STEPS_REQUIRED', 'The recording recipe requires steps.'));
+        }
+        for (const step of recipe?.steps || []) {
+            if (!step.controller || !step.method || !step.projectName || !step.valueTemplate) {
+                errors.push(createFeatureError(
+                    'INVALID_RECIPE_STEP',
+                    `Recipe step "${step.id || step.method || 'unknown'}" is incomplete.`
+                ));
+            }
+        }
+        return errors;
+    }
+
+    function createRecordedCreationAdapter({
+        recipe = null,
+        cryptoApi = globalThis.crypto,
+        requestDelayMs = 300
+    } = {}) {
+        const errors = validateRecipe(recipe);
+        const createId = () => cryptoApi?.randomUUID?.()
+            || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+        function expandSteps(steps, definition) {
+            const expanded = [];
+            for (let index = 0; index < steps.length;) {
+                const step = steps[index];
+                if (step.forEach !== 'blocks') {
+                    expanded.push({ step, block: null, blockIndex: null });
+                    index += 1;
+                    continue;
+                }
+                const group = [];
+                while (index < steps.length && steps[index].forEach === 'blocks') {
+                    group.push(steps[index]);
+                    index += 1;
+                }
+                definition.blocks.forEach((block, blockIndex) => {
+                    const matching = group.find((candidate) =>
+                        !Array.isArray(candidate.blockTypes)
+                        || candidate.blockTypes.includes(block.type)
+                    );
+                    if (matching) {
+                        expanded.push({ step: matching, block, blockIndex });
+                    }
+                });
+            }
+            return expanded;
+        }
+
+        async function executeSteps({
+            steps,
+            marathonId,
+            lesson,
+            definition,
+            sendRequest,
+            wait,
+            captured = {},
+            generated = {}
+        }) {
+            const blockGeneratedById = new Map();
+            const expanded = expandSteps(steps, definition);
+            let markedCreated = false;
+
+            for (const [index, entry] of expanded.entries()) {
+                const blockGenerated = entry.block
+                    ? blockGeneratedById.get(entry.block.id) || {}
+                    : generated;
+                if (entry.block) {
+                    blockGeneratedById.set(entry.block.id, blockGenerated);
+                }
+                const context = {
+                    marathonId,
+                    lesson,
+                    section: definition,
+                    block: entry.block,
+                    blockIndex: entry.blockIndex,
+                    captured,
+                    generated,
+                    blockGenerated,
+                    createId
+                };
+                try {
+                    const response = await sendRequest(
+                        entry.step.controller,
+                        entry.step.method,
+                        entry.step.projectName,
+                        resolveTemplate(entry.step.valueTemplate, context)
+                    );
+                    for (const [name, path] of Object.entries(entry.step.capture || {})) {
+                        const capturedValue = readPath(response, path);
+                        if (capturedValue === undefined) {
+                            throw createFeatureError(
+                                'INVALID_RESPONSE',
+                                `Recipe capture "${name}" was missing after ${entry.step.id || entry.step.method}.`
+                            );
+                        }
+                        captured[name] = capturedValue;
+                    }
+                    if (entry.step.marksSectionCreated === true) {
+                        markedCreated = true;
+                    }
+                    if (index < expanded.length - 1 && requestDelayMs > 0) {
+                        await wait(requestDelayMs);
+                    }
+                } catch (error) {
+                    error.partialCreated = markedCreated;
+                    error.captured = { ...captured };
+                    error.generated = { ...generated };
+                    throw error;
+                }
+            }
+            return { captured: { ...captured }, generated: { ...generated } };
+        }
+
+        return Object.freeze({
+            isReady: errors.length === 0,
+            errors: Object.freeze(errors),
+            async createSection(context) {
+                if (errors.length > 0) {
+                    throw createFeatureError('RECIPE_UNAVAILABLE', errors[0].message);
+                }
+                return executeSteps({ ...context, steps: recipe.steps });
+            },
+            async cleanupSection(context) {
+                if (!Array.isArray(recipe?.cleanupSteps) || recipe.cleanupSteps.length === 0) {
+                    return { attempted: false, status: 'unavailable' };
+                }
+                try {
+                    await executeSteps({ ...context, steps: recipe.cleanupSteps });
+                    return { attempted: true, status: 'success' };
+                } catch (error) {
+                    return {
+                        attempted: true,
+                        status: 'failed',
+                        code: error.code || 'CLEANUP_FAILED',
+                        message: error.message
+                    };
+                }
+            }
+        });
+    }
+
+    async function loadLessonCatalogue({ sendRequest, marathonId, pageSize = 100 }) {
+        let items = [];
+        let total = null;
+        while (total === null || items.length < total) {
+            const response = await sendRequest(
+                'MarathonLessonWsController',
+                'GetMarathonLessonsPagination',
+                'Marathons',
+                {
+                    MarathonId: marathonId,
+                    SearchTerm: '',
+                    Page: { Skip: items.length, Take: pageSize }
+                }
+            );
+            const next = response?.Value?.Items;
+            const count = response?.Value?.Page?.Count;
+            if (!Array.isArray(next) || !Number.isInteger(count)) {
+                throw createFeatureError('INVALID_RESPONSE', 'Lesson catalogue pagination was invalid.');
+            }
+            if (next.length === 0 && items.length < count) {
+                throw createFeatureError('INVALID_RESPONSE', 'Lesson catalogue pagination stalled.');
+            }
+            items = items.concat(next);
+            total = count;
+        }
+        return items.map(normalizeLesson);
+    }
+
+    async function inspectLessonsSequentially({
+        lessons,
+        selectedLessonIds,
+        sendRequest,
+        wait,
+        delayMs = 300
+    }) {
+        const selected = new Set((selectedLessonIds || []).map(Number));
+        const targets = (lessons || []).filter((lesson) => selected.has(Number(lesson.lessonId)));
+        const inspections = new Map();
+        for (const [index, lesson] of targets.entries()) {
+            try {
+                const structure = await sendRequest(
+                    'LessonWsController',
+                    'GetLessonWithId',
+                    'Books',
+                    { LessonId: lesson.lessonId }
+                );
+                inspections.set(Number(lesson.lessonId), { structure });
+            } catch (error) {
+                inspections.set(Number(lesson.lessonId), { error });
+            }
+            if (index < targets.length - 1 && delayMs > 0) {
+                await wait(delayMs);
+            }
+        }
+        return inspections;
+    }
+
+    function createResult(lesson, status, details = {}) {
+        return {
+            lessonId: lesson.lessonId,
+            marathonLessonId: lesson.marathonLessonId,
+            lessonNumber: lesson.number,
+            lessonName: lesson.name,
+            status,
+            ...details
+        };
+    }
+
+    function isFatalError(error, getConnectionState) {
+        if (error?.code === 'WS_UNAVAILABLE') {
+            return true;
+        }
+        if (error?.code === 'SEND_FAILED' && !getConnectionState().isOpen) {
+            return true;
+        }
+        return !EXPECTED_WRITE_CODES.has(error?.code);
+    }
+
+    async function executeCreationPlan({
+        marathonId,
+        plan,
+        adapter,
+        sendRequest,
+        wait,
+        getConnectionState,
+        lessonDelayMs = 300,
+        onProgress = () => {}
+    }) {
+        if (!adapter?.isReady) {
+            throw createFeatureError('RECIPE_UNAVAILABLE', adapter?.errors?.[0]?.message || 'Recording recipe unavailable.');
+        }
+        const results = plan.rejected.map((lesson) => createResult(lesson, 'rejected', {
+            code: lesson.code,
+            message: lesson.message
+        }));
+        let attempts = 0;
+
+        for (const [index, lesson] of plan.eligible.entries()) {
+            onProgress({
+                completed: index,
+                total: plan.eligible.length,
+                lesson,
+                results: [...results]
+            });
+            try {
+                attempts += 1;
+                const created = await adapter.createSection({
+                    marathonId,
+                    lesson,
+                    definition: plan.definition,
+                    sendRequest,
+                    wait
+                });
+                results.push(createResult(lesson, 'created', {
+                    captured: created.captured,
+                    generated: created.generated,
+                    attempts: 1
+                }));
+            } catch (error) {
+                const partial = Boolean(error.partialCreated);
+                const fatal = isFatalError(error, getConnectionState);
+                let cleanup = null;
+                if (partial && !fatal) {
+                    cleanup = await adapter.cleanupSection({
+                        marathonId,
+                        lesson,
+                        definition: plan.definition,
+                        sendRequest,
+                        wait,
+                        captured: error.captured || {},
+                        generated: error.generated || {}
+                    });
+                }
+                results.push(createResult(lesson, partial ? 'partially_created' : 'failed', {
+                    code: error.code || 'UNKNOWN_ERROR',
+                    message: error.message || 'Section creation failed.',
+                    captured: error.captured,
+                    generated: error.generated,
+                    cleanup,
+                    attempts: error.attempts || 1
+                }));
+                if (fatal) {
+                    for (const remaining of plan.eligible.slice(index + 1)) {
+                        results.push(createResult(remaining, 'not_attempted', {
+                            code: 'OPERATION_INTERRUPTED',
+                            message: 'Not attempted because the batch operation stopped.'
+                        }));
+                    }
+                    const partialResult = {
+                        definition: plan.definition,
+                        results,
+                        attempts,
+                        fatalError: error
+                    };
+                    error.partialResult = partialResult;
+                    throw error;
+                }
+            }
+            onProgress({
+                completed: index + 1,
+                total: plan.eligible.length,
+                lesson,
+                results: [...results]
+            });
+            if (index < plan.eligible.length - 1 && lessonDelayMs > 0) {
+                await wait(lessonDelayMs);
+            }
+        }
+        return { definition: plan.definition, results, attempts };
+    }
+
+    function formatCreationReport(result) {
+        const rows = Array.isArray(result?.results) ? result.results : [];
+        const counts = (status) => rows.filter((entry) => entry.status === status).length;
+        const lines = [
+            `Section: ${result?.definition?.name || 'Unknown'}`,
+            `Blocks: ${result?.definition?.blocks?.length || 0}`,
+            `Created: ${counts('created')}`,
+            `Rejected in preflight: ${counts('rejected')}`,
+            `Failed: ${counts('failed')}`,
+            `Partially created: ${counts('partially_created')}`,
+            `Not attempted: ${counts('not_attempted')}`,
+            ''
+        ];
+        for (const entry of rows) {
+            lines.push(
+                `${entry.lessonNumber || '?'}. ${entry.lessonName} — ${entry.status}`
+                + (entry.code ? ` — ${entry.code}: ${entry.message || ''}` : '')
+            );
+            if (entry.captured?.sectionId !== undefined) {
+                lines.push(`  Captured sectionId: ${entry.captured.sectionId}`);
+            }
+            if (entry.cleanup) {
+                lines.push(`  Cleanup: ${entry.cleanup.status}`);
+            }
+        }
+        return lines.join('\n').trim();
+    }
+
+    function createBatchSectionCreationFeature({
+        sendRequest,
+        getConnectionState,
+        wait,
+        canStart,
+        onActiveChange,
+        adapter,
+        createDialog = () => document.createElement(DIALOG_TAG),
+        copyText = async () => {},
+        log = () => {}
+    }) {
+        let active = false;
+        let running = false;
+        let dialog = null;
+        let marathonId = null;
+        let lessons = [];
+        let pendingPlan = null;
+        let completedResult = null;
+
+        function release() {
+            if (active) {
+                active = false;
+                onActiveChange(false);
+            }
+        }
+
+        function close() {
+            running = false;
+            dialog = null;
+            lessons = [];
+            pendingPlan = null;
+            completedResult = null;
+            release();
+        }
+
+        async function preflight(event) {
+            if (running) {
+                return;
+            }
+            running = true;
+            try {
+                const definition = event?.detail?.definition || {};
+                const selectedLessonIds = event?.detail?.selectedLessonIds || [];
+                const validation = validateSectionDefinition(definition);
+                const errors = [...validation.errors];
+                if (selectedLessonIds.length === 0) {
+                    errors.push(createFeatureError('LESSON_SELECTION_REQUIRED', 'Select at least one lesson.'));
+                }
+                if (errors.length > 0) {
+                    dialog.showValidationErrors(errors);
+                    return;
+                }
+                dialog.showLoading('Проверяем выбранные уроки…');
+                const inspections = await inspectLessonsSequentially({
+                    lessons,
+                    selectedLessonIds,
+                    sendRequest,
+                    wait
+                });
+                pendingPlan = buildPreflightPlan({
+                    lessons,
+                    selectedLessonIds,
+                    definition: validation.definition,
+                    inspectionsByLessonId: inspections
+                });
+                dialog.showConfirmation(pendingPlan);
+            } catch (error) {
+                dialog.showValidationErrors([error]);
+            } finally {
+                running = false;
+            }
+        }
+
+        async function confirm() {
+            if (running || !pendingPlan?.eligible?.length) {
+                return;
+            }
+            running = true;
+            try {
+                completedResult = await executeCreationPlan({
+                    marathonId,
+                    plan: pendingPlan,
+                    adapter,
+                    sendRequest,
+                    wait,
+                    getConnectionState,
+                    onProgress: (progress) => dialog.showExecution(progress)
+                });
+                dialog.showComplete(completedResult);
+            } catch (error) {
+                completedResult = error.partialResult || {
+                    definition: pendingPlan.definition,
+                    results: pendingPlan.rejected,
+                    fatalError: error
+                };
+                dialog.showComplete(completedResult, error);
+            } finally {
+                running = false;
+            }
+        }
+
+        async function copyReport() {
+            if (completedResult) {
+                await copyText(formatCreationReport(completedResult));
+            }
+        }
+
+        function restart() {
+            pendingPlan = null;
+            completedResult = null;
+            dialog.showConfigure({
+                lessons,
+                recipeReady: adapter?.isReady,
+                recipeErrors: adapter?.errors || []
+            });
+        }
+
+        async function open({ stylesheetUrl = '' } = {}) {
+            if (active || document.getElementById(OVERLAY_ID)) {
+                return;
+            }
+            if (!canStart()) {
+                window.alert('Another Edvibe Toolbox operation is already running.');
+                return;
+            }
+            marathonId = parseMarathonId(window.location.href);
+            if (!marathonId) {
+                window.alert('Open an Edvibe marathon page before creating sections.');
+                return;
+            }
+
+            active = true;
+            onActiveChange(true);
+            try {
+                dialog = createDialog();
+                dialog.addEventListener('edvibe-dialog-close', close);
+                dialog.addEventListener('edvibe-batch-section-preflight', preflight);
+                dialog.addEventListener('edvibe-batch-section-confirm', confirm);
+                dialog.addEventListener('edvibe-batch-section-copy', copyReport);
+                dialog.addEventListener('edvibe-batch-section-restart', restart);
+                dialog.configure({ stylesheetUrl });
+                (document.body || document.documentElement).appendChild(dialog);
+                dialog.showLoading('Загружаем уроки марафона…');
+                lessons = await loadLessonCatalogue({ sendRequest, marathonId });
+                if (lessons.length === 0) {
+                    throw createFeatureError('EMPTY_LESSON_CATALOGUE', 'No lessons were found.');
+                }
+                dialog.showConfigure({
+                    lessons,
+                    recipeReady: adapter?.isReady,
+                    recipeErrors: adapter?.errors || []
+                });
+                log(`Batch section creation ready for MarathonId ${marathonId}.`);
+            } catch (error) {
+                log(`Batch section creation initialization failed (${error.code || 'UNKNOWN_ERROR'}).`);
+                try {
+                    dialog?.showFatalError?.(error);
+                } finally {
+                    release();
+                }
+            }
+        }
+
+        return { open, isRunning: () => running };
+    }
+
+    return {
+        parseMarathonId,
+        validateSectionDefinition,
+        reorderBlocks,
+        normalizeLesson,
+        buildPreflightPlan,
+        createRecordedCreationAdapter,
+        loadLessonCatalogue,
+        inspectLessonsSequentially,
+        executeCreationPlan,
+        formatCreationReport,
+        createBatchSectionCreationFeature,
+        createFeatureError,
+        DIALOG_TAG,
+        OVERLAY_ID
+    };
+});

--- a/src/isolated.js
+++ b/src/isolated.js
@@ -67,6 +67,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }, '*');
             sendResponse({ status: 'success', info: 'Batch user management opened.' });
             break;
+        case 'OPEN_BATCH_SECTION_CREATION':
+            window.postMessage({
+                type: 'EDVIBE_TOOLBOX_OPEN_BATCH_SECTION_CREATION',
+                stylesheetUrl: chrome.runtime.getURL(
+                    'src/components/batch-section-creation-dialog.css'
+                )
+            }, '*');
+            sendResponse({ status: 'success', info: 'Batch section creation opened.' });
+            break;
         default:
             sendResponse({ status: 'ignored' });
             break;

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ const batchUserManagementApi = requireToolboxModule('EdVibeBatchUserManagement')
 const batchUserManagementDialogApi = requireToolboxModule('EdVibeBatchUserManagementDialog');
 const batchSectionCreationApi = requireToolboxModule('EdVibeBatchSectionCreation');
 const batchSectionCreationDialogApi = requireToolboxModule('EdVibeBatchSectionCreationDialog');
+const batchSectionCreationRecipe = requireToolboxModule('EdVibeBatchSectionCreationRecipe');
 
 const transportLog = createMainLog('Transport');
 const exportLog = createMainLog('Export');
@@ -151,7 +152,7 @@ const batchUserManagementFeature = batchUserManagementApi.createBatchUserManagem
 });
 
 const batchSectionCreationAdapter = batchSectionCreationApi.createRecordedCreationAdapter({
-    recipe: window.EdVibeBatchSectionCreationRecipe || null,
+    recipe: batchSectionCreationRecipe,
     cryptoApi: window.crypto
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,8 @@ const batchAccessApi = requireToolboxModule('EdVibeBatchLessonAccess');
 const batchAccessDialogApi = requireToolboxModule('EdVibeBatchAccessDialogComponent');
 const batchUserManagementApi = requireToolboxModule('EdVibeBatchUserManagement');
 const batchUserManagementDialogApi = requireToolboxModule('EdVibeBatchUserManagementDialog');
+const batchSectionCreationApi = requireToolboxModule('EdVibeBatchSectionCreation');
+const batchSectionCreationDialogApi = requireToolboxModule('EdVibeBatchSectionCreationDialog');
 
 const transportLog = createMainLog('Transport');
 const exportLog = createMainLog('Export');
@@ -30,6 +32,7 @@ const resetLog = createMainLog('Reset');
 const recorderLog = createMainLog('Recorder');
 const batchAccessLog = createMainLog('BatchAccess');
 const batchUserManagementLog = createMainLog('BatchUserManagement');
+const batchSectionCreationLog = createMainLog('BatchSectionCreation');
 
 const transport = transportApi.createWebSocketTransport({
     WebSocketClass: window.WebSocket,
@@ -85,10 +88,25 @@ const lessonResetFeature = resetApi.createResetLessonsFeature({
     log: resetLog
 });
 
+let recorderOpen = false;
 const actionRecorderFeature = recorderApi.createActionRecorderFeature({
     subscribeFrames: transport.subscribeFrames,
     createPanel() {
-        return document.createElement(recorderDialogApi.RECORDER_DIALOG_TAG);
+        const panel = document.createElement(recorderDialogApi.RECORDER_DIALOG_TAG);
+        const configure = panel.configure.bind(panel);
+        panel.configure = (options = {}) => configure({
+            ...options,
+            onClose() {
+                try {
+                    options.onClose?.();
+                } finally {
+                    recorderOpen = false;
+                    operationGuard.release('recording');
+                }
+            }
+        });
+        recorderOpen = true;
+        return panel;
     },
     log: recorderLog
 });
@@ -132,6 +150,32 @@ const batchUserManagementFeature = batchUserManagementApi.createBatchUserManagem
     log: batchUserManagementLog
 });
 
+const batchSectionCreationAdapter = batchSectionCreationApi.createRecordedCreationAdapter({
+    recipe: window.EdVibeBatchSectionCreationRecipe || null,
+    cryptoApi: window.crypto
+});
+
+const batchSectionCreationFeature = batchSectionCreationApi.createBatchSectionCreationFeature({
+    sendRequest: transport.sendRequest,
+    getConnectionState: transport.getConnectionState,
+    wait,
+    canStart: operationGuard.canStart,
+    onActiveChange(isActive) {
+        if (isActive) {
+            operationGuard.activate('batch-section-creation');
+        }
+        else {
+            operationGuard.release('batch-section-creation');
+        }
+    },
+    adapter: batchSectionCreationAdapter,
+    createDialog() {
+        return document.createElement(batchSectionCreationDialogApi.BATCH_SECTION_DIALOG_TAG);
+    },
+    copyText: (text) => navigator.clipboard.writeText(text),
+    log: batchSectionCreationLog
+});
+
 window.addEventListener('message', (event) => {
     if (event.source !== window) {
         return;
@@ -146,7 +190,18 @@ window.addEventListener('message', (event) => {
     }
 
     if (event.data?.type === 'EDVIBE_TOOLBOX_OPEN_RECORDER') {
-        actionRecorderFeature.open({ stylesheetUrl: event.data.stylesheetUrl });
+        if (recorderOpen) {
+            actionRecorderFeature.open({ stylesheetUrl: event.data.stylesheetUrl });
+        } else if (operationGuard.activate('recording')) {
+            try {
+                actionRecorderFeature.open({ stylesheetUrl: event.data.stylesheetUrl });
+            } catch (error) {
+                operationGuard.release('recording');
+                throw error;
+            }
+        } else {
+            window.alert('Another Edvibe Toolbox operation is already running.');
+        }
     }
 
     if (event.data?.type === 'EDVIBE_TOOLBOX_OPEN_BATCH_LESSON_ACCESS') {
@@ -155,6 +210,10 @@ window.addEventListener('message', (event) => {
 
     if (event.data?.type === 'EDVIBE_TOOLBOX_OPEN_BATCH_USER_MANAGEMENT') {
         batchUserManagementFeature.open({ stylesheetUrl: event.data.stylesheetUrl });
+    }
+
+    if (event.data?.type === 'EDVIBE_TOOLBOX_OPEN_BATCH_SECTION_CREATION') {
+        batchSectionCreationFeature.open({ stylesheetUrl: event.data.stylesheetUrl });
     }
 });
 

--- a/tests/batchSectionCreation.test.js
+++ b/tests/batchSectionCreation.test.js
@@ -1,0 +1,454 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const api = require('../src/features/batch-section-creation.js');
+
+function definition() {
+    return {
+        name: 'Summer promotion',
+        blocks: [
+            { id: 'banner', type: 'image', url: 'https://cdn.example/banner.jpg', alt: 'Sale' },
+            { id: 'copy', type: 'text', text: '<p>Save twenty percent.</p>' },
+            { id: 'cta', type: 'link', label: 'Open offer', url: 'https://example.com/offer' }
+        ]
+    };
+}
+
+function lessons() {
+    return [
+        { lessonId: 101, marathonLessonId: 1001, number: 1, name: 'Welcome' },
+        { lessonId: 102, marathonLessonId: 1002, number: 2, name: 'Practice' },
+        { lessonId: 103, marathonLessonId: 1003, number: 3, name: 'Review' }
+    ];
+}
+
+function plan({ eligible = lessons(), rejected = [] } = {}) {
+    return Object.freeze({
+        definition: Object.freeze(definition()),
+        selectedLessonIds: Object.freeze(eligible.map((lesson) => lesson.lessonId)),
+        eligible: Object.freeze(eligible.map(Object.freeze)),
+        rejected: Object.freeze(rejected.map(Object.freeze)),
+        blockSummary: Object.freeze([])
+    });
+}
+
+function reviewedRecipe() {
+    return {
+        version: 1,
+        reviewedDynamicFields: true,
+        steps: [
+            {
+                id: 'create-section',
+                controller: 'RecordedSectionController',
+                method: 'CreateSection',
+                projectName: 'Books',
+                valueTemplate: {
+                    LessonId: '{{lesson.lessonId}}',
+                    MarathonId: '{{marathonId}}',
+                    Name: '{{section.name}}',
+                    ClientId: '{{generated.sectionClientId}}'
+                },
+                capture: { sectionId: 'Value.SectionId' },
+                marksSectionCreated: true
+            },
+            {
+                id: 'add-image',
+                controller: 'RecordedSectionController',
+                method: 'AddImage',
+                projectName: 'Books',
+                forEach: 'blocks',
+                blockTypes: ['image'],
+                valueTemplate: {
+                    LessonId: '{{lesson.lessonId}}',
+                    SectionId: '{{captured.sectionId}}',
+                    Url: '{{block.url}}',
+                    Alt: '{{block.alt}}',
+                    Position: '{{blockIndex}}',
+                    ClientId: '{{generated.imageClientId}}'
+                }
+            },
+            {
+                id: 'add-text',
+                controller: 'RecordedSectionController',
+                method: 'AddText',
+                projectName: 'Books',
+                forEach: 'blocks',
+                blockTypes: ['text'],
+                valueTemplate: {
+                    LessonId: '{{lesson.lessonId}}',
+                    SectionId: '{{captured.sectionId}}',
+                    Text: '{{block.text}}',
+                    Position: '{{blockIndex}}',
+                    ClientId: '{{generated.textClientId}}'
+                }
+            },
+            {
+                id: 'add-link',
+                controller: 'RecordedSectionController',
+                method: 'AddLink',
+                projectName: 'Books',
+                forEach: 'blocks',
+                blockTypes: ['link'],
+                valueTemplate: {
+                    LessonId: '{{lesson.lessonId}}',
+                    SectionId: '{{captured.sectionId}}',
+                    Label: '{{block.label}}',
+                    Url: '{{block.url}}',
+                    Position: '{{blockIndex}}',
+                    ClientId: '{{generated.linkClientId}}'
+                }
+            }
+        ],
+        cleanupSteps: [
+            {
+                id: 'delete-partial-section',
+                controller: 'RecordedSectionController',
+                method: 'DeleteSection',
+                projectName: 'Books',
+                valueTemplate: {
+                    LessonId: '{{lesson.lessonId}}',
+                    SectionId: '{{captured.sectionId}}'
+                }
+            }
+        ]
+    };
+}
+
+test('parses marathon IDs only from marathon pages', () => {
+    assert.equal(api.parseMarathonId('https://school.edvibe.com/marathon/42/lessons'), 42);
+    assert.equal(api.parseMarathonId('https://school.edvibe.com/marathon/not-a-number'), null);
+    assert.equal(api.parseMarathonId('https://school.edvibe.com/books/42'), null);
+});
+
+test('validates the supported section constructor fields', () => {
+    const valid = api.validateSectionDefinition(definition());
+    assert.equal(valid.errors.length, 0);
+    assert.equal(valid.definition.name, 'Summer promotion');
+
+    const invalid = api.validateSectionDefinition({
+        name: '   ',
+        blocks: [
+            { id: 'one', type: 'image', url: 'ftp://example.com/banner.jpg' },
+            { id: 'one', type: 'text', text: '' },
+            { id: 'three', type: 'link', label: '', url: 'not a url' }
+        ]
+    });
+    assert.deepEqual(
+        invalid.errors.map((error) => error.code),
+        [
+            'SECTION_NAME_REQUIRED',
+            'IMAGE_URL_REQUIRED',
+            'DUPLICATE_BLOCK_ID',
+            'TEXT_REQUIRED',
+            'LINK_LABEL_REQUIRED',
+            'LINK_URL_REQUIRED'
+        ]
+    );
+});
+
+test('reorders blocks without mutating the input', () => {
+    const source = definition().blocks;
+    const reordered = api.reorderBlocks(source, 2, 0);
+    assert.deepEqual(reordered.map((block) => block.id), ['cta', 'banner', 'copy']);
+    assert.deepEqual(source.map((block) => block.id), ['banner', 'copy', 'cta']);
+});
+
+test('builds an immutable collision-aware preflight plan', () => {
+    const inspection = new Map([
+        [101, { structure: { Sections: [{ Id: 1, Name: 'Existing section' }] } }],
+        [102, { structure: { Sections: [{ Id: 2, Name: 'Summer promotion' }] } }],
+        [103, { error: Object.assign(new Error('Could not inspect lesson.'), { code: 'REQUEST_TIMEOUT' }) }]
+    ]);
+    const result = api.buildPreflightPlan({
+        lessons: lessons(),
+        selectedLessonIds: [101, 102, 103],
+        definition: definition(),
+        inspectionsByLessonId: inspection
+    });
+
+    assert.deepEqual(result.eligible.map((lesson) => lesson.lessonId), [101]);
+    assert.deepEqual(
+        result.rejected.map((lesson) => lesson.code),
+        ['SECTION_NAME_COLLISION', 'REQUEST_TIMEOUT']
+    );
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(Object.isFrozen(result.definition.blocks[0]), true);
+    assert.throws(() => result.eligible.push({}), TypeError);
+});
+
+test('expands a reviewed recording recipe with lesson-specific IDs and stable generated values', async () => {
+    const calls = [];
+    const waits = [];
+    let uuid = 0;
+    const adapter = api.createRecordedCreationAdapter({
+        recipe: reviewedRecipe(),
+        cryptoApi: { randomUUID: () => `uuid-${++uuid}` },
+        requestDelayMs: 25
+    });
+    const result = await adapter.createSection({
+        marathonId: 77,
+        lesson: lessons()[0],
+        definition: definition(),
+        wait: async (ms) => waits.push(ms),
+        sendRequest: async (controller, method, projectName, value) => {
+            calls.push({ controller, method, projectName, value });
+            return method === 'CreateSection'
+                ? { Value: { SectionId: 9001 } }
+                : { Value: true };
+        }
+    });
+
+    assert.equal(adapter.isReady, true);
+    assert.deepEqual(calls.map((call) => call.method), [
+        'CreateSection', 'AddImage', 'AddText', 'AddLink'
+    ]);
+    assert.equal(calls[0].value.LessonId, 101);
+    assert.equal(calls[0].value.MarathonId, 77);
+    assert.equal(calls[1].value.SectionId, 9001);
+    assert.equal(calls[2].value.Position, 1);
+    assert.equal(calls[3].value.Position, 2);
+    assert.equal(calls[0].value.ClientId, 'uuid-1');
+    assert.equal(calls[1].value.ClientId, 'uuid-2');
+    assert.deepEqual(waits, [25, 25, 25]);
+    assert.equal(result.captured.sectionId, 9001);
+});
+
+test('preserves configured block order and generates unique IDs per block', async () => {
+    const calls = [];
+    let uuid = 0;
+    const adapter = api.createRecordedCreationAdapter({
+        recipe: reviewedRecipe(),
+        cryptoApi: { randomUUID: () => `uuid-${++uuid}` },
+        requestDelayMs: 0
+    });
+    const reorderedDefinition = {
+        name: 'Ordered section',
+        blocks: [
+            { id: 'cta', type: 'link', label: 'Go', url: 'https://example.com' },
+            { id: 'banner-a', type: 'image', url: 'https://cdn.example/a.jpg', alt: 'A' },
+            { id: 'banner-b', type: 'image', url: 'https://cdn.example/b.jpg', alt: 'B' },
+            { id: 'copy', type: 'text', text: 'Last' }
+        ]
+    };
+
+    await adapter.createSection({
+        marathonId: 77,
+        lesson: lessons()[0],
+        definition: reorderedDefinition,
+        wait: async () => {},
+        sendRequest: async (_controller, method, _projectName, value) => {
+            calls.push({ method, value });
+            return method === 'CreateSection'
+                ? { Value: { SectionId: 9100 } }
+                : { Value: true };
+        }
+    });
+
+    assert.deepEqual(calls.map((call) => call.method), [
+        'CreateSection', 'AddLink', 'AddImage', 'AddImage', 'AddText'
+    ]);
+    assert.notEqual(calls[2].value.ClientId, calls[3].value.ClientId);
+    assert.deepEqual(calls.slice(1).map((call) => call.value.Position), [0, 1, 2, 3]);
+});
+
+test('keeps execution sequential, continues after per-lesson failure, and preserves preflight rejection', async () => {
+    const active = [];
+    const waits = [];
+    const executionPlan = plan({
+        eligible: lessons().slice(0, 2),
+        rejected: [{
+            ...lessons()[2],
+            code: 'SECTION_NAME_COLLISION',
+            message: 'Already exists.'
+        }]
+    });
+    const adapter = {
+        isReady: true,
+        errors: [],
+        async createSection({ lesson }) {
+            active.push(`start-${lesson.lessonId}`);
+            if (lesson.lessonId === 101) {
+                throw Object.assign(new Error('Rejected by server.'), {
+                    code: 'SERVER_REJECTED',
+                    partialCreated: false
+                });
+            }
+            active.push(`done-${lesson.lessonId}`);
+            return { captured: { sectionId: 502 }, generated: {} };
+        },
+        async cleanupSection() {
+            throw new Error('Cleanup should not run.');
+        }
+    };
+
+    const result = await api.executeCreationPlan({
+        marathonId: 77,
+        plan: executionPlan,
+        adapter,
+        sendRequest: async () => ({}),
+        wait: async (ms) => waits.push(ms),
+        getConnectionState: () => ({ isOpen: true }),
+        lessonDelayMs: 40
+    });
+
+    assert.deepEqual(active, ['start-101', 'start-102', 'done-102']);
+    assert.deepEqual(waits, [40]);
+    assert.deepEqual(
+        result.results.map((entry) => [entry.lessonId, entry.status]),
+        [[103, 'rejected'], [101, 'failed'], [102, 'created']]
+    );
+});
+
+test('reports partial creation and runs safe cleanup without stopping later lessons', async () => {
+    const cleaned = [];
+    const adapter = {
+        isReady: true,
+        errors: [],
+        async createSection({ lesson }) {
+            if (lesson.lessonId === 101) {
+                throw Object.assign(new Error('Block creation failed.'), {
+                    code: 'SERVER_REJECTED',
+                    partialCreated: true,
+                    captured: { sectionId: 501 },
+                    generated: { clientId: 'a' }
+                });
+            }
+            return { captured: { sectionId: 502 }, generated: {} };
+        },
+        async cleanupSection({ lesson, captured }) {
+            cleaned.push([lesson.lessonId, captured.sectionId]);
+            return { attempted: true, status: 'success' };
+        }
+    };
+
+    const result = await api.executeCreationPlan({
+        marathonId: 77,
+        plan: plan({ eligible: lessons().slice(0, 2) }),
+        adapter,
+        sendRequest: async () => ({}),
+        wait: async () => {},
+        getConnectionState: () => ({ isOpen: true })
+    });
+
+    assert.deepEqual(cleaned, [[101, 501]]);
+    assert.deepEqual(result.results.map((entry) => entry.status), [
+        'partially_created', 'created'
+    ]);
+    assert.equal(result.results[0].cleanup.status, 'success');
+});
+
+test('retains a complete partial result after a fatal connection interruption', async () => {
+    const adapter = {
+        isReady: true,
+        errors: [],
+        async createSection({ lesson }) {
+            if (lesson.lessonId === 102) {
+                throw Object.assign(new Error('Connection disappeared.'), {
+                    code: 'WS_UNAVAILABLE',
+                    partialCreated: true,
+                    captured: { sectionId: 602 }
+                });
+            }
+            return { captured: { sectionId: 601 }, generated: {} };
+        },
+        async cleanupSection() {
+            throw new Error('Fatal paths must not attempt cleanup.');
+        }
+    };
+
+    await assert.rejects(
+        api.executeCreationPlan({
+            marathonId: 77,
+            plan: plan(),
+            adapter,
+            sendRequest: async () => ({}),
+            wait: async () => {},
+            getConnectionState: () => ({ isOpen: false })
+        }),
+        (error) => {
+            assert.equal(error.code, 'WS_UNAVAILABLE');
+            assert.deepEqual(error.partialResult.results.map((entry) => entry.status), [
+                'created', 'partially_created', 'not_attempted'
+            ]);
+            assert.equal(error.partialResult.results[1].captured.sectionId, 602);
+            return true;
+        }
+    );
+});
+
+test('inspects selected lessons sequentially with one throttle gap', async () => {
+    const calls = [];
+    const waits = [];
+    const inspections = await api.inspectLessonsSequentially({
+        lessons: lessons(),
+        selectedLessonIds: [101, 103],
+        delayMs: 55,
+        wait: async (ms) => waits.push(ms),
+        sendRequest: async (_controller, _method, _project, payload) => {
+            calls.push(payload.LessonId);
+            return { Value: { Sections: [] } };
+        }
+    });
+
+    assert.deepEqual(calls, [101, 103]);
+    assert.deepEqual(waits, [55]);
+    assert.equal(inspections.size, 2);
+});
+
+test('formats a copyable report with all terminal states', () => {
+    const report = api.formatCreationReport({
+        definition: definition(),
+        results: [
+            { lessonNumber: 1, lessonName: 'Welcome', status: 'created' },
+            { lessonNumber: 2, lessonName: 'Practice', status: 'rejected', code: 'SECTION_NAME_COLLISION', message: 'Already exists.' },
+            { lessonNumber: 3, lessonName: 'Review', status: 'partially_created', code: 'SERVER_REJECTED', message: 'Failed.', captured: { sectionId: 88 }, cleanup: { status: 'failed' } }
+        ]
+    });
+
+    assert.match(report, /Section: Summer promotion/);
+    assert.match(report, /Created: 1/);
+    assert.match(report, /Rejected in preflight: 1/);
+    assert.match(report, /Partially created: 1/);
+    assert.match(report, /Captured sectionId: 88/);
+    assert.match(report, /Cleanup: failed/);
+});
+
+test('releases the operation guard when initialization fails', async () => {
+    const activeChanges = [];
+    const dialog = {
+        listeners: new Map(),
+        addEventListener(type, handler) { this.listeners.set(type, handler); },
+        configure() {},
+        showLoading() {},
+        showFatalError(error) { this.error = error; }
+    };
+    const previousDocument = global.document;
+    const previousWindow = global.window;
+    global.document = {
+        getElementById: () => null,
+        body: { appendChild() {} },
+        documentElement: { appendChild() {} }
+    };
+    global.window = {
+        location: { href: 'https://school.edvibe.com/marathon/77/lessons' },
+        alert() {}
+    };
+
+    try {
+        const feature = api.createBatchSectionCreationFeature({
+            sendRequest: async () => { throw Object.assign(new Error('No socket.'), { code: 'WS_UNAVAILABLE' }); },
+            getConnectionState: () => ({ isOpen: false }),
+            wait: async () => {},
+            canStart: () => true,
+            onActiveChange: (value) => activeChanges.push(value),
+            adapter: api.createRecordedCreationAdapter(),
+            createDialog: () => dialog
+        });
+        await feature.open({ stylesheetUrl: 'dialog.css' });
+        assert.deepEqual(activeChanges, [true, false]);
+        assert.equal(dialog.error.code, 'WS_UNAVAILABLE');
+    } finally {
+        global.document = previousDocument;
+        global.window = previousWindow;
+    }
+});

--- a/tests/batchSectionCreationDialog.test.js
+++ b/tests/batchSectionCreationDialog.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const source = fs.readFileSync(
+    path.join(root, 'src/components/batch-section-creation-dialog.js'),
+    'utf8'
+);
+const styles = fs.readFileSync(
+    path.join(root, 'src/components/batch-section-creation-dialog.css'),
+    'utf8'
+);
+
+test('dialog is a dedicated Web Component with constructor, selection, preview, and report events', () => {
+    assert.match(source, /customElements\.define\(BATCH_SECTION_DIALOG_TAG/);
+    assert.match(source, /data-add-block="image"/);
+    assert.match(source, /data-add-block="text"/);
+    assert.match(source, /data-add-block="link"/);
+    assert.match(source, /dataset\.blockAction = action/);
+    assert.match(source, /edvibe-batch-section-preflight/);
+    assert.match(source, /edvibe-batch-section-confirm/);
+    assert.match(source, /edvibe-batch-section-copy/);
+    assert.match(source, /edvibe-batch-section-restart/);
+    assert.match(source, /recipeReady/);
+    assert.match(source, /SECTION_NAME_COLLISION|Отклонено проверкой/);
+});
+
+test('dialog keeps presentation in its dedicated stylesheet', () => {
+    assert.doesNotMatch(source, /cssText|\.style\.|<style/);
+    assert.match(styles, /\.edvibe-batch-section-overlay/);
+    assert.match(styles, /\.edvibe-batch-section-grid/);
+    assert.match(styles, /\.edvibe-batch-section-block/);
+    assert.match(styles, /\.edvibe-batch-section-result\.is-partially_created/);
+    assert.match(styles, /@media \(max-width: 820px\)/);
+});

--- a/tests/batchSectionCreationIntegration.test.js
+++ b/tests/batchSectionCreationIntegration.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const popup = fs.readFileSync(path.join(root, 'popup.js'), 'utf8');
+const isolated = fs.readFileSync(path.join(root, 'src/isolated.js'), 'utf8');
+const main = fs.readFileSync(path.join(root, 'src/main.js'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+
+test('popup exposes batch section creation only on marathon pages', () => {
+    assert.match(
+        popup,
+        /id: 'batch-section-creation',[\s\S]*?command: 'OPEN_BATCH_SECTION_CREATION',[\s\S]*?requirement: 'marathon'/
+    );
+    assert.match(popup, /title: 'Создать раздел в уроках'/);
+});
+
+test('popup command crosses the isolated and main worlds', () => {
+    assert.match(isolated, /case 'OPEN_BATCH_SECTION_CREATION'/);
+    assert.match(isolated, /EDVIBE_TOOLBOX_OPEN_BATCH_SECTION_CREATION/);
+    assert.match(isolated, /batch-section-creation-dialog\.css/);
+    assert.match(main, /batchSectionCreationFeature\.open/);
+    assert.match(main, /operationGuard\.activate\('batch-section-creation'\)/);
+    assert.match(main, /operationGuard\.release\('batch-section-creation'\)/);
+    assert.match(main, /operationGuard\.activate\('recording'\)/);
+    assert.match(main, /operationGuard\.release\('recording'\)/);
+});
+
+test('manifest loads the component before the feature and main coordinator', () => {
+    const scripts = manifest.content_scripts.find((entry) => entry.world === 'MAIN').js;
+    const componentIndex = scripts.indexOf('src/components/batch-section-creation-dialog.js');
+    const featureIndex = scripts.indexOf('src/features/batch-section-creation.js');
+    const mainIndex = scripts.indexOf('src/main.js');
+
+    assert.ok(componentIndex >= 0);
+    assert.ok(featureIndex > componentIndex);
+    assert.ok(mainIndex > featureIndex);
+    assert.ok(manifest.web_accessible_resources[0].resources.includes(
+        'src/components/batch-section-creation-dialog.css'
+    ));
+});

--- a/tests/moduleArchitecture.test.js
+++ b/tests/moduleArchitecture.test.js
@@ -24,11 +24,13 @@ test('manifest loads shared infrastructure and features before main', () => {
         'src/components/export-progress-dialog.js',
         'src/components/batch-lesson-access-dialog.js',
         'src/components/batch-user-management-dialog.js',
+        'src/components/batch-section-creation-dialog.js',
         'src/features/reset-lessons.js',
         'src/features/marathon-export.js',
         'src/features/action-recorder.js',
         'src/features/batch-lesson-access.js',
         'src/features/batch-user-management.js',
+        'src/features/batch-section-creation.js',
         'src/main.js'
     ]);
 
@@ -46,7 +48,8 @@ test('manifest loads shared infrastructure and features before main', () => {
             'src/components/action-recorder-dialog.css',
             'src/components/export-progress-dialog.css',
             'src/components/batch-lesson-access-dialog.css',
-            'src/components/batch-user-management-dialog.css'
+            'src/components/batch-user-management-dialog.css',
+            'src/components/batch-section-creation-dialog.css'
         ],
         matches: ['*://*.edvibe.com/*']
     }]);
@@ -68,7 +71,8 @@ test('dynamic UI and presentation stay in components and stylesheets', () => {
         'src/features/reset-lessons.js',
         'src/features/action-recorder.js',
         'src/features/batch-lesson-access.js',
-        'src/features/batch-user-management.js'
+        'src/features/batch-user-management.js',
+        'src/features/batch-section-creation.js'
     ];
 
     for (const file of coordinatorFiles) {
@@ -113,6 +117,7 @@ test('main remains a coordinator without concrete feature logic', () => {
     assert.match(source, /createActionRecorderFeature/);
     assert.match(source, /createBatchLessonAccessFeature/);
     assert.match(source, /createBatchUserManagementFeature/);
+    assert.match(source, /createBatchSectionCreationFeature/);
 });
 
 test('marathon export owns its ZIP compiler implementation', () => {
@@ -197,5 +202,32 @@ test('batch user management routing crosses worlds with its stylesheet only', ()
     assert.match(
         mainSource,
         /event\.data\?\.type === 'EDVIBE_TOOLBOX_OPEN_BATCH_USER_MANAGEMENT'[\s\S]*?batchUserManagementFeature\.open\(\{ stylesheetUrl: event\.data\.stylesheetUrl \}\)/
+    );
+});
+
+test('batch section creation routing crosses worlds and uses a reviewed recipe adapter', () => {
+    const isolatedSource = fs.readFileSync(
+        path.join(root, 'src/isolated.js'),
+        'utf8'
+    );
+    const mainSource = fs.readFileSync(path.join(root, 'src/main.js'), 'utf8');
+
+    assert.match(
+        isolatedSource,
+        /case 'OPEN_BATCH_SECTION_CREATION':\s*window\.postMessage\(\{\s*type: 'EDVIBE_TOOLBOX_OPEN_BATCH_SECTION_CREATION',\s*stylesheetUrl: chrome\.runtime\.getURL\(\s*'src\/components\/batch-section-creation-dialog\.css'\s*\)\s*\}, '\*'\)/
+    );
+    assert.match(mainSource, /requireToolboxModule\('EdVibeBatchSectionCreation'\)/);
+    assert.match(mainSource, /requireToolboxModule\('EdVibeBatchSectionCreationDialog'\)/);
+    assert.match(
+        mainSource,
+        /createRecordedCreationAdapter\(\{[\s\S]*?recipe: window\.EdVibeBatchSectionCreationRecipe \|\| null/
+    );
+    assert.match(
+        mainSource,
+        /createBatchSectionCreationFeature\(\{[\s\S]*?adapter: batchSectionCreationAdapter/
+    );
+    assert.match(
+        mainSource,
+        /event\.data\?\.type === 'EDVIBE_TOOLBOX_OPEN_BATCH_SECTION_CREATION'[\s\S]*?batchSectionCreationFeature\.open\(\{ stylesheetUrl: event\.data\.stylesheetUrl \}\)/
     );
 });

--- a/tests/moduleArchitecture.test.js
+++ b/tests/moduleArchitecture.test.js
@@ -30,6 +30,7 @@ test('manifest loads shared infrastructure and features before main', () => {
         'src/features/action-recorder.js',
         'src/features/batch-lesson-access.js',
         'src/features/batch-user-management.js',
+        'src/features/batch-section-creation-recipe.js',
         'src/features/batch-section-creation.js',
         'src/main.js'
     ]);
@@ -205,12 +206,16 @@ test('batch user management routing crosses worlds with its stylesheet only', ()
     );
 });
 
-test('batch section creation routing crosses worlds and uses a reviewed recipe adapter', () => {
+test('batch section creation routing crosses worlds and uses the recorded recipe', () => {
     const isolatedSource = fs.readFileSync(
         path.join(root, 'src/isolated.js'),
         'utf8'
     );
     const mainSource = fs.readFileSync(path.join(root, 'src/main.js'), 'utf8');
+    const recipeSource = fs.readFileSync(
+        path.join(root, 'src/features/batch-section-creation-recipe.js'),
+        'utf8'
+    );
 
     assert.match(
         isolatedSource,
@@ -218,10 +223,16 @@ test('batch section creation routing crosses worlds and uses a reviewed recipe a
     );
     assert.match(mainSource, /requireToolboxModule\('EdVibeBatchSectionCreation'\)/);
     assert.match(mainSource, /requireToolboxModule\('EdVibeBatchSectionCreationDialog'\)/);
+    assert.match(mainSource, /requireToolboxModule\('EdVibeBatchSectionCreationRecipe'\)/);
     assert.match(
         mainSource,
-        /createRecordedCreationAdapter\(\{[\s\S]*?recipe: window\.EdVibeBatchSectionCreationRecipe \|\| null/
+        /createRecordedCreationAdapter\(\{[\s\S]*?recipe: batchSectionCreationRecipe/
     );
+    assert.match(recipeSource, /LessonSectionWsController/);
+    assert.match(recipeSource, /AddStageSection/);
+    assert.match(recipeSource, /SaveExerciseWsController/);
+    assert.match(recipeSource, /Type: 27/);
+    assert.match(recipeSource, /Type: 29/);
     assert.match(
         mainSource,
         /createBatchSectionCreationFeature\(\{[\s\S]*?adapter: batchSectionCreationAdapter/


### PR DESCRIPTION
## What changed

- add batch section creation for selected marathon lessons
- add a Web Component constructor and collision-aware preflight
- execute lessons sequentially with per-lesson results
- integrate with the popup, isolated/main worlds, manifest, and operation guard
- add focused feature, dialog, integration, protocol, and architecture tests

## Recorded protocol

The write path is enabled from the WebSocket Action Recorder capture supplied on August 5, 2026.

The reviewed v1 recipe performs the observed sequence:

1. `LessonSectionWsController.AddStageSection`
2. capture `Value.StageSectionId`
3. `LessonSectionWsController.EditStageSection` with the captured ID
4. `SaveExerciseWsController.SaveExercise` using exercise type `27` for the recorded image asset
5. `SaveExerciseWsController.SaveExercise` using exercise type `29` for CTA text and link

Exercise `Number` follows the configured block order. The failed recorded `ChangeExerciseImages` call is intentionally omitted because the preceding image save succeeded.

Only the minimal derived recipe is committed. The original recording remains outside the repository.

## V1 boundaries

- reuses the image asset captured in the recording
- creates new sections only
- does not attempt automatic rollback because no deletion sequence was recorded
- uses the recorded append position (`SortId: 4`)

## Validation

Focused Node tests pass: **17/17**.

The branch is currently behind `master` by four commits and should be updated before merge.

Related to #1.