### PR TITLE
Persist batch user-management execution history

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -54,6 +54,7 @@
                 "src/features/action-recorder.js",
                 "src/features/batch-lesson-access.js",
                 "src/features/batch-user-management.js",
+                "src/features/batch-user-management-history.js",
                 "src/features/batch-section-creation-recipe.js",
                 "src/features/batch-section-creation.js",
                 "src/features/batch-section-deletion.js",

--- a/src/features/batch-user-management-history.js
+++ b/src/features/batch-user-management-history.js
@@ -1,0 +1,315 @@
+(function initializeBatchUserManagementHistory(root, factory) {
+    if (typeof module === 'object' && module.exports) module.exports = factory();
+    else root.EdVibeBatchUserManagementHistory = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule() {
+    'use strict';
+
+    const OPERATION_TYPE = 'batch_user_management';
+    const OPERATION_NAMES = Object.freeze({
+        unassign: 'unassign_curator',
+        delete: 'delete_user'
+    });
+
+    function parseMarathonId(url) {
+        const match = String(url || '').match(/\/marathon\/(\d+)(?:\/|$)/);
+        return match ? String(match[1]) : null;
+    }
+
+    function selectedOperations(row) {
+        const operations = [];
+        if (row?.unassignSelected) operations.push(OPERATION_NAMES.unassign);
+        if (row?.deleteSelected) operations.push(OPERATION_NAMES.delete);
+        return operations;
+    }
+
+    function serializeIdentity(row) {
+        const pupil = row?.pupil || {};
+        return Object.freeze({
+            email: pupil.Email || row?.normalizedEmail || row?.email || null,
+            displayName: pupil.DisplayName || pupil.FullName || pupil.Name || null,
+            firstName: pupil.FirstName || null,
+            lastName: pupil.LastName || null,
+            pupilId: pupil.PupilId ?? pupil.Id ?? null,
+            marathonPupilId: row?.marathonPupilId ?? pupil.MarathonPupilId ?? null
+        });
+    }
+
+    function serializeOperation(name, result) {
+        if (!result) {
+            return Object.freeze({
+                name,
+                status: 'not_attempted',
+                attemptCount: 0,
+                code: 'NOT_ATTEMPTED',
+                message: 'The operation was not attempted.',
+                dependency: null
+            });
+        }
+        const dependencyBlocked = result.status === 'skipped'
+            && /curator removal failed/i.test(result.message || '');
+        return Object.freeze({
+            name,
+            status: result.status,
+            attemptCount: Number.isInteger(result.attempts) ? result.attempts : 0,
+            code: result.code || (dependencyBlocked ? 'DEPENDENCY_FAILED' : null),
+            message: result.message || null,
+            dependency: dependencyBlocked
+                ? Object.freeze({ blockedBy: OPERATION_NAMES.unassign })
+                : null
+        });
+    }
+
+    function inferItemStatus(row, operations) {
+        if (row?.status !== 'matched') return 'rejected';
+        if (operations.length === 0) return 'skipped';
+        const values = operations.map((operation) => operation.status);
+        if (values.includes('failed')) return 'failed';
+        if (values.includes('not_attempted')) return 'not_attempted';
+        if (values.includes('skipped')) return 'skipped';
+        if (values.every((status) => status === 'noop')) return 'noop';
+        return 'success';
+    }
+
+    function resultCode(row, status) {
+        if (status === 'rejected') {
+            return {
+                malformed: 'USER_INPUT_MALFORMED',
+                missing: 'USER_NOT_FOUND',
+                ambiguous: 'USER_AMBIGUOUS'
+            }[row?.status] || 'USER_REJECTED';
+        }
+        return {
+            success: 'USER_OPERATIONS_COMPLETED',
+            noop: 'USER_OPERATIONS_NOOP',
+            skipped: 'USER_OPERATIONS_SKIPPED',
+            failed: 'USER_OPERATIONS_FAILED',
+            not_attempted: 'USER_OPERATIONS_NOT_ATTEMPTED'
+        }[status];
+    }
+
+    function resultMessage(row, status, operations) {
+        if (status === 'rejected') return row?.message || 'The submitted user could not be resolved safely.';
+        if (operations.length === 0) return 'No user-management operation was selected.';
+        const messages = operations.map((operation) => operation.message).filter(Boolean);
+        if (messages.length > 0) return messages.join('; ');
+        return {
+            success: 'All selected operations completed successfully.',
+            noop: 'All selected operations were already satisfied.',
+            skipped: 'One or more selected operations were skipped.',
+            failed: 'One or more selected operations failed.',
+            not_attempted: 'One or more selected operations were not attempted.'
+        }[status];
+    }
+
+    function serializeRow(row, index) {
+        const names = selectedOperations(row);
+        const operations = names.map((name) => name === OPERATION_NAMES.unassign
+            ? serializeOperation(name, row?.unassign)
+            : serializeOperation(name, row?.delete));
+        const status = inferItemStatus(row, operations);
+        return Object.freeze({
+            itemId: row?.normalizedEmail || row?.email || `input-${index + 1}`,
+            label: row?.email || row?.normalizedEmail || `Input ${index + 1}`,
+            status,
+            code: resultCode(row, status),
+            message: resultMessage(row, status, operations),
+            attempts: operations.reduce((sum, operation) => sum + operation.attemptCount, 0),
+            data: Object.freeze({
+                submittedInput: row?.email || null,
+                normalizedEmail: row?.normalizedEmail || null,
+                resolution: row?.status || 'malformed',
+                resolutionMessage: row?.message || null,
+                user: row?.status === 'matched' ? serializeIdentity(row) : null,
+                curatorPresent: row?.status === 'matched' ? Boolean(row?.hasCurator) : null,
+                selectedOperations: Object.freeze(names),
+                operations: Object.freeze(operations)
+            })
+        });
+    }
+
+    function buildCounts(results) {
+        const eligible = results.filter((result) => result.data.resolution === 'matched'
+            && result.data.selectedOperations.length > 0).length;
+        const notAttempted = results.filter((result) => result.status === 'not_attempted').length;
+        const attempted = results.filter((result) => result.data.resolution === 'matched'
+            && result.data.selectedOperations.length > 0
+            && result.status !== 'not_attempted').length;
+        return Object.freeze({
+            requested: results.length,
+            eligible,
+            attempted,
+            successful: results.filter((result) => result.status === 'success').length,
+            noOp: results.filter((result) => result.status === 'noop').length,
+            skipped: results.filter((result) => result.status === 'skipped' || result.status === 'rejected').length,
+            failed: results.filter((result) => result.status === 'failed').length,
+            notAttempted
+        });
+    }
+
+    function inferTerminalStatus(summary, results) {
+        if (summary?.error) return 'interrupted';
+        return results.some((result) => result.status === 'failed'
+            || result.status === 'skipped'
+            || result.status === 'rejected')
+            ? 'completed_with_failures'
+            : 'completed';
+    }
+
+    function buildExecutionHistoryInput({
+        rows,
+        summary = {},
+        startedAt,
+        completedAt,
+        marathonId,
+        marathonName = null
+    }) {
+        const results = (Array.isArray(rows) ? rows : []).map(serializeRow);
+        const operationCounts = {
+            selected: 0,
+            attempted: 0,
+            successful: 0,
+            noOp: 0,
+            skipped: 0,
+            failed: 0,
+            notAttempted: 0
+        };
+        for (const result of results) {
+            for (const operation of result.data.operations) {
+                operationCounts.selected += 1;
+                if (operation.status !== 'not_attempted') operationCounts.attempted += 1;
+                if (operation.status === 'success') operationCounts.successful += 1;
+                if (operation.status === 'noop') operationCounts.noOp += 1;
+                if (operation.status === 'skipped') operationCounts.skipped += 1;
+                if (operation.status === 'failed') operationCounts.failed += 1;
+                if (operation.status === 'not_attempted') operationCounts.notAttempted += 1;
+            }
+        }
+        return Object.freeze({
+            operationType: OPERATION_TYPE,
+            startedAt,
+            completedAt,
+            status: inferTerminalStatus(summary, results),
+            pageContext: Object.freeze({ marathonId, marathonName }),
+            counts: buildCounts(results),
+            results: Object.freeze(results),
+            message: JSON.stringify({
+                userCounts: buildCounts(results),
+                operationCounts
+            })
+        });
+    }
+
+    function createHistoryAwareDialog({
+        createDialog,
+        persistExecution,
+        openHistory = () => {},
+        getLocationHref = () => '',
+        getMarathonName = () => null,
+        now = () => new Date(),
+        log = () => {}
+    }) {
+        if (typeof createDialog !== 'function') throw new TypeError('createDialog is required');
+        if (typeof persistExecution !== 'function') throw new TypeError('persistExecution is required');
+        return function createPatchedDialog() {
+            const dialog = createDialog();
+            let startedAt = null;
+            let stylesheetUrl = '';
+            let persistenceSequence = 0;
+            const originalConfigure = dialog.configure.bind(dialog);
+            const originalShowComplete = dialog.showComplete.bind(dialog);
+            const originalShowReview = dialog.showReview.bind(dialog);
+            const originalShowConfigure = dialog.showConfigure.bind(dialog);
+
+            function clearHistoryButton() {
+                dialog.shadowRoot?.querySelector?.('.edvibe-batch-user-management-history')?.remove?.();
+            }
+
+            function appendStatus(message) {
+                const current = dialog.elements?.status?.textContent || '';
+                dialog.setStatus?.(`${current}${current ? ' ' : ''}${message}`);
+            }
+
+            function addHistoryButton(executionId) {
+                clearHistoryButton();
+                const document = dialog.ownerDocument || root.document;
+                const button = document?.createElement?.('button');
+                if (!button) return;
+                button.type = 'button';
+                button.className = 'edvibe-batch-user-management-history';
+                button.textContent = 'Открыть в истории';
+                button.addEventListener('click', () => {
+                    dialog.close?.();
+                    openHistory(executionId, stylesheetUrl);
+                });
+                dialog.elements?.footer?.appendChild?.(button);
+                if (!dialog.elements?.footer) {
+                    dialog.shadowRoot?.querySelector?.('.edvibe-batch-user-management-footer')?.appendChild?.(button);
+                }
+            }
+
+            dialog.configure = (options = {}) => {
+                stylesheetUrl = String(options?.stylesheetUrl || stylesheetUrl || '');
+                return originalConfigure(options);
+            };
+            dialog.showReview = (value) => {
+                startedAt = null;
+                persistenceSequence += 1;
+                clearHistoryButton();
+                return originalShowReview(value);
+            };
+            dialog.showConfigure = (...args) => {
+                startedAt = null;
+                persistenceSequence += 1;
+                clearHistoryButton();
+                return originalShowConfigure(...args);
+            };
+            dialog.addEventListener('edvibe-batch-user-management-start', () => {
+                startedAt = now().toISOString();
+                persistenceSequence += 1;
+                clearHistoryButton();
+            });
+            dialog.showComplete = (summary = {}) => {
+                const output = originalShowComplete(summary);
+                const sequence = persistenceSequence;
+                const completedAt = now().toISOString();
+                const input = buildExecutionHistoryInput({
+                    rows: summary.rows || dialog.rows,
+                    summary,
+                    startedAt: startedAt || completedAt,
+                    completedAt,
+                    marathonId: parseMarathonId(getLocationHref()),
+                    marathonName: getMarathonName()
+                });
+                Promise.resolve()
+                    .then(() => persistExecution(input))
+                    .then((history) => {
+                        if (sequence !== persistenceSequence) return;
+                        if (history?.stored) {
+                            appendStatus('Результат сохранён в истории.');
+                            if (history.record?.id) addHistoryButton(history.record.id);
+                        } else {
+                            appendStatus('Экранный результат сохранён, но записать историю не удалось.');
+                            if (history?.persistenceError) log('Batch user management history persistence failed:', history.persistenceError);
+                        }
+                    })
+                    .catch((error) => {
+                        if (sequence !== persistenceSequence) return;
+                        appendStatus('Экранный результат сохранён, но записать историю не удалось.');
+                        log('Batch user management history persistence failed:', error);
+                    });
+                return output;
+            };
+            return dialog;
+        };
+    }
+
+    return Object.freeze({
+        OPERATION_TYPE,
+        OPERATION_NAMES,
+        parseMarathonId,
+        serializeRow,
+        buildCounts,
+        buildExecutionHistoryInput,
+        createHistoryAwareDialog
+    });
+});

--- a/src/features/batch-user-management-history.test.js
+++ b/src/features/batch-user-management-history.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const history = require('./batch-user-management-history.js');
+const recordApi = require('../shared/execution-history-record.js');
+
+function matchedRow(overrides = {}) {
+    return {
+        email: 'User@Example.com',
+        normalizedEmail: 'user@example.com',
+        status: 'matched',
+        message: '',
+        actionable: true,
+        hasCurator: true,
+        marathonPupilId: 42,
+        pupil: {
+            Email: 'user@example.com',
+            Name: 'Example User',
+            PupilId: 7,
+            MarathonPupilId: 42,
+            Moderators: [{ Id: 3 }]
+        },
+        unassignSelected: true,
+        deleteSelected: true,
+        unassign: { status: 'success', attempts: 1 },
+        delete: { status: 'success', attempts: 2 },
+        result: { status: 'success', message: 'Curator removed; User deleted' },
+        ...overrides
+    };
+}
+
+test('builds a canonical record accepted by the shared history envelope', () => {
+    const input = history.buildExecutionHistoryInput({
+        rows: [matchedRow()],
+        summary: { failures: 0 },
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:03.000Z',
+        marathonId: '123',
+        marathonName: 'Demo marathon'
+    });
+    const record = recordApi.buildExecutionRecord(input, {
+        cryptoApi: { randomUUID: () => 'execution-id' },
+        now: new Date('2026-08-06T05:00:03.000Z')
+    });
+    assert.equal(record.id, 'execution-id');
+    assert.equal(record.operationType, history.OPERATION_TYPE);
+    assert.equal(record.status, 'completed');
+    assert.equal(record.results[0].data.operations[0].name, 'unassign_curator');
+    assert.equal(record.results[0].data.operations[1].attemptCount, 2);
+});
+
+test('preserves malformed, missing, and ambiguous inputs in order', () => {
+    const rows = [
+        { email: 'bad', normalizedEmail: 'bad', status: 'malformed', message: 'Invalid email.' },
+        { email: 'none@example.com', normalizedEmail: 'none@example.com', status: 'missing', message: 'Not found.' },
+        { email: 'many@example.com', normalizedEmail: 'many@example.com', status: 'ambiguous', message: 'Multiple users.' }
+    ];
+    const input = history.buildExecutionHistoryInput({
+        rows,
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:01.000Z',
+        marathonId: '123'
+    });
+    assert.deepEqual(input.results.map((result) => result.data.resolution), [
+        'malformed', 'missing', 'ambiguous'
+    ]);
+    assert.deepEqual(input.results.map((result) => result.code), [
+        'USER_INPUT_MALFORMED', 'USER_NOT_FOUND', 'USER_AMBIGUOUS'
+    ]);
+    assert.equal(input.counts.requested, 3);
+    assert.equal(input.counts.skipped, 3);
+});
+
+test('records noop curator removal independently', () => {
+    const input = history.buildExecutionHistoryInput({
+        rows: [matchedRow({
+            hasCurator: false,
+            deleteSelected: false,
+            unassign: { status: 'noop', attempts: 0, message: 'No curator was assigned.' },
+            delete: null
+        })],
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:01.000Z',
+        marathonId: '123'
+    });
+    assert.equal(input.results[0].status, 'noop');
+    assert.equal(input.results[0].data.operations[0].status, 'noop');
+    assert.equal(input.counts.noOp, 1);
+});
+
+test('distinguishes dependency-blocked deletion from deletion failure', () => {
+    const input = history.buildExecutionHistoryInput({
+        rows: [matchedRow({
+            unassign: { status: 'failed', attempts: 3, code: 'REQUEST_TIMEOUT', message: 'Timed out.' },
+            delete: { status: 'skipped', attempts: 0, message: 'Skipped because curator removal failed.' }
+        })],
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:05.000Z',
+        marathonId: '123'
+    });
+    const operations = input.results[0].data.operations;
+    assert.equal(operations[0].status, 'failed');
+    assert.equal(operations[0].attemptCount, 3);
+    assert.equal(operations[1].status, 'skipped');
+    assert.equal(operations[1].code, 'DEPENDENCY_FAILED');
+    assert.equal(operations[1].dependency.blockedBy, 'unassign_curator');
+    assert.equal(input.status, 'completed_with_failures');
+});
+
+test('marks unfinished selected operations not attempted after interruption', () => {
+    const input = history.buildExecutionHistoryInput({
+        rows: [matchedRow({ unassign: null, delete: null })],
+        summary: { error: Object.assign(new Error('Stopped'), { code: 'WS_UNAVAILABLE' }) },
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:02.000Z',
+        marathonId: '123'
+    });
+    assert.equal(input.status, 'interrupted');
+    assert.equal(input.results[0].status, 'not_attempted');
+    assert.equal(input.results[0].data.operations[0].status, 'not_attempted');
+    assert.equal(input.results[0].data.operations[1].status, 'not_attempted');
+    assert.equal(input.counts.notAttempted, 1);
+});
+
+test('serializes only audit fields and excludes raw pupil transport data', () => {
+    const input = history.buildExecutionHistoryInput({
+        rows: [matchedRow({
+            pupil: {
+                Email: 'user@example.com',
+                Name: 'Example User',
+                PupilId: 7,
+                MarathonPupilId: 42,
+                Moderators: [{ Id: 3 }],
+                Response: { Secret: true },
+                SessionId: 'secret'
+            }
+        })],
+        startedAt: '2026-08-06T05:00:00.000Z',
+        completedAt: '2026-08-06T05:00:01.000Z',
+        marathonId: '123'
+    });
+    const serialized = JSON.stringify(input);
+    assert.equal(serialized.includes('Secret'), false);
+    assert.equal(serialized.includes('SessionId'), false);
+    assert.equal(serialized.includes('Moderators'), false);
+    assert.equal(input.results[0].data.user.pupilId, 7);
+});
+
+test('history-aware dialog preserves visible completion when persistence rejects', async () => {
+    const events = new Map();
+    const status = { textContent: '' };
+    const dialog = {
+        rows: [matchedRow()],
+        elements: { status },
+        shadowRoot: { querySelector: () => null },
+        ownerDocument: { createElement: () => null },
+        configure() { return this; },
+        showReview() { return this; },
+        showConfigure() { return this; },
+        showComplete() { status.textContent = 'Готово.'; return this; },
+        setStatus(value) { status.textContent = value; },
+        addEventListener(name, listener) { events.set(name, listener); }
+    };
+    const logs = [];
+    const createDialog = history.createHistoryAwareDialog({
+        createDialog: () => dialog,
+        persistExecution: async () => { throw new Error('database unavailable'); },
+        getLocationHref: () => 'https://app.edvibe.com/marathon/123',
+        now: () => new Date('2026-08-06T05:00:00.000Z'),
+        log: (...args) => logs.push(args)
+    });
+    const patched = createDialog();
+    events.get('edvibe-batch-user-management-start')();
+    patched.showComplete({ rows: dialog.rows, failures: 0 });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.match(status.textContent, /Готово\./);
+    assert.match(status.textContent, /записать историю не удалось/);
+    assert.equal(logs.length, 1);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ const recorderDialogApi = requireToolboxModule('EdVibeActionRecorderDialog');
 const batchAccessApi = requireToolboxModule('EdVibeBatchLessonAccess');
 const batchAccessDialogApi = requireToolboxModule('EdVibeBatchAccessDialogComponent');
 const batchUserManagementApi = requireToolboxModule('EdVibeBatchUserManagement');
+const batchUserManagementHistoryApi = requireToolboxModule('EdVibeBatchUserManagementHistory');
 const batchUserManagementDialogApi = requireToolboxModule('EdVibeBatchUserManagementDialog');
 const batchSectionCreationApi = requireToolboxModule('EdVibeBatchSectionCreation');
 const batchSectionCreationDialogApi = requireToolboxModule('EdVibeBatchSectionCreationDialog');
@@ -114,13 +115,24 @@ const batchLessonAccessFeature = batchAccessApi.createBatchLessonAccessFeature({
     log: createMainLog('BatchAccess')
 });
 
+const createBatchUserManagementDialog = batchUserManagementHistoryApi.createHistoryAwareDialog({
+    createDialog: () => document.createElement(batchUserManagementDialogApi.USER_MANAGEMENT_DIALOG_TAG),
+    persistExecution: historyService.persistTerminal,
+    openHistory: (executionId, sourceStylesheetUrl) => executionHistoryFeature.open({
+        stylesheetUrl: new URL('execution-history-dialog.css', sourceStylesheetUrl).href,
+        executionId
+    }),
+    getLocationHref: () => window.location.href,
+    getMarathonName: () => document.querySelector('h1')?.textContent?.trim() || document.title || null,
+    log: createMainLog('BatchUserManagementHistory')
+});
 const batchUserManagementFeature = batchUserManagementApi.createBatchUserManagementFeature({
     sendRequest: transport.sendRequest,
     getConnectionState: transport.getConnectionState,
     wait,
     canStart: operationGuard.canStart,
     onActiveChange: guardedActiveChange('batch-user-management'),
-    createDialog: () => document.createElement(batchUserManagementDialogApi.USER_MANAGEMENT_DIALOG_TAG),
+    createDialog: createBatchUserManagementDialog,
     log: createMainLog('BatchUserManagement')
 });
 


### PR DESCRIPTION
Closes #4

## Summary

- integrate batch user management with the shared execution-history service introduced by #16
- preserve every ordered submitted input, including malformed, missing, and ambiguous users
- record curator removal and user deletion as independent auditable operation outcomes
- distinguish dependency-blocked deletion from an attempted deletion failure
- retain retry attempt counts, stable codes, resolved audit identity, curator preflight state, and selected operations
- mark unfinished selected work as `not_attempted` when execution is interrupted
- maintain canonical user-level counts while preserving independently derivable operation-level counts
- keep the visible completion result intact when persistence fails and surface that failure separately
- add an “Open in history” action after successful persistence

## Architecture

The integration is implemented as a focused lifecycle adapter around the existing batch-user-management dialog. The execution engine remains unaware of IndexedDB, retention, filtering, and JSON download details. Canonical inputs are passed only through `historyService.persistTerminal()`.

## Safety

Only explicitly whitelisted audit identity and operation fields are serialized. Raw pupil payloads, transport responses, session data, moderator collections, and unrelated user fields are excluded.

## Validation

- `npm run test:ci`
- GitHub Actions CI run #11 passed
- focused coverage includes canonical-envelope compatibility, ordered validation failures, success/no-op/failure paths, dependency blocking, retries, interruption, serialization safety, and persistence-failure handling

Supersedes #15.