### PR TITLE
Support native banner uploads in batch section creation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,31 +3,51 @@
     "name": "Edvibe Toolbox",
     "version": "1.0",
     "description": "A universal toolkit for automation and backup on the Edvibe platform.",
-    "permissions": ["storage", "activeTab", "scripting"],
-    "host_permissions": ["*://*.edvibe.com/*"],
-    "action": { "default_popup": "popup.html" },
-    "web_accessible_resources": [{
-        "resources": [
-            "src/components/reset-lessons-dialog.css",
-            "src/components/action-recorder-dialog.css",
-            "src/components/export-progress-dialog.css",
-            "src/components/batch-lesson-access-dialog.css",
-            "src/components/batch-user-management-dialog.css",
-            "src/components/batch-section-creation-dialog.css",
-            "src/components/batch-section-deletion-dialog.css",
-            "src/components/execution-history-dialog.css"
-        ],
-        "matches": ["*://*.edvibe.com/*"]
-    }],
+    "permissions": [
+        "storage",
+        "activeTab",
+        "scripting"
+    ],
+    "host_permissions": [
+        "*://*.edvibe.com/*"
+    ],
+    "action": {
+        "default_popup": "popup.html"
+    },
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "src/components/reset-lessons-dialog.css",
+                "src/components/action-recorder-dialog.css",
+                "src/components/export-progress-dialog.css",
+                "src/components/batch-lesson-access-dialog.css",
+                "src/components/batch-user-management-dialog.css",
+                "src/components/batch-section-creation-dialog.css",
+                "src/components/batch-section-image-upload.css",
+                "src/components/batch-section-deletion-dialog.css",
+                "src/components/execution-history-dialog.css"
+            ],
+            "matches": [
+                "*://*.edvibe.com/*"
+            ]
+        }
+    ],
     "content_scripts": [
         {
-            "matches": ["*://*.edvibe.com/*"],
-            "js": ["src/shared//logger.js", "src/isolated.js"],
+            "matches": [
+                "*://*.edvibe.com/*"
+            ],
+            "js": [
+                "src/shared//logger.js",
+                "src/isolated.js"
+            ],
             "run_at": "document_start",
             "world": "ISOLATED"
         },
         {
-            "matches": ["*://*.edvibe.com/*"],
+            "matches": [
+                "*://*.edvibe.com/*"
+            ],
             "js": [
                 "lib/jszip.min.js",
                 "lib/turndown.min.js",
@@ -47,6 +67,7 @@
                 "src/components/batch-lesson-access-dialog.js",
                 "src/components/batch-user-management-dialog.js",
                 "src/components/batch-section-creation-dialog.js",
+                "src/components/batch-section-image-upload.js",
                 "src/components/batch-section-deletion-dialog.js",
                 "src/components/execution-history-dialog.js",
                 "src/features/reset-lessons.js",
@@ -60,6 +81,7 @@
                 "src/features/batch-user-management-history.js",
                 "src/features/batch-section-creation-recipe.js",
                 "src/features/batch-section-creation.js",
+                "src/features/batch-section-image-upload.js",
                 "src/features/batch-section-deletion.js",
                 "src/features/execution-history.js",
                 "src/main.js"

--- a/manifest.json
+++ b/manifest.json
@@ -3,51 +3,32 @@
     "name": "Edvibe Toolbox",
     "version": "1.0",
     "description": "A universal toolkit for automation and backup on the Edvibe platform.",
-    "permissions": [
-        "storage",
-        "activeTab",
-        "scripting"
-    ],
-    "host_permissions": [
-        "*://*.edvibe.com/*"
-    ],
-    "action": {
-        "default_popup": "popup.html"
-    },
-    "web_accessible_resources": [
-        {
-            "resources": [
-                "src/components/reset-lessons-dialog.css",
-                "src/components/action-recorder-dialog.css",
-                "src/components/export-progress-dialog.css",
-                "src/components/batch-lesson-access-dialog.css",
-                "src/components/batch-user-management-dialog.css",
-                "src/components/batch-section-creation-dialog.css",
-                "src/components/batch-section-image-upload.css",
-                "src/components/batch-section-deletion-dialog.css",
-                "src/components/execution-history-dialog.css"
-            ],
-            "matches": [
-                "*://*.edvibe.com/*"
-            ]
-        }
-    ],
+    "permissions": ["storage", "activeTab", "scripting"],
+    "host_permissions": ["*://*.edvibe.com/*"],
+    "action": { "default_popup": "popup.html" },
+    "web_accessible_resources": [{
+        "resources": [
+            "src/components/reset-lessons-dialog.css",
+            "src/components/action-recorder-dialog.css",
+            "src/components/export-progress-dialog.css",
+            "src/components/batch-lesson-access-dialog.css",
+            "src/components/batch-user-management-dialog.css",
+            "src/components/batch-section-creation-dialog.css",
+            "src/components/batch-section-image-upload.css",
+            "src/components/batch-section-deletion-dialog.css",
+            "src/components/execution-history-dialog.css"
+        ],
+        "matches": ["*://*.edvibe.com/*"]
+    }],
     "content_scripts": [
         {
-            "matches": [
-                "*://*.edvibe.com/*"
-            ],
-            "js": [
-                "src/shared//logger.js",
-                "src/isolated.js"
-            ],
+            "matches": ["*://*.edvibe.com/*"],
+            "js": ["src/shared//logger.js", "src/isolated.js"],
             "run_at": "document_start",
             "world": "ISOLATED"
         },
         {
-            "matches": [
-                "*://*.edvibe.com/*"
-            ],
+            "matches": ["*://*.edvibe.com/*"],
             "js": [
                 "lib/jszip.min.js",
                 "lib/turndown.min.js",

--- a/src/components/batch-section-image-upload.css
+++ b/src/components/batch-section-image-upload.css
@@ -1,0 +1,43 @@
+.edvibe-batch-section-file-input {
+    cursor: pointer;
+}
+
+.edvibe-batch-section-file-details {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 8px;
+    color: #64748b;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.edvibe-batch-section-file-details button {
+    flex: 0 0 auto;
+    padding: 6px 9px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+    color: #334155;
+    font: 650 12px/1.2 "Segoe UI", Arial, sans-serif;
+    cursor: pointer;
+}
+
+.edvibe-batch-section-file-error {
+    margin: 8px 0 0;
+    color: #b91c1c;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.edvibe-batch-section-image-preview {
+    display: block;
+    width: 100%;
+    max-height: 240px;
+    margin-top: 10px;
+    object-fit: contain;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    background: #f8fafc;
+}

--- a/src/components/batch-section-image-upload.js
+++ b/src/components/batch-section-image-upload.js
@@ -1,0 +1,324 @@
+(function initializeBatchSectionImageUploadComponent(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], () => factory(root));
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(null);
+    } else {
+        root.EdVibeBatchSectionImageUploadComponent = factory(root);
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(root) {
+    'use strict';
+
+    const IMAGE_PLACEHOLDER_PREFIX = 'https://media-files-y.edvibe.com/local-upload/';
+    const ENHANCED_MARKER = Symbol('edvibeBatchSectionImageUploadEnhanced');
+
+    function createClientId(cryptoApi = globalThis.crypto) {
+        return cryptoApi?.randomUUID?.()
+            || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
+
+    function createPlaceholderUrl(clientId) {
+        return `${IMAGE_PLACEHOLDER_PREFIX}${encodeURIComponent(String(clientId || ''))}`;
+    }
+
+    function parseClientId(value) {
+        const text = String(value || '');
+        if (!text.startsWith(IMAGE_PLACEHOLDER_PREFIX)) {
+            return '';
+        }
+        try {
+            return decodeURIComponent(text.slice(IMAGE_PLACEHOLDER_PREFIX.length));
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function formatFileSize(value) {
+        const bytes = Math.max(0, Number(value) || 0);
+        if (bytes < 1024) {
+            return `${bytes} Б`;
+        }
+        if (bytes < 1024 * 1024) {
+            return `${(bytes / 1024).toFixed(1)} КБ`;
+        }
+        return `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+    }
+
+    function createRegistry() {
+        const files = new Map();
+        return Object.freeze({
+            register(clientId, file) {
+                if (clientId && file) {
+                    files.set(String(clientId), file);
+                }
+            },
+            get(clientId) {
+                return files.get(String(clientId || '')) || null;
+            },
+            remove(clientId) {
+                files.delete(String(clientId || ''));
+            },
+            clear() {
+                files.clear();
+            },
+            size() {
+                return files.size;
+            }
+        });
+    }
+
+    function enhanceImageBlock(block, cryptoApi = globalThis.crypto) {
+        const clientId = createClientId(cryptoApi);
+        return {
+            ...block,
+            clientId,
+            url: createPlaceholderUrl(clientId),
+            alt: String(block?.alt || ''),
+            fileName: '',
+            fileSize: 0,
+            fileType: '',
+            previewUrl: '',
+            fileError: ''
+        };
+    }
+
+    function resolveEnhancementStylesheet(stylesheetUrl) {
+        try {
+            return new URL('./batch-section-image-upload.css', stylesheetUrl).href;
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function enhanceDialog({ rootObject, dialogApi, registry }) {
+        const Dialog = dialogApi?.BatchSectionCreationDialog;
+        if (!Dialog?.prototype || Dialog.prototype[ENHANCED_MARKER]) {
+            return false;
+        }
+
+        const prototype = Dialog.prototype;
+        Object.defineProperty(prototype, ENHANCED_MARKER, { value: true });
+
+        const originalConfigure = prototype.configure;
+        const originalCreateBlock = prototype.createBlock;
+        const originalRenderBlocks = prototype.renderBlocks;
+        const originalRenderPreview = prototype.renderPreview;
+        const originalOnInput = prototype.onInput;
+        const originalOnBlockClick = prototype.onBlockClick;
+        const originalOnRestart = prototype.onRestart;
+        const originalClose = prototype.close;
+        const originalRenderState = prototype.renderState;
+
+        function releaseBlock(block) {
+            if (!block || block.type !== 'image') {
+                return;
+            }
+            registry.remove(block.clientId || parseClientId(block.url));
+            if (block.previewUrl) {
+                rootObject.URL?.revokeObjectURL?.(block.previewUrl);
+            }
+            block.fileName = '';
+            block.fileSize = 0;
+            block.fileType = '';
+            block.previewUrl = '';
+            block.fileError = '';
+        }
+
+        function releaseAll(dialog) {
+            for (const block of dialog.blocks || []) {
+                releaseBlock(block);
+            }
+        }
+
+        prototype.configure = function configure(options = {}) {
+            const result = originalConfigure.call(this, options);
+            const href = resolveEnhancementStylesheet(options.stylesheetUrl || this.stylesheetUrl);
+            if (href && this.shadowRoot && !this.shadowRoot.querySelector('.edvibe-batch-section-image-upload-stylesheet')) {
+                const link = (this.ownerDocument || rootObject.document).createElement('link');
+                link.className = 'edvibe-batch-section-image-upload-stylesheet';
+                link.rel = 'stylesheet';
+                link.href = href;
+                this.shadowRoot.prepend(link);
+            }
+            return result;
+        };
+
+        prototype.createBlock = function createBlock(type) {
+            const block = originalCreateBlock.call(this, type);
+            return type === 'image'
+                ? enhanceImageBlock(block, rootObject.crypto)
+                : block;
+        };
+
+        prototype.renderBlocks = function renderBlocks() {
+            originalRenderBlocks.call(this);
+            const document = this.ownerDocument || rootObject.document;
+
+            for (const block of this.blocks || []) {
+                if (block.type !== 'image') {
+                    continue;
+                }
+                const article = this.elements.blocks.querySelector(`[data-block-id="${block.id}"]`);
+                const urlInput = article?.querySelector('[data-block-field="url"]');
+                const field = urlInput?.closest?.('label');
+                if (!article || !field) {
+                    continue;
+                }
+
+                const title = document.createElement('span');
+                title.textContent = 'Файл изображения';
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = 'image/*';
+                input.dataset.blockField = 'file';
+                input.className = 'edvibe-batch-section-file-input';
+                field.replaceChildren(title, input);
+
+                const details = document.createElement('div');
+                details.className = 'edvibe-batch-section-file-details';
+                const text = document.createElement('span');
+                text.textContent = block.fileName
+                    ? `${block.fileName} · ${formatFileSize(block.fileSize)}`
+                    : 'Файл ещё не выбран';
+                details.appendChild(text);
+
+                if (block.fileName) {
+                    const clear = document.createElement('button');
+                    clear.type = 'button';
+                    clear.dataset.blockAction = 'clear-file';
+                    clear.textContent = 'Убрать файл';
+                    details.appendChild(clear);
+                }
+                field.after(details);
+
+                if (block.fileError) {
+                    const error = document.createElement('p');
+                    error.className = 'edvibe-batch-section-file-error';
+                    error.textContent = block.fileError;
+                    details.after(error);
+                }
+
+                if (block.previewUrl) {
+                    const preview = document.createElement('img');
+                    preview.className = 'edvibe-batch-section-image-preview';
+                    preview.src = block.previewUrl;
+                    preview.alt = block.alt || block.fileName || 'Предпросмотр баннера';
+                    (article.querySelector('.edvibe-batch-section-file-error') || details).after(preview);
+                }
+            }
+        };
+
+        prototype.renderPreview = function renderPreview() {
+            originalRenderPreview.call(this);
+            const items = this.elements.previewBlocks.querySelectorAll('li');
+            (this.blocks || []).forEach((block, index) => {
+                if (block.type === 'image' && items[index]) {
+                    items[index].textContent = `${index + 1}. Баннер: ${block.fileName || 'файл не выбран'}`;
+                }
+            });
+        };
+
+        prototype.onInput = function onInput(event) {
+            const field = event.target?.dataset?.blockField;
+            if (field !== 'file') {
+                originalOnInput.call(this, event);
+                if (field === 'alt') {
+                    const article = event.target.closest?.('[data-block-id]');
+                    const preview = article?.querySelector?.('.edvibe-batch-section-image-preview');
+                    if (preview) {
+                        preview.alt = event.target.value || 'Предпросмотр баннера';
+                    }
+                }
+                return;
+            }
+
+            const article = event.target.closest?.('[data-block-id]');
+            const block = this.blocks.find((entry) => entry.id === article?.dataset?.blockId);
+            if (!block) {
+                return;
+            }
+
+            releaseBlock(block);
+            const file = event.target.files?.[0] || null;
+            if (file && !String(file.type || '').startsWith('image/')) {
+                block.fileError = 'Выберите файл изображения.';
+                event.target.value = '';
+            } else if (file) {
+                block.fileName = file.name;
+                block.fileSize = file.size;
+                block.fileType = file.type;
+                block.previewUrl = rootObject.URL?.createObjectURL?.(file) || '';
+                registry.register(block.clientId, file);
+            }
+
+            this.renderBlocks();
+            this.renderPreview();
+            this.renderState();
+        };
+
+        prototype.onBlockClick = function onBlockClick(event) {
+            const action = event.target?.dataset?.blockAction;
+            const article = event.target?.closest?.('[data-block-id]');
+            const block = this.blocks.find((entry) => entry.id === article?.dataset?.blockId);
+
+            if (action === 'clear-file' && block?.type === 'image') {
+                releaseBlock(block);
+                this.renderBlocks();
+                this.renderPreview();
+                this.renderState();
+                return;
+            }
+            if (action === 'remove' && block?.type === 'image') {
+                releaseBlock(block);
+            }
+            originalOnBlockClick.call(this, event);
+        };
+
+        prototype.onRestart = function onRestart() {
+            releaseAll(this);
+            originalOnRestart.call(this);
+        };
+
+        prototype.close = function close() {
+            releaseAll(this);
+            originalClose.call(this);
+        };
+
+        prototype.renderState = function renderState() {
+            originalRenderState.call(this);
+            const configurable = ['configure', 'validation-error'].includes(this.mode);
+            const missingImage = (this.blocks || []).some((block) =>
+                block.type === 'image' && !registry.get(block.clientId || parseClientId(block.url))
+            );
+            if (configurable && missingImage) {
+                this.elements.preflight.disabled = true;
+            }
+        };
+
+        return true;
+    }
+
+    let registry = null;
+    if (root?.document && root.EdVibeBatchSectionCreationDialog) {
+        registry = createRegistry();
+        root.EdVibeBatchSectionImageRegistry = registry;
+        enhanceDialog({
+            rootObject: root,
+            dialogApi: root.EdVibeBatchSectionCreationDialog,
+            registry
+        });
+    }
+
+    return {
+        IMAGE_PLACEHOLDER_PREFIX,
+        createClientId,
+        createPlaceholderUrl,
+        parseClientId,
+        formatFileSize,
+        createRegistry,
+        enhanceImageBlock,
+        resolveEnhancementStylesheet,
+        enhanceDialog,
+        registry
+    };
+});

--- a/src/components/batch-section-image-upload.test.js
+++ b/src/components/batch-section-image-upload.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    createPlaceholderUrl,
+    parseClientId,
+    formatFileSize,
+    createRegistry,
+    enhanceImageBlock,
+    resolveEnhancementStylesheet
+} = require('./batch-section-image-upload.js');
+
+test('image blocks receive stable upload placeholders without storing the file in the URL', () => {
+    const block = enhanceImageBlock(
+        { id: 'block-1', type: 'image', url: '', alt: '' },
+        { randomUUID: () => 'client-image-1' }
+    );
+
+    assert.equal(block.clientId, 'client-image-1');
+    assert.equal(block.url, createPlaceholderUrl('client-image-1'));
+    assert.equal(parseClientId(block.url), 'client-image-1');
+    assert.equal(block.fileName, '');
+});
+
+test('image registry keeps selected files only in memory', () => {
+    const registry = createRegistry();
+    const file = { name: 'banner.png', type: 'image/png', size: 2048 };
+
+    registry.register('client-image-1', file);
+    assert.equal(registry.get('client-image-1'), file);
+    assert.equal(registry.size(), 1);
+
+    registry.remove('client-image-1');
+    assert.equal(registry.get('client-image-1'), null);
+    assert.equal(registry.size(), 0);
+});
+
+test('file metadata and enhancement stylesheet are formatted for the dialog', () => {
+    assert.equal(formatFileSize(512), '512 Б');
+    assert.equal(formatFileSize(2048), '2.0 КБ');
+    assert.equal(formatFileSize(2 * 1024 * 1024), '2.0 МБ');
+    assert.equal(
+        resolveEnhancementStylesheet('chrome-extension://toolbox/src/components/batch-section-creation-dialog.css'),
+        'chrome-extension://toolbox/src/components/batch-section-image-upload.css'
+    );
+});

--- a/src/features/batch-section-image-upload.integration.test.js
+++ b/src/features/batch-section-image-upload.integration.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '../..');
+
+test('manifest loads the image picker and upload enhancer before main', () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+    const mainWorld = manifest.content_scripts.find((entry) => entry.world === 'MAIN');
+    const scripts = mainWorld.js;
+
+    const dialogIndex = scripts.indexOf('src/components/batch-section-creation-dialog.js');
+    const pickerIndex = scripts.indexOf('src/components/batch-section-image-upload.js');
+    const featureIndex = scripts.indexOf('src/features/batch-section-creation.js');
+    const uploadIndex = scripts.indexOf('src/features/batch-section-image-upload.js');
+    const mainIndex = scripts.indexOf('src/main.js');
+
+    assert.ok(dialogIndex >= 0 && pickerIndex > dialogIndex);
+    assert.ok(featureIndex >= 0 && uploadIndex > featureIndex);
+    assert.ok(mainIndex > uploadIndex);
+
+    const resources = manifest.web_accessible_resources.flatMap((entry) => entry.resources || []);
+    assert.ok(resources.includes('src/components/batch-section-image-upload.css'));
+});

--- a/src/features/batch-section-image-upload.js
+++ b/src/features/batch-section-image-upload.js
@@ -1,0 +1,357 @@
+(function initializeBatchSectionImageUpload(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], () => factory(root));
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(null);
+    } else {
+        root.EdVibeBatchSectionImageUpload = factory(root);
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(root) {
+    'use strict';
+
+    const UPLOAD_ENDPOINT = 'https://media-files-y.edvibe.com/api/MediaFile/create-multiple';
+    const IMAGE_PLACEHOLDER_PREFIX = 'https://media-files-y.edvibe.com/local-upload/';
+
+    function createUploadError(code, message, details = {}) {
+        const error = new Error(message);
+        error.code = code;
+        Object.assign(error, details);
+        return error;
+    }
+
+    function parseClientId(value) {
+        const text = String(value || '');
+        if (!text.startsWith(IMAGE_PLACEHOLDER_PREFIX)) {
+            return '';
+        }
+        try {
+            return decodeURIComponent(text.slice(IMAGE_PLACEHOLDER_PREFIX.length));
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function normalizeRequestUrl(input, baseUrl) {
+        const candidate = typeof input === 'string' || input instanceof URL
+            ? String(input)
+            : String(input?.url || '');
+        try {
+            return new URL(candidate, baseUrl || 'https://edvibe.com/');
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function isTrustedEdvibeUrl(input, baseUrl) {
+        const url = normalizeRequestUrl(input, baseUrl);
+        return Boolean(url)
+            && url.protocol === 'https:'
+            && (url.hostname === 'edvibe.com' || url.hostname.endsWith('.edvibe.com'));
+    }
+
+    function readHeader(headers, name, HeadersCtor = globalThis.Headers) {
+        if (!headers) {
+            return '';
+        }
+        try {
+            if (HeadersCtor) {
+                return new HeadersCtor(headers).get(name) || '';
+            }
+        } catch (_) {
+            // Fall through to plain-object and tuple handling.
+        }
+        const target = String(name).toLowerCase();
+        if (Array.isArray(headers)) {
+            const entry = headers.find(([key]) => String(key).toLowerCase() === target);
+            return entry ? String(entry[1] || '') : '';
+        }
+        for (const [key, value] of Object.entries(headers)) {
+            if (String(key).toLowerCase() === target) {
+                return String(value || '');
+            }
+        }
+        return '';
+    }
+
+    function createAuthorizationCapture(rootObject) {
+        let authorization = '';
+        const baseUrl = rootObject.location?.href || 'https://edvibe.com/';
+        const originalFetch = rootObject.fetch;
+        const HeadersCtor = rootObject.Headers;
+
+        function capture(input, headers) {
+            if (!isTrustedEdvibeUrl(input, baseUrl)) {
+                return;
+            }
+            const value = readHeader(headers, 'authorization', HeadersCtor);
+            if (value) {
+                authorization = value;
+            }
+        }
+
+        if (typeof originalFetch === 'function') {
+            rootObject.fetch = function edvibeToolboxFetch(input, init) {
+                capture(input, init?.headers || input?.headers);
+                return originalFetch.apply(this, arguments);
+            };
+        }
+
+        const xhrPrototype = rootObject.XMLHttpRequest?.prototype;
+        if (xhrPrototype?.open && xhrPrototype?.setRequestHeader) {
+            const originalOpen = xhrPrototype.open;
+            const originalSetRequestHeader = xhrPrototype.setRequestHeader;
+            const urls = new WeakMap();
+
+            xhrPrototype.open = function open(method, url) {
+                urls.set(this, url);
+                return originalOpen.apply(this, arguments);
+            };
+            xhrPrototype.setRequestHeader = function setRequestHeader(name, value) {
+                if (
+                    String(name).toLowerCase() === 'authorization'
+                    && isTrustedEdvibeUrl(urls.get(this), baseUrl)
+                    && value
+                ) {
+                    authorization = String(value);
+                }
+                return originalSetRequestHeader.apply(this, arguments);
+            };
+        }
+
+        return Object.freeze({
+            getAuthorization: () => authorization,
+            capture
+        });
+    }
+
+    function createDynamicImageRecipe(recipe) {
+        if (!recipe || !Array.isArray(recipe.steps)) {
+            return recipe;
+        }
+        const steps = recipe.steps.map((step) => {
+            if (step.id !== 'save-image') {
+                return step;
+            }
+            const exerciseView = step.valueTemplate?.ExerciseView || {};
+            return Object.freeze({
+                ...step,
+                valueTemplate: Object.freeze({
+                    ...step.valueTemplate,
+                    ExerciseView: Object.freeze({
+                        ...exerciseView,
+                        ChangeExerciseImages: Object.freeze([
+                            Object.freeze({
+                                ImageId: '{{block.asset.imageId}}',
+                                FullImageId: '{{block.asset.fullImageId}}',
+                                ImageUrl: '{{block.asset.imageUrl}}',
+                                FullImageUrl: '{{block.asset.fullImageUrl}}',
+                                cropped: false
+                            })
+                        ])
+                    })
+                })
+            });
+        });
+        return Object.freeze({ ...recipe, steps: Object.freeze(steps) });
+    }
+
+    async function uploadImageAssets({
+        definition,
+        registry,
+        authorization,
+        fetchFn,
+        FormDataCtor
+    }) {
+        const imageBlocks = (definition?.blocks || []).filter((block) => block.type === 'image');
+        if (imageBlocks.length === 0) {
+            return definition;
+        }
+        if (!authorization) {
+            throw createUploadError(
+                'AUTH_CONTEXT_UNAVAILABLE',
+                'Edvibe authorization context is unavailable. Reload the page and try again.'
+            );
+        }
+
+        const formData = new FormDataCtor();
+        formData.append('Type', '8');
+        formData.append('SaveOriginal', 'true');
+        formData.append('IsOriginalSizeOutputImage', 'true');
+
+        const clientIds = [];
+        imageBlocks.forEach((block, index) => {
+            const clientId = parseClientId(block.url);
+            const file = registry?.get?.(clientId);
+            if (!clientId || !file) {
+                throw createUploadError(
+                    'IMAGE_FILE_REQUIRED',
+                    `Image block ${index + 1} requires a selected file.`
+                );
+            }
+            clientIds.push(clientId);
+            formData.append(`Files[${index}]`, file, file.name);
+            formData.append(`Selections[${index}].X`, '0');
+            formData.append(`Selections[${index}].Y`, '0');
+            formData.append(`Selections[${index}].Width`, '0');
+            formData.append(`Selections[${index}].Height`, '0');
+            formData.append(`Ids[${index}]`, clientId);
+        });
+
+        let response;
+        try {
+            response = await fetchFn(UPLOAD_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    accept: '*/*',
+                    authorization
+                },
+                body: formData,
+                mode: 'cors',
+                credentials: 'include'
+            });
+        } catch (error) {
+            throw createUploadError('MEDIA_UPLOAD_FAILED', 'Could not upload the selected image.', {
+                cause: error
+            });
+        }
+
+        if (!response?.ok) {
+            throw createUploadError(
+                'MEDIA_UPLOAD_FAILED',
+                `Edvibe image upload failed with HTTP ${response?.status || 'unknown'}.`
+            );
+        }
+
+        let payload;
+        try {
+            payload = await response.json();
+        } catch (error) {
+            throw createUploadError('INVALID_MEDIA_RESPONSE', 'Edvibe returned an invalid image response.', {
+                cause: error
+            });
+        }
+
+        if (!payload?.IsSuccess) {
+            throw createUploadError(
+                'MEDIA_UPLOAD_REJECTED',
+                payload?.ErrorMessage || 'Edvibe rejected the selected image.'
+            );
+        }
+        if ((payload?.Data?.ErrorItems || []).length > 0) {
+            throw createUploadError(
+                'MEDIA_UPLOAD_PARTIAL',
+                'Edvibe failed to upload one or more selected images.',
+                { errorItems: payload.Data.ErrorItems }
+            );
+        }
+
+        const assetsByClientId = new Map((payload?.Data?.Items || []).map((item) => [
+            String(item.OldId || ''),
+            Object.freeze({
+                imageId: item.Id,
+                fullImageId: item.IdFull,
+                imageUrl: item.Url,
+                fullImageUrl: item.UrlFull
+            })
+        ]));
+
+        for (const clientId of clientIds) {
+            if (!assetsByClientId.has(clientId)) {
+                throw createUploadError(
+                    'INVALID_MEDIA_RESPONSE',
+                    'Edvibe did not return an asset for every selected image.'
+                );
+            }
+        }
+
+        const blocks = definition.blocks.map((block) => {
+            if (block.type !== 'image') {
+                return block;
+            }
+            const clientId = parseClientId(block.url);
+            return Object.freeze({ ...block, asset: assetsByClientId.get(clientId) });
+        });
+        return Object.freeze({ ...definition, blocks: Object.freeze(blocks) });
+    }
+
+    function enhanceAdapterFactory({
+        featureApi,
+        registry,
+        authorizationCapture,
+        fetchFn,
+        FormDataCtor
+    }) {
+        const originalFactory = featureApi?.createRecordedCreationAdapter;
+        if (typeof originalFactory !== 'function' || originalFactory.__imageUploadEnhanced) {
+            return false;
+        }
+
+        function createEnhancedAdapter(options) {
+            const adapter = originalFactory(options);
+            const uploadsByDefinition = new WeakMap();
+
+            async function enrich(definition) {
+                if (!definition || typeof definition !== 'object') {
+                    return definition;
+                }
+                let upload = uploadsByDefinition.get(definition);
+                if (!upload) {
+                    upload = uploadImageAssets({
+                        definition,
+                        registry,
+                        authorization: authorizationCapture.getAuthorization(),
+                        fetchFn,
+                        FormDataCtor
+                    });
+                    uploadsByDefinition.set(definition, upload);
+                }
+                return upload;
+            }
+
+            return Object.freeze({
+                ...adapter,
+                async createSection(context) {
+                    const definition = await enrich(context.definition);
+                    return adapter.createSection({ ...context, definition });
+                },
+                async cleanupSection(context) {
+                    const definition = await enrich(context.definition);
+                    return adapter.cleanupSection({ ...context, definition });
+                }
+            });
+        }
+        createEnhancedAdapter.__imageUploadEnhanced = true;
+        featureApi.createRecordedCreationAdapter = createEnhancedAdapter;
+        return true;
+    }
+
+    let authorizationCapture = null;
+    if (root?.document && root.EdVibeBatchSectionCreation && root.EdVibeBatchSectionImageRegistry) {
+        authorizationCapture = createAuthorizationCapture(root);
+        root.EdVibeBatchSectionCreationRecipe = createDynamicImageRecipe(
+            root.EdVibeBatchSectionCreationRecipe
+        );
+        enhanceAdapterFactory({
+            featureApi: root.EdVibeBatchSectionCreation,
+            registry: root.EdVibeBatchSectionImageRegistry,
+            authorizationCapture,
+            fetchFn: root.fetch.bind(root),
+            FormDataCtor: root.FormData
+        });
+    }
+
+    return {
+        UPLOAD_ENDPOINT,
+        IMAGE_PLACEHOLDER_PREFIX,
+        createUploadError,
+        parseClientId,
+        normalizeRequestUrl,
+        isTrustedEdvibeUrl,
+        readHeader,
+        createAuthorizationCapture,
+        createDynamicImageRecipe,
+        uploadImageAssets,
+        enhanceAdapterFactory,
+        authorizationCapture
+    };
+});

--- a/src/features/batch-section-image-upload.test.js
+++ b/src/features/batch-section-image-upload.test.js
@@ -1,0 +1,143 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    UPLOAD_ENDPOINT,
+    createAuthorizationCapture,
+    createDynamicImageRecipe,
+    uploadImageAssets
+} = require('./batch-section-image-upload.js');
+
+class FakeFormData {
+    constructor() {
+        this.entries = [];
+    }
+
+    append(name, value, filename) {
+        this.entries.push({ name, value, filename });
+    }
+}
+
+test('recipe resolves uploaded image assets instead of a recorded fixed banner', () => {
+    const recipe = {
+        version: 1,
+        reviewedDynamicFields: true,
+        steps: [{
+            id: 'save-image',
+            valueTemplate: {
+                ExerciseView: {
+                    ChangeExerciseImages: [{ ImageId: 123 }]
+                }
+            }
+        }]
+    };
+
+    const patched = createDynamicImageRecipe(recipe);
+    const image = patched.steps[0].valueTemplate.ExerciseView.ChangeExerciseImages[0];
+
+    assert.deepEqual(image, {
+        ImageId: '{{block.asset.imageId}}',
+        FullImageId: '{{block.asset.fullImageId}}',
+        ImageUrl: '{{block.asset.imageUrl}}',
+        FullImageUrl: '{{block.asset.fullImageUrl}}',
+        cropped: false
+    });
+    assert.equal(recipe.steps[0].valueTemplate.ExerciseView.ChangeExerciseImages[0].ImageId, 123);
+});
+
+test('selected images are uploaded once as multipart data and mapped by OldId', async () => {
+    const file = { name: 'banner.png', type: 'image/png', size: 4096 };
+    const registry = {
+        get: (clientId) => clientId === 'client-image-1' ? file : null
+    };
+    const definition = {
+        name: 'Announcement',
+        blocks: [{
+            id: 'block-1',
+            type: 'image',
+            url: 'https://media-files-y.edvibe.com/local-upload/client-image-1',
+            alt: 'Banner'
+        }]
+    };
+    let request = null;
+    const fetchFn = async (url, init) => {
+        request = { url, init };
+        return {
+            ok: true,
+            status: 200,
+            async json() {
+                return {
+                    IsSuccess: true,
+                    Data: {
+                        Items: [{
+                            IdFull: 687940561,
+                            UrlFull: 'https://media-y.edvibe.com/full.png',
+                            Id: 687940559,
+                            Url: 'https://media-y.edvibe.com/image.png',
+                            OldId: 'client-image-1'
+                        }],
+                        ErrorItems: []
+                    }
+                };
+            }
+        };
+    };
+
+    const enriched = await uploadImageAssets({
+        definition,
+        registry,
+        authorization: 'session-token',
+        fetchFn,
+        FormDataCtor: FakeFormData
+    });
+
+    assert.equal(request.url, UPLOAD_ENDPOINT);
+    assert.equal(request.init.method, 'POST');
+    assert.equal(request.init.credentials, 'include');
+    assert.equal(request.init.headers.authorization, 'session-token');
+    assert.equal(request.init.headers['content-type'], undefined);
+    assert.deepEqual(
+        request.init.body.entries.map(({ name }) => name),
+        [
+            'Type',
+            'SaveOriginal',
+            'IsOriginalSizeOutputImage',
+            'Files[0]',
+            'Selections[0].X',
+            'Selections[0].Y',
+            'Selections[0].Width',
+            'Selections[0].Height',
+            'Ids[0]'
+        ]
+    );
+    assert.deepEqual(enriched.blocks[0].asset, {
+        imageId: 687940559,
+        fullImageId: 687940561,
+        imageUrl: 'https://media-y.edvibe.com/image.png',
+        fullImageUrl: 'https://media-y.edvibe.com/full.png'
+    });
+});
+
+test('authorization is captured only from trusted Edvibe requests', async () => {
+    const calls = [];
+    const root = {
+        location: { href: 'https://edvibe.com/cabinet' },
+        Headers,
+        fetch: async (...args) => {
+            calls.push(args);
+            return { ok: true };
+        }
+    };
+    const capture = createAuthorizationCapture(root);
+
+    await root.fetch('https://example.com/api', {
+        headers: { authorization: 'outside-token' }
+    });
+    assert.equal(capture.getAuthorization(), '');
+
+    await root.fetch('https://media-files-y.edvibe.com/api/test', {
+        headers: { authorization: 'edvibe-token' }
+    });
+    assert.equal(capture.getAuthorization(), 'edvibe-token');
+    assert.equal(calls.length, 2);
+});


### PR DESCRIPTION
## What changed

- replace the batch section banner URL workflow with a native image file picker and local preview
- keep selected `File` objects only in page memory and revoke preview object URLs during cleanup
- capture the current Edvibe authorization header from trusted Edvibe fetch/XHR traffic without persisting or logging it
- upload all configured banner files once through `MediaFile/create-multiple`
- map the upload response by `OldId` and feed the returned image IDs and URLs into the existing `SaveExercise` recipe
- preserve the uploaded assets across all selected lessons in the same batch operation
- add focused unit and manifest-order integration coverage

## Why

The existing UI asked for an image URL, while the recorded recipe ignored that URL and reused one fixed recorded Edvibe image asset. Native Edvibe uploads a local file first, then passes the returned `Id`, `IdFull`, `Url`, and `UrlFull` values to `SaveExercise`.

## User impact

Users can now choose banner images directly from the filesystem, see a preview, and reuse one uploaded asset across every lesson selected for the batch section operation.

## Validation

- `node --check` for both new runtime modules
- 7 focused Node tests covering the file registry, multipart request shape, upload response mapping, authorization capture, recipe token replacement, and manifest ordering

## Manual follow-up

Before merging, load the unpacked extension on a disposable Edvibe lesson and verify one image-only section and one mixed image/link section end to end.