### PR TITLE
Add batch user-management history record contract

### DIFF
--- a/src/features/batch-user-management-history.js
+++ b/src/features/batch-user-management-history.js
@@ -1,0 +1,251 @@
+(function initializeBatchUserManagementHistory(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.EdVibeBatchUserManagementHistory = factory();
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule() {
+    'use strict';
+
+    const OPERATION_TYPE = 'batch_user_management';
+    const SCHEMA_VERSION = 1;
+    const OPERATION_NAMES = Object.freeze({
+        unassign: 'unassign_curator',
+        delete: 'delete_user'
+    });
+    const TERMINAL_STATUSES = new Set([
+        'completed',
+        'completed_with_failures',
+        'cancelled',
+        'interrupted'
+    ]);
+
+    function clone(value) {
+        if (value === undefined) {
+            return undefined;
+        }
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function createExecutionId(now = Date.now, random = Math.random) {
+        const timestamp = Number(now()).toString(36);
+        const entropy = Math.floor(random() * Number.MAX_SAFE_INTEGER).toString(36);
+        return `${OPERATION_TYPE}-${timestamp}-${entropy}`;
+    }
+
+    function normalizeIdentity(row) {
+        const pupil = row?.pupil || {};
+        return {
+            email: pupil.Email || row?.normalizedEmail || row?.email || null,
+            displayName: pupil.DisplayName || pupil.FullName || pupil.Name || null,
+            firstName: pupil.FirstName || null,
+            lastName: pupil.LastName || null,
+            pupilId: pupil.PupilId ?? pupil.Id ?? null,
+            marathonPupilId: row?.marathonPupilId ?? pupil.MarathonPupilId ?? null
+        };
+    }
+
+    function selectedOperations(row) {
+        const operations = [];
+        if (row?.unassignSelected) {
+            operations.push(OPERATION_NAMES.unassign);
+        }
+        if (row?.deleteSelected) {
+            operations.push(OPERATION_NAMES.delete);
+        }
+        return operations;
+    }
+
+    function operationResult(result, fallbackStatus = 'not_attempted') {
+        if (!result) {
+            return {
+                status: fallbackStatus,
+                attemptCount: 0,
+                code: fallbackStatus === 'not_attempted' ? 'NOT_ATTEMPTED' : null,
+                message: fallbackStatus === 'not_attempted' ? 'The operation was not attempted.' : null,
+                blockedBy: null
+            };
+        }
+
+        const dependencyBlocked = result.status === 'skipped'
+            && /curator removal failed/i.test(result.message || '');
+        return {
+            status: result.status,
+            attemptCount: Number.isInteger(result.attempts) ? result.attempts : 0,
+            code: result.code || (dependencyBlocked ? 'DEPENDENCY_FAILED' : null),
+            message: result.message || null,
+            blockedBy: dependencyBlocked ? OPERATION_NAMES.unassign : null
+        };
+    }
+
+    function finalOutcome(row, operations) {
+        if (row?.status !== 'matched') {
+            return 'rejected';
+        }
+        if (operations.length === 0) {
+            return 'skipped';
+        }
+        const results = Object.values(row?.operations || {});
+        if (results.some((result) => result.status === 'failed')) {
+            return 'failed';
+        }
+        if (results.some((result) => result.status === 'not_attempted')) {
+            return 'not_attempted';
+        }
+        if (results.some((result) => result.status === 'skipped')) {
+            return 'partially_skipped';
+        }
+        if (results.every((result) => result.status === 'noop')) {
+            return 'noop';
+        }
+        return 'success';
+    }
+
+    function serializeItem(row) {
+        const operations = selectedOperations(row);
+        const operationResults = {};
+        if (operations.includes(OPERATION_NAMES.unassign)) {
+            operationResults[OPERATION_NAMES.unassign] = operationResult(row?.unassign);
+        }
+        if (operations.includes(OPERATION_NAMES.delete)) {
+            operationResults[OPERATION_NAMES.delete] = operationResult(row?.delete);
+        }
+
+        const item = {
+            submitted: row?.email || null,
+            normalizedEmail: row?.normalizedEmail || null,
+            resolution: row?.status || 'malformed',
+            resolutionMessage: row?.message || null,
+            user: row?.status === 'matched' ? normalizeIdentity(row) : null,
+            curatorPresent: row?.status === 'matched' ? Boolean(row?.hasCurator) : null,
+            selectedOperations: operations,
+            operations: operationResults
+        };
+        item.outcome = finalOutcome(item, operations);
+        return item;
+    }
+
+    function countSummary(items) {
+        const userCounts = {
+            requested: items.length,
+            matched: 0,
+            rejected: 0,
+            successful: 0,
+            failed: 0,
+            skipped: 0,
+            notAttempted: 0
+        };
+        const operationCounts = {
+            selected: 0,
+            attempted: 0,
+            successful: 0,
+            noop: 0,
+            skipped: 0,
+            failed: 0,
+            notAttempted: 0
+        };
+
+        for (const item of items) {
+            if (item.resolution === 'matched') {
+                userCounts.matched += 1;
+            } else {
+                userCounts.rejected += 1;
+            }
+            if (item.outcome === 'success' || item.outcome === 'noop') {
+                userCounts.successful += 1;
+            } else if (item.outcome === 'failed') {
+                userCounts.failed += 1;
+            } else if (item.outcome === 'not_attempted') {
+                userCounts.notAttempted += 1;
+            } else if (item.outcome !== 'rejected') {
+                userCounts.skipped += 1;
+            }
+
+            for (const result of Object.values(item.operations)) {
+                operationCounts.selected += 1;
+                if (result.status !== 'not_attempted') {
+                    operationCounts.attempted += 1;
+                }
+                if (result.status === 'success') operationCounts.successful += 1;
+                if (result.status === 'noop') operationCounts.noop += 1;
+                if (result.status === 'skipped') operationCounts.skipped += 1;
+                if (result.status === 'failed') operationCounts.failed += 1;
+                if (result.status === 'not_attempted') operationCounts.notAttempted += 1;
+            }
+        }
+
+        return { users: userCounts, operations: operationCounts };
+    }
+
+    function inferTerminalStatus(items, requestedStatus) {
+        if (requestedStatus && !TERMINAL_STATUSES.has(requestedStatus)) {
+            throw new TypeError(`Unsupported terminal status: ${requestedStatus}`);
+        }
+        if (requestedStatus) {
+            return requestedStatus;
+        }
+        const hasFailure = items.some((item) =>
+            item.outcome === 'failed' || item.outcome === 'partially_skipped'
+        );
+        return hasFailure ? 'completed_with_failures' : 'completed';
+    }
+
+    function createExecutionRecord({
+        executionId = createExecutionId(),
+        startedAt,
+        completedAt,
+        terminalStatus,
+        marathonId,
+        marathonName = null,
+        rows,
+        interruption = null
+    }) {
+        const items = (Array.isArray(rows) ? rows : []).map(serializeItem);
+        return Object.freeze({
+            executionId,
+            schemaVersion: SCHEMA_VERSION,
+            operationType: OPERATION_TYPE,
+            startedAt,
+            completedAt,
+            terminalStatus: inferTerminalStatus(items, terminalStatus),
+            context: Object.freeze({ marathonId, marathonName }),
+            summary: Object.freeze(countSummary(items)),
+            items: Object.freeze(items.map((item) => Object.freeze(item))),
+            interruption: interruption ? Object.freeze(clone(interruption)) : null
+        });
+    }
+
+    async function persistTerminalRecord({
+        record,
+        persist,
+        onPersistenceError = () => {}
+    }) {
+        if (typeof persist !== 'function') {
+            throw new TypeError('persist must be a function');
+        }
+        try {
+            await persist(record);
+            return { record, persisted: true, persistenceError: null };
+        } catch (error) {
+            try {
+                onPersistenceError(error, record);
+            } catch (_) {
+                // Error reporting must not replace the visible operation result.
+            }
+            return { record, persisted: false, persistenceError: error };
+        }
+    }
+
+    return {
+        OPERATION_TYPE,
+        SCHEMA_VERSION,
+        OPERATION_NAMES,
+        createExecutionId,
+        serializeItem,
+        countSummary,
+        createExecutionRecord,
+        persistTerminalRecord
+    };
+});

--- a/src/features/batch-user-management-history.test.js
+++ b/src/features/batch-user-management-history.test.js
@@ -1,0 +1,214 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    createExecutionRecord,
+    persistTerminalRecord
+} = require('./batch-user-management-history');
+
+function matchedRow(overrides = {}) {
+    return {
+        email: 'User@Example.com',
+        normalizedEmail: 'user@example.com',
+        status: 'matched',
+        message: '',
+        hasCurator: true,
+        marathonPupilId: 42,
+        pupil: {
+            Email: 'user@example.com',
+            FirstName: 'Ada',
+            LastName: 'Lovelace',
+            PupilId: 7,
+            MarathonPupilId: 42
+        },
+        unassignSelected: true,
+        deleteSelected: true,
+        unassign: { status: 'success', attempts: 1 },
+        delete: { status: 'success', attempts: 1 },
+        ...overrides
+    };
+}
+
+function recordFor(rows, overrides = {}) {
+    return createExecutionRecord({
+        executionId: 'execution-1',
+        startedAt: '2026-08-06T04:00:00.000Z',
+        completedAt: '2026-08-06T04:01:00.000Z',
+        marathonId: 123,
+        marathonName: 'History marathon',
+        rows,
+        ...overrides
+    });
+}
+
+test('serializes mixed operation selections independently', () => {
+    const record = recordFor([
+        matchedRow({ deleteSelected: false, delete: null }),
+        matchedRow({
+            email: 'delete@example.com',
+            normalizedEmail: 'delete@example.com',
+            unassignSelected: false,
+            unassign: null
+        })
+    ]);
+
+    assert.deepEqual(record.items[0].selectedOperations, ['unassign_curator']);
+    assert.deepEqual(record.items[1].selectedOperations, ['delete_user']);
+    assert.equal(record.summary.users.requested, 2);
+    assert.equal(record.summary.operations.selected, 2);
+    assert.equal(record.summary.operations.successful, 2);
+});
+
+test('records successful curator removal and deletion with identity data', () => {
+    const record = recordFor([matchedRow()]);
+    const [item] = record.items;
+
+    assert.equal(item.user.email, 'user@example.com');
+    assert.equal(item.user.pupilId, 7);
+    assert.equal(item.user.marathonPupilId, 42);
+    assert.equal(item.operations.unassign_curator.status, 'success');
+    assert.equal(item.operations.delete_user.status, 'success');
+    assert.equal(item.outcome, 'success');
+});
+
+test('records no-op curator removal without counting an attempt', () => {
+    const record = recordFor([matchedRow({
+        hasCurator: false,
+        deleteSelected: false,
+        delete: null,
+        unassign: { status: 'noop', attempts: 0, message: 'No curator was assigned.' }
+    })]);
+
+    assert.equal(record.items[0].operations.unassign_curator.status, 'noop');
+    assert.equal(record.summary.operations.attempted, 1);
+    assert.equal(record.summary.operations.noop, 1);
+});
+
+test('keeps dependency-blocked deletion distinct from curator failure', () => {
+    const record = recordFor([matchedRow({
+        unassign: {
+            status: 'failed',
+            attempts: 3,
+            code: 'REQUEST_TIMEOUT',
+            message: 'Timed out.'
+        },
+        delete: {
+            status: 'skipped',
+            attempts: 0,
+            message: 'Skipped because curator removal failed.'
+        }
+    })]);
+    const operations = record.items[0].operations;
+
+    assert.equal(operations.unassign_curator.status, 'failed');
+    assert.equal(operations.unassign_curator.attemptCount, 3);
+    assert.equal(operations.delete_user.status, 'skipped');
+    assert.equal(operations.delete_user.code, 'DEPENDENCY_FAILED');
+    assert.equal(operations.delete_user.blockedBy, 'unassign_curator');
+    assert.equal(record.terminalStatus, 'completed_with_failures');
+});
+
+test('records deletion failure after successful curator removal', () => {
+    const record = recordFor([matchedRow({
+        delete: {
+            status: 'failed',
+            attempts: 2,
+            code: 'INVALID_RESPONSE',
+            message: 'Deletion was not confirmed.'
+        }
+    })]);
+
+    assert.equal(record.items[0].operations.unassign_curator.status, 'success');
+    assert.equal(record.items[0].operations.delete_user.status, 'failed');
+    assert.equal(record.summary.operations.failed, 1);
+    assert.equal(record.summary.users.failed, 1);
+});
+
+test('preserves malformed, missing, and ambiguous inputs in order', () => {
+    const record = recordFor([
+        {
+            email: 'not-an-email',
+            normalizedEmail: 'not-an-email',
+            status: 'malformed',
+            message: 'Invalid email address.',
+            unassignSelected: false,
+            deleteSelected: false
+        },
+        {
+            email: 'missing@example.com',
+            normalizedEmail: 'missing@example.com',
+            status: 'missing',
+            message: 'No marathon pupil found.',
+            unassignSelected: false,
+            deleteSelected: false
+        },
+        {
+            email: 'duplicate@example.com',
+            normalizedEmail: 'duplicate@example.com',
+            status: 'ambiguous',
+            message: 'Multiple marathon pupils found.',
+            unassignSelected: false,
+            deleteSelected: false
+        }
+    ]);
+
+    assert.deepEqual(record.items.map((item) => item.resolution), [
+        'malformed',
+        'missing',
+        'ambiguous'
+    ]);
+    assert.equal(record.summary.users.requested, 3);
+    assert.equal(record.summary.users.rejected, 3);
+});
+
+test('marks selected but unfinished operations as not attempted', () => {
+    const record = recordFor([matchedRow({
+        unassign: { status: 'success', attempts: 1 },
+        delete: null
+    })], {
+        terminalStatus: 'interrupted',
+        interruption: { code: 'WS_UNAVAILABLE', message: 'Connection lost.' }
+    });
+
+    assert.equal(record.items[0].operations.delete_user.status, 'not_attempted');
+    assert.equal(record.items[0].operations.delete_user.code, 'NOT_ATTEMPTED');
+    assert.equal(record.summary.operations.notAttempted, 1);
+    assert.equal(record.terminalStatus, 'interrupted');
+});
+
+test('does not serialize raw transport or session data', () => {
+    const record = recordFor([matchedRow({
+        rawResponse: { token: 'secret' },
+        session: { id: 'session-secret' },
+        pupil: {
+            Email: 'user@example.com',
+            PupilId: 7,
+            MarathonPupilId: 42,
+            AccessToken: 'secret',
+            UnrelatedProfile: { private: true }
+        }
+    })]);
+    const json = JSON.stringify(record);
+
+    assert.equal(json.includes('secret'), false);
+    assert.equal(json.includes('rawResponse'), false);
+    assert.equal(json.includes('session'), false);
+});
+
+test('reports persistence failure without replacing the record', async () => {
+    const record = recordFor([matchedRow()]);
+    const seen = [];
+    const error = new Error('quota exceeded');
+    const result = await persistTerminalRecord({
+        record,
+        persist: async () => { throw error; },
+        onPersistenceError: (received, receivedRecord) => {
+            seen.push(received, receivedRecord);
+        }
+    });
+
+    assert.equal(result.record, record);
+    assert.equal(result.persisted, false);
+    assert.equal(result.persistenceError, error);
+    assert.deepEqual(seen, [error, record]);
+});


### PR DESCRIPTION
Superseded by #18, which is rebuilt from the current `master` after #16/#17 introduced the shared execution-history subsystem.

The replacement PR keeps the operation-specific record work, adapts it to the final canonical envelope, and adds complete runtime persistence and history-UI integration.