### PR TITLE
Introduce IndexedDB persistence framework

### DIFF
--- a/docs/indexeddb.md
+++ b/docs/indexeddb.md
@@ -1,0 +1,65 @@
+# IndexedDB persistence
+
+`src/shared/indexeddb.js` provides the extension-owned IndexedDB boundary. It keeps database lifecycle, migrations, transaction completion, request errors, and common store operations out of feature modules without hiding native IndexedDB concepts.
+
+## Define a database
+
+```js
+const historyDb = EdVibeIndexedDb.createIndexedDb({
+    name: 'edvibe-toolbox',
+    version: 2,
+    migrations: [
+        {
+            version: 1,
+            migrate({ db }) {
+                if (!db.objectStoreNames.contains('history')) {
+                    const store = db.createObjectStore('history', { keyPath: 'id' });
+                    store.createIndex('createdAt', 'createdAt');
+                }
+            }
+        },
+        {
+            version: 2,
+            migrate({ transaction }) {
+                const store = transaction.objectStore('history');
+                if (!store.indexNames.contains('feature')) {
+                    store.createIndex('feature', 'feature');
+                }
+            }
+        }
+    ]
+});
+```
+
+Migration versions are explicit integers. Add one migration for each schema version, keep it synchronous, and guard store/index creation with `contains()` where practical. Schema changes run only in the upgrade transaction. Throwing aborts the upgrade and rejects `open()` with an `IndexedDbError` whose `cause` is the original failure.
+
+## Transactions
+
+```js
+await historyDb.readwrite(['history', 'metadata'], ({ store, abort }) => {
+    const write = store('history').put(entry);
+    const metadata = store('metadata').put({ key: 'lastWrite', value: entry.createdAt });
+
+    if (!entry.id) abort(new Error('History entries require an id'));
+    return Promise.all([write, metadata]);
+}, 'save-history-entry');
+```
+
+The callback runs immediately so all IndexedDB work is queued while the transaction is active. Do not await network calls, timers, or unrelated asynchronous work inside it. The returned promise resolves only after both the callback result and the native transaction complete.
+
+## Repository helpers
+
+```js
+const history = historyDb.repository('history');
+
+await history.put(entry);
+const item = await history.get(entry.id);
+const latest = await history.newest('createdAt', {
+    range: IDBKeyRange.bound(from, to),
+    limit: 50
+});
+```
+
+Repositories expose `get`, `put`, `add`, `delete`, `clear`, `count`, cursor iteration, indexed queries, and newest-first indexed retrieval. Advanced consumers can use `raw` on a store or index helper and the native transaction passed to the callback.
+
+Call `close()` (or its alias `reset()`) for tests and extension lifecycle cleanup. Open connections close automatically on `versionchange`. Use `onBlocked` to log or surface an upgrade blocked by another extension context.

--- a/src/shared/indexeddb.js
+++ b/src/shared/indexeddb.js
@@ -1,0 +1,445 @@
+(function initializeIndexedDbModule(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.EdVibeIndexedDb = factory();
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function indexedDbModuleFactory() {
+    'use strict';
+
+    class IndexedDbError extends Error {
+        constructor(message, context = {}, cause) {
+            super(message, cause === undefined ? undefined : { cause });
+            this.name = 'IndexedDbError';
+            this.context = Object.freeze({ ...context });
+            if (cause !== undefined && this.cause === undefined) {
+                this.cause = cause;
+            }
+        }
+    }
+
+    function errorMessage(action, context) {
+        const details = [
+            context.database && `database=${context.database}`,
+            context.stores && `stores=${context.stores.join(',')}`,
+            context.store && `store=${context.store}`,
+            context.index && `index=${context.index}`,
+            context.mode && `mode=${context.mode}`,
+            context.operation && `operation=${context.operation}`,
+            context.version && `version=${context.version}`
+        ].filter(Boolean).join(' ');
+        return details ? `${action} (${details})` : action;
+    }
+
+    function wrapError(action, context, cause) {
+        if (cause instanceof IndexedDbError) {
+            return cause;
+        }
+        return new IndexedDbError(errorMessage(action, context), context, cause);
+    }
+
+    function requestToPromise(request, context = {}) {
+        return new Promise((resolve, reject) => {
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(wrapError('IndexedDB request failed', context, request.error));
+        });
+    }
+
+    function transactionToPromise(transaction, context = {}) {
+        return new Promise((resolve, reject) => {
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(wrapError('IndexedDB transaction failed', context, transaction.error));
+            transaction.onabort = () => reject(wrapError('IndexedDB transaction aborted', context, transaction.error));
+        });
+    }
+
+    function normalizeStores(storeNames) {
+        const stores = typeof storeNames === 'string' ? [storeNames] : Array.from(storeNames || []);
+        if (stores.length === 0) {
+            throw new TypeError('At least one object store is required');
+        }
+        return stores;
+    }
+
+    function normalizeMigrations(definition) {
+        const migrations = Array.from(definition.migrations || []).sort((left, right) => left.version - right.version);
+        const seen = new Set();
+        for (const migration of migrations) {
+            if (!Number.isInteger(migration.version) || migration.version < 1 || migration.version > definition.version) {
+                throw new TypeError(`Invalid migration version: ${migration.version}`);
+            }
+            if (seen.has(migration.version)) {
+                throw new TypeError(`Duplicate migration version: ${migration.version}`);
+            }
+            if (typeof migration.migrate !== 'function') {
+                throw new TypeError(`Migration ${migration.version} must define migrate()`);
+            }
+            seen.add(migration.version);
+        }
+        return migrations;
+    }
+
+    function cursorToPromise(source, options, context) {
+        const {
+            range = null,
+            direction = 'next',
+            limit = Infinity,
+            keysOnly = false,
+            map = null
+        } = options || {};
+
+        if (!Number.isFinite(limit) && limit !== Infinity) {
+            throw new TypeError('Cursor limit must be a finite number or Infinity');
+        }
+        if (limit < 0) {
+            throw new RangeError('Cursor limit cannot be negative');
+        }
+        if (limit === 0) {
+            return Promise.resolve([]);
+        }
+
+        return new Promise((resolve, reject) => {
+            const results = [];
+            let request;
+            try {
+                request = keysOnly
+                    ? source.openKeyCursor(range, direction)
+                    : source.openCursor(range, direction);
+            } catch (error) {
+                reject(wrapError('Failed to open IndexedDB cursor', context, error));
+                return;
+            }
+
+            request.onerror = () => reject(wrapError('IndexedDB cursor failed', context, request.error));
+            request.onsuccess = () => {
+                const cursor = request.result;
+                if (!cursor || results.length >= limit) {
+                    resolve(results);
+                    return;
+                }
+
+                const raw = keysOnly ? cursor.primaryKey : cursor.value;
+                results.push(typeof map === 'function' ? map(raw, cursor) : raw);
+                cursor.continue();
+            };
+        });
+    }
+
+    function createSourceHelpers(source, context) {
+        return {
+            raw: source,
+            get(key) {
+                return requestToPromise(source.get(key), { ...context, operation: 'get' });
+            },
+            getKey(query) {
+                return requestToPromise(source.getKey(query), { ...context, operation: 'getKey' });
+            },
+            getAll(query = null, count) {
+                return requestToPromise(source.getAll(query, count), { ...context, operation: 'getAll' });
+            },
+            getAllKeys(query = null, count) {
+                return requestToPromise(source.getAllKeys(query, count), { ...context, operation: 'getAllKeys' });
+            },
+            count(query = null) {
+                return requestToPromise(source.count(query), { ...context, operation: 'count' });
+            },
+            iterate(options = {}) {
+                return cursorToPromise(source, options, { ...context, operation: 'iterate' });
+            }
+        };
+    }
+
+    function createStoreHelpers(store, context) {
+        return {
+            ...createSourceHelpers(store, context),
+            put(value, key) {
+                return requestToPromise(store.put(value, key), { ...context, operation: 'put' });
+            },
+            add(value, key) {
+                return requestToPromise(store.add(value, key), { ...context, operation: 'add' });
+            },
+            delete(key) {
+                return requestToPromise(store.delete(key), { ...context, operation: 'delete' });
+            },
+            clear() {
+                return requestToPromise(store.clear(), { ...context, operation: 'clear' });
+            },
+            index(indexName) {
+                const index = store.index(indexName);
+                return createSourceHelpers(index, { ...context, index: indexName });
+            }
+        };
+    }
+
+    function createIndexedDb(definition, options = {}) {
+        if (!definition || typeof definition.name !== 'string' || definition.name.length === 0) {
+            throw new TypeError('Database definition requires a non-empty name');
+        }
+        if (!Number.isInteger(definition.version) || definition.version < 1) {
+            throw new TypeError('Database definition requires a positive integer version');
+        }
+
+        const indexedDbFactory = options.indexedDB || root.indexedDB;
+        if (!indexedDbFactory || typeof indexedDbFactory.open !== 'function') {
+            throw new TypeError('An IndexedDB factory is required');
+        }
+
+        const migrations = normalizeMigrations(definition);
+        let connection = null;
+        let opening = null;
+
+        function invalidate(db) {
+            if (connection === db) {
+                connection = null;
+            }
+            opening = null;
+        }
+
+        function open() {
+            if (connection) {
+                return Promise.resolve(connection);
+            }
+            if (opening) {
+                return opening;
+            }
+
+            opening = new Promise((resolve, reject) => {
+                let request;
+                let settled = false;
+                let blockedTimer = null;
+                try {
+                    request = indexedDbFactory.open(definition.name, definition.version);
+                } catch (error) {
+                    reject(wrapError('Failed to open IndexedDB database', {
+                        database: definition.name,
+                        version: definition.version
+                    }, error));
+                    return;
+                }
+
+                const fail = (error) => {
+                    if (settled) return;
+                    settled = true;
+                    if (blockedTimer !== null) clearTimeout(blockedTimer);
+                    opening = null;
+                    reject(error);
+                };
+
+                request.onblocked = () => {
+                    const context = {
+                        database: definition.name,
+                        version: definition.version,
+                        operation: 'open'
+                    };
+                    const error = wrapError('IndexedDB upgrade is blocked by another open connection', context, request.error);
+                    if (typeof options.onBlocked === 'function') {
+                        options.onBlocked(error, context);
+                    }
+                    if (options.blockedTimeoutMs > 0 && blockedTimer === null) {
+                        blockedTimer = setTimeout(() => fail(error), options.blockedTimeoutMs);
+                    }
+                };
+
+                request.onupgradeneeded = (event) => {
+                    const db = request.result;
+                    const transaction = request.transaction;
+                    try {
+                        for (const migration of migrations) {
+                            if (migration.version > event.oldVersion && migration.version <= event.newVersion) {
+                                migration.migrate({
+                                    db,
+                                    transaction,
+                                    oldVersion: event.oldVersion,
+                                    newVersion: event.newVersion,
+                                    version: migration.version
+                                });
+                            }
+                        }
+                    } catch (error) {
+                        try {
+                            transaction.abort();
+                        } catch (_) {
+                            // The browser may already have aborted the upgrade transaction.
+                        }
+                        fail(wrapError('IndexedDB migration failed', {
+                            database: definition.name,
+                            version: event.newVersion,
+                            operation: 'migrate'
+                        }, error));
+                    }
+                };
+
+                request.onerror = () => fail(wrapError('Failed to open IndexedDB database', {
+                    database: definition.name,
+                    version: definition.version,
+                    operation: 'open'
+                }, request.error));
+
+                request.onsuccess = () => {
+                    const db = request.result;
+                    if (settled) {
+                        db.close();
+                        return;
+                    }
+                    settled = true;
+                    if (blockedTimer !== null) clearTimeout(blockedTimer);
+                    connection = db;
+                    opening = null;
+                    db.onversionchange = () => {
+                        db.close();
+                        invalidate(db);
+                        if (typeof options.onVersionChange === 'function') {
+                            options.onVersionChange({ database: definition.name, version: db.version });
+                        }
+                    };
+                    resolve(db);
+                };
+            });
+
+            return opening;
+        }
+
+        async function runTransaction(storeNames, mode, callback, operation = 'transaction') {
+            const stores = normalizeStores(storeNames);
+            if (mode !== 'readonly' && mode !== 'readwrite') {
+                throw new TypeError(`Unsupported transaction mode: ${mode}`);
+            }
+            if (typeof callback !== 'function') {
+                throw new TypeError('Transaction callback must be a function');
+            }
+
+            const db = await open();
+            const context = { database: definition.name, stores, mode, operation };
+            let transaction;
+            try {
+                transaction = db.transaction(stores, mode);
+            } catch (error) {
+                throw wrapError('Failed to create IndexedDB transaction', context, error);
+            }
+
+            const completion = transactionToPromise(transaction, context);
+            const helpers = Object.create(null);
+            for (const storeName of stores) {
+                helpers[storeName] = createStoreHelpers(transaction.objectStore(storeName), {
+                    ...context,
+                    store: storeName
+                });
+            }
+
+            let result;
+            try {
+                result = callback({
+                    transaction,
+                    stores: helpers,
+                    store(name) {
+                        if (!helpers[name]) {
+                            throw new IndexedDbError(errorMessage('Store is not part of this transaction', {
+                                ...context,
+                                store: name
+                            }), { ...context, store: name });
+                        }
+                        return helpers[name];
+                    },
+                    abort(reason) {
+                        if (reason !== undefined && transaction.error === null) {
+                            try {
+                                Object.defineProperty(transaction, '__edvibeAbortReason', { value: reason });
+                            } catch (_) {
+                                // Native transactions may be non-extensible.
+                            }
+                        }
+                        transaction.abort();
+                    }
+                });
+            } catch (error) {
+                try {
+                    transaction.abort();
+                } catch (_) {
+                    // Ignore secondary abort failures.
+                }
+                try {
+                    await completion;
+                } catch (_) {
+                    // The callback error is the actionable cause.
+                }
+                throw wrapError('IndexedDB transaction callback failed', context, error);
+            }
+
+            try {
+                const [value] = await Promise.all([Promise.resolve(result), completion]);
+                return value;
+            } catch (error) {
+                const cause = transaction.__edvibeAbortReason || error;
+                throw wrapError('IndexedDB transaction did not commit', context, cause);
+            }
+        }
+
+        function repository(storeName) {
+            return {
+                get(key) {
+                    return runTransaction(storeName, 'readonly', ({ store }) => store(storeName).get(key), `get:${storeName}`);
+                },
+                put(value, key) {
+                    return runTransaction(storeName, 'readwrite', ({ store }) => store(storeName).put(value, key), `put:${storeName}`);
+                },
+                add(value, key) {
+                    return runTransaction(storeName, 'readwrite', ({ store }) => store(storeName).add(value, key), `add:${storeName}`);
+                },
+                delete(key) {
+                    return runTransaction(storeName, 'readwrite', ({ store }) => store(storeName).delete(key), `delete:${storeName}`);
+                },
+                clear() {
+                    return runTransaction(storeName, 'readwrite', ({ store }) => store(storeName).clear(), `clear:${storeName}`);
+                },
+                count(query = null) {
+                    return runTransaction(storeName, 'readonly', ({ store }) => store(storeName).count(query), `count:${storeName}`);
+                },
+                iterate(options = {}) {
+                    return runTransaction(storeName, 'readonly', ({ store }) => store(storeName).iterate(options), `iterate:${storeName}`);
+                },
+                queryIndex(indexName, options = {}) {
+                    return runTransaction(storeName, 'readonly', ({ store }) => {
+                        return store(storeName).index(indexName).iterate(options);
+                    }, `query-index:${storeName}.${indexName}`);
+                },
+                newest(indexName, options = {}) {
+                    return this.queryIndex(indexName, { ...options, direction: 'prev' });
+                }
+            };
+        }
+
+        function close() {
+            if (connection) {
+                const db = connection;
+                connection = null;
+                db.close();
+            }
+            opening = null;
+        }
+
+        return Object.freeze({
+            name: definition.name,
+            version: definition.version,
+            open,
+            close,
+            reset: close,
+            transaction: runTransaction,
+            readonly(storeNames, callback, operation) {
+                return runTransaction(storeNames, 'readonly', callback, operation);
+            },
+            readwrite(storeNames, callback, operation) {
+                return runTransaction(storeNames, 'readwrite', callback, operation);
+            },
+            repository
+        });
+    }
+
+    return {
+        IndexedDbError,
+        createIndexedDb,
+        requestToPromise,
+        transactionToPromise
+    };
+});

--- a/tests/indexeddb.test.js
+++ b/tests/indexeddb.test.js
@@ -1,0 +1,242 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    IndexedDbError,
+    createIndexedDb,
+    requestToPromise
+} = require('../src/shared/indexeddb.js');
+
+class FakeRequest {
+    succeed(result) {
+        this.result = result;
+        queueMicrotask(() => this.onsuccess?.({ target: this }));
+        return this;
+    }
+
+    fail(error) {
+        this.error = error;
+        queueMicrotask(() => this.onerror?.({ target: this }));
+        return this;
+    }
+}
+
+class FakeCursorSource {
+    constructor(values) {
+        this.values = values;
+    }
+
+    openCursor(_range, direction) {
+        const request = new FakeRequest();
+        const values = direction === 'prev' ? [...this.values].reverse() : [...this.values];
+        let index = 0;
+        const makeCursor = () => ({
+            value: values[index],
+            primaryKey: values[index].id,
+            continue() {
+                index += 1;
+                request.result = index < values.length ? makeCursor() : null;
+                queueMicrotask(() => request.onsuccess?.({ target: request }));
+            }
+        });
+        request.result = values.length ? makeCursor() : null;
+        queueMicrotask(() => request.onsuccess?.({ target: request }));
+        return request;
+    }
+
+    openKeyCursor(range, direction) { return this.openCursor(range, direction); }
+    get(key) { return new FakeRequest().succeed(this.values.find((value) => value.id === key)); }
+    getKey() { return new FakeRequest().succeed(this.values[0]?.id); }
+    getAll() { return new FakeRequest().succeed([...this.values]); }
+    getAllKeys() { return new FakeRequest().succeed(this.values.map((value) => value.id)); }
+    count() { return new FakeRequest().succeed(this.values.length); }
+}
+
+class FakeStore extends FakeCursorSource {
+    put(value) {
+        const index = this.values.findIndex((item) => item.id === value.id);
+        if (index >= 0) this.values[index] = value;
+        else this.values.push(value);
+        return new FakeRequest().succeed(value.id);
+    }
+
+    add(value) {
+        if (this.values.some((item) => item.id === value.id)) {
+            return new FakeRequest().fail(new Error('ConstraintError'));
+        }
+        this.values.push(value);
+        return new FakeRequest().succeed(value.id);
+    }
+
+    delete(key) {
+        const index = this.values.findIndex((item) => item.id === key);
+        if (index >= 0) this.values.splice(index, 1);
+        return new FakeRequest().succeed(undefined);
+    }
+
+    clear() {
+        this.values.splice(0);
+        return new FakeRequest().succeed(undefined);
+    }
+
+    index() { return this; }
+}
+
+class FakeTransaction {
+    constructor(stores, commitDelay = 0) {
+        this.stores = stores;
+        this.error = null;
+        setTimeout(() => {
+            if (!this.aborted) this.oncomplete?.();
+        }, commitDelay);
+    }
+
+    objectStore(name) { return this.stores[name]; }
+
+    abort() {
+        this.aborted = true;
+        queueMicrotask(() => this.onabort?.());
+    }
+}
+
+class FakeDatabase {
+    constructor(stores = {}) {
+        this.stores = stores;
+        this.version = 1;
+        this.closeCount = 0;
+        this.transactions = [];
+        this.objectStoreNames = { contains: (name) => Object.hasOwn(this.stores, name) };
+    }
+
+    createObjectStore(name) {
+        const store = new FakeStore([]);
+        this.stores[name] = store;
+        return store;
+    }
+
+    transaction(names) {
+        const selected = Object.fromEntries(Array.from(names).map((name) => [name, this.stores[name]]));
+        const transaction = new FakeTransaction(selected, 15);
+        this.transactions.push(transaction);
+        return transaction;
+    }
+
+    close() { this.closeCount += 1; }
+}
+
+class FakeFactory {
+    constructor(database) {
+        this.database = database;
+        this.openCount = 0;
+        this.oldVersion = 0;
+    }
+
+    open(_name, version) {
+        this.openCount += 1;
+        const request = new FakeRequest();
+        request.result = this.database;
+        request.transaction = new FakeTransaction(this.database.stores);
+        queueMicrotask(() => {
+            request.onupgradeneeded?.({ oldVersion: this.oldVersion, newVersion: version });
+            queueMicrotask(() => request.onsuccess?.({ target: request }));
+        });
+        return request;
+    }
+}
+
+test('request adapter preserves the native error as cause', async () => {
+    const nativeError = new Error('boom');
+    const request = new FakeRequest().fail(nativeError);
+
+    await assert.rejects(requestToPromise(request, { operation: 'demo' }), (error) => {
+        assert.ok(error instanceof IndexedDbError);
+        assert.equal(error.cause, nativeError);
+        assert.equal(error.context.operation, 'demo');
+        return true;
+    });
+});
+
+test('open runs ordered migrations once and reuses the connection', async () => {
+    const database = new FakeDatabase();
+    const factory = new FakeFactory(database);
+    const applied = [];
+    const db = createIndexedDb({
+        name: 'test',
+        version: 3,
+        migrations: [
+            { version: 3, migrate: () => applied.push(3) },
+            { version: 1, migrate: ({ db: opened }) => { opened.createObjectStore('items'); applied.push(1); } },
+            { version: 2, migrate: () => applied.push(2) }
+        ]
+    }, { indexedDB: factory });
+
+    const first = await db.open();
+    const second = await db.open();
+
+    assert.equal(first, second);
+    assert.deepEqual(applied, [1, 2, 3]);
+    assert.equal(factory.openCount, 1);
+});
+
+test('versionchange closes and invalidates the cached connection', async () => {
+    const database = new FakeDatabase({ items: new FakeStore([]) });
+    const factory = new FakeFactory(database);
+    const db = createIndexedDb({ name: 'test', version: 1 }, { indexedDB: factory });
+
+    await db.open();
+    database.onversionchange();
+    await db.open();
+
+    assert.equal(database.closeCount, 1);
+    assert.equal(factory.openCount, 2);
+});
+
+test('readwrite resolves only after the transaction commits', async () => {
+    const database = new FakeDatabase({ items: new FakeStore([]) });
+    const db = createIndexedDb({ name: 'test', version: 1 }, { indexedDB: new FakeFactory(database) });
+    const events = [];
+
+    const result = await db.readwrite('items', ({ store }) => {
+        events.push('callback');
+        return store('items').put({ id: 1 }).then(() => {
+            events.push('request');
+            return 'saved';
+        });
+    }, 'save-item').then((value) => {
+        events.push('resolved');
+        return value;
+    });
+
+    assert.equal(result, 'saved');
+    assert.deepEqual(events, ['callback', 'request', 'resolved']);
+});
+
+test('repository supports CRUD and newest-first limited index queries', async () => {
+    const store = new FakeStore([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    const database = new FakeDatabase({ items: store });
+    const db = createIndexedDb({ name: 'test', version: 1 }, { indexedDB: new FakeFactory(database) });
+    const repository = db.repository('items');
+
+    assert.equal((await repository.get(2)).id, 2);
+    await repository.put({ id: 4 });
+    assert.equal(await repository.count(), 4);
+    assert.deepEqual((await repository.newest('createdAt', { limit: 2 })).map((item) => item.id), [4, 3]);
+    await repository.delete(1);
+    assert.equal(await repository.count(), 3);
+    await repository.clear();
+    assert.equal(await repository.count(), 0);
+});
+
+test('callback failures abort and produce contextual errors', async () => {
+    const database = new FakeDatabase({ items: new FakeStore([]) });
+    const db = createIndexedDb({ name: 'test', version: 1 }, { indexedDB: new FakeFactory(database) });
+
+    await assert.rejects(db.readwrite('items', () => {
+        throw new Error('invalid state');
+    }, 'validate'), (error) => {
+        assert.ok(error instanceof IndexedDbError);
+        assert.match(error.message, /operation=validate/);
+        assert.equal(error.cause.message, 'invalid state');
+        return true;
+    });
+});


### PR DESCRIPTION
Closes #10

## What changed

- added a shared IndexedDB lifecycle abstraction with ordered migrations, cached connections, blocked-upgrade diagnostics, `versionchange` cleanup, and explicit close/reset
- added transaction runners that expose scoped store helpers and resolve only after native transaction commit
- added contextual `IndexedDbError` wrapping for open, migration, request, cursor, transaction, and abort failures
- added lightweight CRUD, index, range, cursor, limit, and newest-first repository helpers while retaining access to native stores, indexes, transactions, and `IDBKeyRange`
- documented the migration and feature-repository pattern
- added deterministic Node tests for migration ordering, connection reuse/invalidation, commit timing, CRUD/query helpers, and failure propagation

## Validation

- `node --check src/shared/indexeddb.js`
- `node --test tests/indexeddb.test.js`

All six focused tests pass locally.