### PR TITLE
Persist batch section deletion execution history

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -67,6 +67,7 @@
                 "src/features/batch-section-creation-history.js",
                 "src/features/batch-section-image-upload.js",
                 "src/features/batch-section-deletion.js",
+                "src/features/batch-section-deletion-history.js",
                 "src/features/execution-history.js",
                 "src/main.js"
             ],

--- a/src/execution-history-wiring.test.js
+++ b/src/execution-history-wiring.test.js
@@ -27,11 +27,16 @@ test('manifest loads execution-history infrastructure before UI and features', (
         'src/features/batch-section-creation-history-model.js',
         'src/features/batch-section-creation-history-record.js',
         'src/features/batch-section-creation-history.js',
+        'src/features/batch-section-deletion.js',
+        'src/features/batch-section-deletion-history.js',
         'src/features/execution-history.js',
         'src/main.js'
     ];
     for (const script of expected) assert.ok(scripts.includes(script), `${script} should be loaded`);
-    assert.deepEqual(expected.map((script) => scripts.indexOf(script)), [...expected.map((script) => scripts.indexOf(script))].sort((a, b) => a - b));
+    assert.deepEqual(
+        expected.map((script) => scripts.indexOf(script)),
+        [...expected.map((script) => scripts.indexOf(script))].sort((a, b) => a - b)
+    );
     assert.ok(manifest.web_accessible_resources[0].resources.includes('src/components/execution-history-dialog.css'));
 });
 
@@ -40,6 +45,7 @@ test('popup, isolated bridge, main coordinator, and representative batch results
     const isolated = read('src/isolated.js');
     const main = read('src/main.js');
     const batchDeletionFeature = read('src/features/batch-section-deletion.js');
+    const batchDeletionHistory = read('src/features/batch-section-deletion-history.js');
     const batchDeletionDialog = read('src/components/batch-section-deletion-dialog.js');
     const batchAccessHistory = read('src/features/batch-lesson-access-history.js');
     const batchAccessHistoryRecord = read('src/features/batch-lesson-access-history-record.js');
@@ -50,7 +56,7 @@ test('popup, isolated bridge, main coordinator, and representative batch results
     assert.match(isolated, /ALLOWED_STORAGE_KEYS = new Set\(\['executionHistoryPreferences'\]\)/);
     assert.match(main, /batchAccessHistoryApi\.createHistoryAwareFeature/);
     assert.match(main, /batchSectionCreationHistoryApi\.createHistoryAwareDialog/);
-    assert.match(main, /createDialog: createBatchSectionCreationDialog/);
+    assert.match(main, /batchSectionDeletionApi\.createBatchSectionDeletionFeature/);
     assert.match(main, /persistExecution: historyService\.persistTerminal/);
     assert.match(main, /openHistory: \(executionId, sourceStylesheetUrl\)/);
     assert.match(batchAccessHistoryRecord, /buildExecutionHistoryInput/);
@@ -59,7 +65,10 @@ test('popup, isolated bridge, main coordinator, and representative batch results
     assert.match(batchSectionCreationHistory, /buildExecutionHistoryInput/);
     assert.match(batchSectionCreationHistory, /Результат сохранён в истории/);
     assert.match(batchSectionCreationHistory, /Экранный результат сохранён, но записать историю не удалось/);
-    assert.match(batchDeletionFeature, /buildExecutionHistoryInput/);
+    assert.match(batchDeletionHistory, /buildExecutionHistoryInput/);
+    assert.match(batchDeletionHistory, /installHistoryAwareFeature/);
+    assert.match(batchDeletionHistory, /root\.EdVibeBatchSectionDeletion = historyApi\.installHistoryAwareFeature/);
+    assert.match(batchDeletionHistory, /visible preflight is intact, but history could not be saved/i);
     assert.match(batchDeletionDialog, /Open in history/);
     assert.match(batchDeletionDialog, /visible report is intact, but history could not be saved/);
 });

--- a/src/features/batch-section-deletion-history-record.test.js
+++ b/src/features/batch-section-deletion-history-record.test.js
@@ -1,0 +1,176 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const history = require('./batch-section-deletion-history.js');
+const lessons = () => [
+{ lessonId: 101, marathonLessonId: 1001, number: 1, name: 'Welcome' },
+{ lessonId: 102, marathonLessonId: 1002, number: 2, name: 'Practice' },
+{ lessonId: 103, marathonLessonId: 1003, number: 3, name: 'Review' }
+];
+function plan(overrides = {}) {
+const selected = lessons();
+return {
+sectionName: 'Summer promotion',
+selectedLessonIds: selected.map((entry) => entry.lessonId),
+selectedCount: selected.length,
+eligible: selected.map((entry) => ({
+...entry,
+sectionName: 'Summer promotion',
+sectionId: entry.lessonId + 500,
+sectionType: 'normal',
+discoveryOutcome: 'matched',
+matchCount: 1
+})),
+rejected: [],
+...overrides
+};
+}
+function build(overrides = {}) {
+return history.buildExecutionHistoryInput({
+plan: plan(),
+result: {},
+startedAt: '2026-08-06T10:00:00.000Z',
+completedAt: '2026-08-06T10:01:00.000Z',
+marathonId: '77',
+marathonName: 'Autumn course',
+...overrides
+});
+}
+test('preserves explicit discovery outcomes for zero, one, multiple, unsupported, and invalid cases', () => {
+const selected = lessons();
+const rejected = [
+{
+...selected[0], sectionName: 'Summer promotion', discoveryOutcome: 'not_found',
+status: 'rejected', code: 'SECTION_NOT_FOUND', message: 'Not found.', attempts: 0, matchCount: 0
+},
+{
+...selected[1], sectionName: 'Summer promotion', discoveryOutcome: 'ambiguous',
+status: 'rejected', code: 'SECTION_NAME_AMBIGUOUS', message: 'Two matches.', attempts: 0, matchCount: 2
+},
+{
+...selected[2], sectionName: 'Summer promotion', discoveryOutcome: 'unsupported_section_type',
+status: 'rejected', code: 'UNSUPPORTED_SECTION_TYPE', message: 'Unsupported.', attempts: 0, matchCount: 1
+},
+{
+lessonId: 104, marathonLessonId: 1004, number: 4, name: 'Broken',
+sectionName: 'Summer promotion', discoveryOutcome: 'invalid_lesson_response',
+status: 'rejected', code: 'INVALID_LESSON_RESPONSE', message: 'Invalid lesson.', attempts: 0
+}
+];
+const eligible = [{
+lessonId: 105, marathonLessonId: 1005, number: 5, name: 'Matched',
+sectionName: 'Summer promotion', sectionId: 605, sectionType: 'normal',
+discoveryOutcome: 'matched', matchCount: 1
+}];
+const input = build({
+plan: plan({
+selectedLessonIds: [101, 102, 103, 104, 105],
+selectedCount: 5,
+eligible,
+rejected
+}),
+result: { results: [...rejected, { ...eligible[0], status: 'deleted', attempts: 1 }] }
+});
+assert.deepEqual(input.results.map((entry) => entry.data.discovery.outcome), [
+'not_found', 'ambiguous', 'unsupported_section_type', 'invalid_lesson_response', 'matched'
+]);
+assert.equal(input.results[4].data.section.matchedId, 605);
+assert.equal(input.results[4].data.section.supportedType, 'normal');
+assert.equal(input.results[4].data.finalOutcome, 'deleted');
+});
+test('distinguishes validated deletion failure and preserves retries', () => {
+const target = plan().eligible[0];
+const input = build({
+plan: plan({ selectedLessonIds: [101], selectedCount: 1, eligible: [target] }),
+result: {
+results: [{
+...target,
+status: 'failed',
+code: 'REQUEST_TIMEOUT',
+message: 'Deletion timed out.',
+attempts: 3
+}]
+}
+});
+assert.equal(input.status, 'completed_with_failures');
+assert.equal(input.results[0].status, 'failed');
+assert.equal(input.results[0].attempts, 3);
+assert.deepEqual(input.results[0].data.deletionFailure, {
+code: 'REQUEST_TIMEOUT',
+message: 'Deletion timed out.',
+attemptCount: 3
+});
+assert.equal(input.results[0].data.discovery.outcome, 'matched');
+});
+test('retains completed work and materializes the remaining plan after interruption', () => {
+const targetPlan = plan();
+const input = build({
+plan: targetPlan,
+result: {
+results: [
+{ ...targetPlan.eligible[0], status: 'deleted', attempts: 1 },
+{
+...targetPlan.eligible[1], status: 'failed', code: 'WS_UNAVAILABLE',
+message: 'Connection disappeared.', attempts: 2
+}
+],
+fatalError: Object.assign(new Error('Connection disappeared.'), { code: 'WS_UNAVAILABLE' })
+}
+});
+assert.equal(input.status, 'interrupted');
+assert.deepEqual(input.results.map((entry) => entry.status), ['deleted', 'failed', 'not_attempted']);
+assert.equal(input.results[2].code, 'OPERATION_INTERRUPTED');
+assert.equal(input.results[2].attempts, 0);
+assert.equal(input.counts.notAttempted, 1);
+});
+test('cancellation preserves rejections and marks every remaining eligible lesson not attempted', () => {
+const selected = lessons();
+const rejected = {
+...selected[1],
+sectionName: 'Summer promotion',
+discoveryOutcome: 'not_found',
+status: 'rejected',
+code: 'SECTION_NOT_FOUND',
+message: 'Not found.',
+attempts: 0
+};
+const eligible = [selected[0], selected[2]].map((entry) => ({
+...entry,
+sectionName: 'Summer promotion',
+sectionId: entry.lessonId + 500,
+sectionType: 'normal',
+discoveryOutcome: 'matched'
+}));
+const input = build({
+plan: plan({ eligible, rejected: [rejected] }),
+terminalStatus: 'cancelled'
+});
+assert.equal(input.status, 'cancelled');
+assert.deepEqual(input.results.map((entry) => entry.status), [
+'not_attempted', 'rejected', 'not_attempted'
+]);
+assert.equal(input.results[0].code, 'OPERATION_CANCELLED');
+assert.equal(input.counts.skipped, 1);
+assert.equal(input.counts.notAttempted, 2);
+});
+test('history input whitelists audit fields and excludes raw or session-shaped payloads', () => {
+const target = plan().eligible[0];
+const input = build({
+plan: plan({ selectedLessonIds: [101], selectedCount: 1, eligible: [target] }),
+result: {
+results: [{
+...target,
+status: 'deleted',
+attempts: 1,
+rawLesson: { Sections: [{ Id: 1 }] },
+transportResponse: { Value: true },
+recording: [{ frame: 'secret' }],
+sessionToken: 'secret'
+}]
+}
+});
+const json = JSON.stringify(input);
+assert.doesNotMatch(json, /rawLesson|transportResponse|recording|sessionToken|secret/);
+assert.match(json, /Summer promotion/);
+assert.match(json, /batch-section-deletion/);
+});

--- a/src/features/batch-section-deletion-history-record.test.js
+++ b/src/features/batch-section-deletion-history-record.test.js
@@ -1,176 +1,253 @@
 'use strict';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const history = require('./batch-section-deletion-history.js');
+
 const lessons = () => [
-{ lessonId: 101, marathonLessonId: 1001, number: 1, name: 'Welcome' },
-{ lessonId: 102, marathonLessonId: 1002, number: 2, name: 'Practice' },
-{ lessonId: 103, marathonLessonId: 1003, number: 3, name: 'Review' }
+    { lessonId: 101, marathonLessonId: 1001, number: 1, name: 'Welcome' },
+    { lessonId: 102, marathonLessonId: 1002, number: 2, name: 'Practice' },
+    { lessonId: 103, marathonLessonId: 1003, number: 3, name: 'Review' }
 ];
+
 function plan(overrides = {}) {
-const selected = lessons();
-return {
-sectionName: 'Summer promotion',
-selectedLessonIds: selected.map((entry) => entry.lessonId),
-selectedCount: selected.length,
-eligible: selected.map((entry) => ({
-...entry,
-sectionName: 'Summer promotion',
-sectionId: entry.lessonId + 500,
-sectionType: 'normal',
-discoveryOutcome: 'matched',
-matchCount: 1
-})),
-rejected: [],
-...overrides
-};
+    const selected = lessons();
+    return {
+        sectionName: 'Summer promotion',
+        selectedLessonIds: selected.map((entry) => entry.lessonId),
+        selectedCount: selected.length,
+        eligible: selected.map((entry) => ({
+            ...entry,
+            sectionName: 'Summer promotion',
+            sectionId: entry.lessonId + 500,
+            sectionType: 'normal',
+            discoveryOutcome: 'matched',
+            matchCount: 1
+        })),
+        rejected: [],
+        ...overrides
+    };
 }
+
 function build(overrides = {}) {
-return history.buildExecutionHistoryInput({
-plan: plan(),
-result: {},
-startedAt: '2026-08-06T10:00:00.000Z',
-completedAt: '2026-08-06T10:01:00.000Z',
-marathonId: '77',
-marathonName: 'Autumn course',
-...overrides
-});
+    return history.buildExecutionHistoryInput({
+        plan: plan(),
+        result: {},
+        startedAt: '2026-08-06T10:00:00.000Z',
+        completedAt: '2026-08-06T10:01:00.000Z',
+        marathonId: '77',
+        marathonName: 'Autumn course',
+        ...overrides
+    });
 }
+
 test('preserves explicit discovery outcomes for zero, one, multiple, unsupported, and invalid cases', () => {
-const selected = lessons();
-const rejected = [
-{
-...selected[0], sectionName: 'Summer promotion', discoveryOutcome: 'not_found',
-status: 'rejected', code: 'SECTION_NOT_FOUND', message: 'Not found.', attempts: 0, matchCount: 0
-},
-{
-...selected[1], sectionName: 'Summer promotion', discoveryOutcome: 'ambiguous',
-status: 'rejected', code: 'SECTION_NAME_AMBIGUOUS', message: 'Two matches.', attempts: 0, matchCount: 2
-},
-{
-...selected[2], sectionName: 'Summer promotion', discoveryOutcome: 'unsupported_section_type',
-status: 'rejected', code: 'UNSUPPORTED_SECTION_TYPE', message: 'Unsupported.', attempts: 0, matchCount: 1
-},
-{
-lessonId: 104, marathonLessonId: 1004, number: 4, name: 'Broken',
-sectionName: 'Summer promotion', discoveryOutcome: 'invalid_lesson_response',
-status: 'rejected', code: 'INVALID_LESSON_RESPONSE', message: 'Invalid lesson.', attempts: 0
-}
-];
-const eligible = [{
-lessonId: 105, marathonLessonId: 1005, number: 5, name: 'Matched',
-sectionName: 'Summer promotion', sectionId: 605, sectionType: 'normal',
-discoveryOutcome: 'matched', matchCount: 1
-}];
-const input = build({
-plan: plan({
-selectedLessonIds: [101, 102, 103, 104, 105],
-selectedCount: 5,
-eligible,
-rejected
-}),
-result: { results: [...rejected, { ...eligible[0], status: 'deleted', attempts: 1 }] }
+    const selected = lessons();
+    const rejected = [
+        {
+            ...selected[0],
+            sectionName: 'Summer promotion',
+            discoveryOutcome: 'not_found',
+            status: 'rejected',
+            code: 'SECTION_NOT_FOUND',
+            message: 'Not found.',
+            attempts: 0,
+            matchCount: 0
+        },
+        {
+            ...selected[1],
+            sectionName: 'Summer promotion',
+            discoveryOutcome: 'ambiguous',
+            status: 'rejected',
+            code: 'SECTION_NAME_AMBIGUOUS',
+            message: 'Two matches.',
+            attempts: 0,
+            matchCount: 2
+        },
+        {
+            ...selected[2],
+            sectionName: 'Summer promotion',
+            discoveryOutcome: 'unsupported_section_type',
+            status: 'rejected',
+            code: 'UNSUPPORTED_SECTION_TYPE',
+            message: 'Unsupported.',
+            attempts: 0,
+            matchCount: 1
+        },
+        {
+            lessonId: 104,
+            marathonLessonId: 1004,
+            number: 4,
+            name: 'Broken',
+            sectionName: 'Summer promotion',
+            discoveryOutcome: 'invalid_lesson_response',
+            status: 'rejected',
+            code: 'INVALID_LESSON_RESPONSE',
+            message: 'Invalid lesson.',
+            attempts: 0
+        }
+    ];
+    const eligible = [{
+        lessonId: 105,
+        marathonLessonId: 1005,
+        number: 5,
+        name: 'Matched',
+        sectionName: 'Summer promotion',
+        sectionId: 605,
+        sectionType: 'normal',
+        discoveryOutcome: 'matched',
+        matchCount: 1
+    }];
+    const input = build({
+        plan: plan({
+            selectedLessonIds: [101, 102, 103, 104, 105],
+            selectedCount: 5,
+            eligible,
+            rejected
+        }),
+        result: {
+            results: [
+                ...rejected,
+                { ...eligible[0], status: 'deleted', attempts: 1 }
+            ]
+        }
+    });
+
+    assert.deepEqual(input.results.map((entry) => entry.data.discovery.outcome), [
+        'not_found',
+        'ambiguous',
+        'unsupported_section_type',
+        'invalid_lesson_response',
+        'matched'
+    ]);
+    assert.equal(input.results[4].data.section.matchedId, 605);
+    assert.equal(input.results[4].data.section.supportedType, 'normal');
+    assert.equal(input.results[4].data.finalOutcome, 'deleted');
 });
-assert.deepEqual(input.results.map((entry) => entry.data.discovery.outcome), [
-'not_found', 'ambiguous', 'unsupported_section_type', 'invalid_lesson_response', 'matched'
-]);
-assert.equal(input.results[4].data.section.matchedId, 605);
-assert.equal(input.results[4].data.section.supportedType, 'normal');
-assert.equal(input.results[4].data.finalOutcome, 'deleted');
-});
+
 test('distinguishes validated deletion failure and preserves retries', () => {
-const target = plan().eligible[0];
-const input = build({
-plan: plan({ selectedLessonIds: [101], selectedCount: 1, eligible: [target] }),
-result: {
-results: [{
-...target,
-status: 'failed',
-code: 'REQUEST_TIMEOUT',
-message: 'Deletion timed out.',
-attempts: 3
-}]
-}
+    const target = plan().eligible[0];
+    const input = build({
+        plan: plan({
+            selectedLessonIds: [101],
+            selectedCount: 1,
+            eligible: [target]
+        }),
+        result: {
+            results: [{
+                ...target,
+                status: 'failed',
+                code: 'REQUEST_TIMEOUT',
+                message: 'Deletion timed out.',
+                attempts: 3
+            }]
+        }
+    });
+
+    assert.equal(input.status, 'completed_with_failures');
+    assert.equal(input.results[0].status, 'failed');
+    assert.equal(input.results[0].attempts, 3);
+    assert.deepEqual(input.results[0].data.deletionFailure, {
+        code: 'REQUEST_TIMEOUT',
+        message: 'Deletion timed out.',
+        attemptCount: 3
+    });
+    assert.equal(input.results[0].data.discovery.outcome, 'matched');
 });
-assert.equal(input.status, 'completed_with_failures');
-assert.equal(input.results[0].status, 'failed');
-assert.equal(input.results[0].attempts, 3);
-assert.deepEqual(input.results[0].data.deletionFailure, {
-code: 'REQUEST_TIMEOUT',
-message: 'Deletion timed out.',
-attemptCount: 3
-});
-assert.equal(input.results[0].data.discovery.outcome, 'matched');
-});
+
 test('retains completed work and materializes the remaining plan after interruption', () => {
-const targetPlan = plan();
-const input = build({
-plan: targetPlan,
-result: {
-results: [
-{ ...targetPlan.eligible[0], status: 'deleted', attempts: 1 },
-{
-...targetPlan.eligible[1], status: 'failed', code: 'WS_UNAVAILABLE',
-message: 'Connection disappeared.', attempts: 2
-}
-],
-fatalError: Object.assign(new Error('Connection disappeared.'), { code: 'WS_UNAVAILABLE' })
-}
+    const targetPlan = plan();
+    const input = build({
+        plan: targetPlan,
+        result: {
+            results: [
+                { ...targetPlan.eligible[0], status: 'deleted', attempts: 1 },
+                {
+                    ...targetPlan.eligible[1],
+                    status: 'failed',
+                    code: 'WS_UNAVAILABLE',
+                    message: 'Connection disappeared.',
+                    attempts: 2
+                }
+            ],
+            fatalError: Object.assign(
+                new Error('Connection disappeared.'),
+                { code: 'WS_UNAVAILABLE' }
+            )
+        }
+    });
+
+    assert.equal(input.status, 'interrupted');
+    assert.deepEqual(input.results.map((entry) => entry.status), [
+        'deleted',
+        'failed',
+        'not_attempted'
+    ]);
+    assert.equal(input.results[2].code, 'OPERATION_INTERRUPTED');
+    assert.equal(input.results[2].attempts, 0);
+    assert.equal(input.counts.notAttempted, 1);
 });
-assert.equal(input.status, 'interrupted');
-assert.deepEqual(input.results.map((entry) => entry.status), ['deleted', 'failed', 'not_attempted']);
-assert.equal(input.results[2].code, 'OPERATION_INTERRUPTED');
-assert.equal(input.results[2].attempts, 0);
-assert.equal(input.counts.notAttempted, 1);
-});
+
 test('cancellation preserves rejections and marks every remaining eligible lesson not attempted', () => {
-const selected = lessons();
-const rejected = {
-...selected[1],
-sectionName: 'Summer promotion',
-discoveryOutcome: 'not_found',
-status: 'rejected',
-code: 'SECTION_NOT_FOUND',
-message: 'Not found.',
-attempts: 0
-};
-const eligible = [selected[0], selected[2]].map((entry) => ({
-...entry,
-sectionName: 'Summer promotion',
-sectionId: entry.lessonId + 500,
-sectionType: 'normal',
-discoveryOutcome: 'matched'
-}));
-const input = build({
-plan: plan({ eligible, rejected: [rejected] }),
-terminalStatus: 'cancelled'
+    const selected = lessons();
+    const rejected = {
+        ...selected[1],
+        sectionName: 'Summer promotion',
+        discoveryOutcome: 'not_found',
+        status: 'rejected',
+        code: 'SECTION_NOT_FOUND',
+        message: 'Not found.',
+        attempts: 0
+    };
+    const eligible = [selected[0], selected[2]].map((entry) => ({
+        ...entry,
+        sectionName: 'Summer promotion',
+        sectionId: entry.lessonId + 500,
+        sectionType: 'normal',
+        discoveryOutcome: 'matched'
+    }));
+    const input = build({
+        plan: plan({ eligible, rejected: [rejected] }),
+        terminalStatus: 'cancelled'
+    });
+
+    assert.equal(input.status, 'cancelled');
+    assert.deepEqual(input.results.map((entry) => entry.status), [
+        'not_attempted',
+        'rejected',
+        'not_attempted'
+    ]);
+    assert.equal(input.results[0].code, 'OPERATION_CANCELLED');
+    assert.equal(input.counts.skipped, 1);
+    assert.equal(input.counts.notAttempted, 2);
 });
-assert.equal(input.status, 'cancelled');
-assert.deepEqual(input.results.map((entry) => entry.status), [
-'not_attempted', 'rejected', 'not_attempted'
-]);
-assert.equal(input.results[0].code, 'OPERATION_CANCELLED');
-assert.equal(input.counts.skipped, 1);
-assert.equal(input.counts.notAttempted, 2);
-});
+
 test('history input whitelists audit fields and excludes raw or session-shaped payloads', () => {
-const target = plan().eligible[0];
-const input = build({
-plan: plan({ selectedLessonIds: [101], selectedCount: 1, eligible: [target] }),
-result: {
-results: [{
-...target,
-status: 'deleted',
-attempts: 1,
-rawLesson: { Sections: [{ Id: 1 }] },
-transportResponse: { Value: true },
-recording: [{ frame: 'secret' }],
-sessionToken: 'secret'
-}]
-}
-});
-const json = JSON.stringify(input);
-assert.doesNotMatch(json, /rawLesson|transportResponse|recording|sessionToken|secret/);
-assert.match(json, /Summer promotion/);
-assert.match(json, /batch-section-deletion/);
+    const target = plan().eligible[0];
+    const input = build({
+        plan: plan({
+            selectedLessonIds: [101],
+            selectedCount: 1,
+            eligible: [target]
+        }),
+        result: {
+            results: [{
+                ...target,
+                status: 'deleted',
+                attempts: 1,
+                rawLesson: { Sections: [{ Id: 1 }] },
+                transportResponse: { Value: true },
+                recording: [{ frame: 'secret' }],
+                sessionToken: 'secret'
+            }]
+        }
+    });
+    const json = JSON.stringify(input);
+
+    assert.doesNotMatch(
+        json,
+        /rawLesson|transportResponse|recording|sessionToken|secret/
+    );
+    assert.match(json, /Summer promotion/);
+    assert.match(json, /batch-section-deletion/);
 });

--- a/src/features/batch-section-deletion-history.js
+++ b/src/features/batch-section-deletion-history.js
@@ -1,0 +1,333 @@
+(function initializeBatchSectionDeletionHistory(root, factory) {
+if (typeof module === 'object' && module.exports) {
+module.exports = factory(require('./batch-section-deletion.js'), root);
+} else {
+const coreApi = root.EdVibeBatchSectionDeletion;
+const historyApi = factory(coreApi, root);
+root.EdVibeBatchSectionDeletionHistory = historyApi;
+root.EdVibeBatchSectionDeletion = historyApi.installHistoryAwareFeature(coreApi);
+}
+})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(coreApi, rootObject) {
+'use strict';
+const OPERATION_TYPE = 'batch-section-deletion';
+const TERMINAL_STATUSES = new Set(['completed', 'completed_with_failures', 'cancelled', 'interrupted']);
+const ATTEMPTED_STATUSES = new Set(['deleted', 'failed']);
+function text(value, fallback = '', maxLength = 1000) {
+const normalized = String(value ?? '').trim();
+if (!normalized) return fallback;
+return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
+}
+function parseMarathonId(url) {
+const match = String(url || '').match(/\/marathon\/(\d+)(?:\/|$)/);
+return match ? String(match[1]) : null;
+}
+function lessonKey(value) {
+const id = value?.lessonId ?? value?.LessonId;
+return id === undefined || id === null ? null : String(id);
+}
+function discoveryOutcome(entry = {}) {
+if (entry.discoveryOutcome) return text(entry.discoveryOutcome, 'inspection_failed', 120);
+return {
+SECTION_NOT_FOUND: 'not_found',
+SECTION_NAME_AMBIGUOUS: 'ambiguous',
+UNSUPPORTED_SECTION_TYPE: 'unsupported_section_type',
+INVALID_LESSON_RESPONSE: 'invalid_lesson_response'
+}[entry.code] || (entry.sectionId ? 'matched' : 'inspection_failed');
+}
+function enrichPlan(plan = {}, selectedLessonIds = []) {
+const sectionName = text(plan.sectionName, 'Unnamed section', 500);
+const eligible = (plan.eligible || []).map((entry) => Object.freeze({
+...entry,
+sectionName,
+sectionType: 'normal',
+discoveryOutcome: 'matched',
+matchCount: 1
+}));
+const rejected = (plan.rejected || []).map((entry) => Object.freeze({
+...entry,
+sectionName,
+sectionId: null,
+sectionType: null,
+discoveryOutcome: discoveryOutcome(entry),
+matchCount: entry.code === 'SECTION_NOT_FOUND' ? 0 : null,
+attempts: 0
+}));
+return Object.freeze({
+...plan,
+sectionName,
+selectedLessonIds: Object.freeze([...selectedLessonIds]),
+selectedCount: Number.isSafeInteger(plan.selectedCount) ? plan.selectedCount : selectedLessonIds.length,
+eligible: Object.freeze(eligible),
+rejected: Object.freeze(rejected)
+});
+}
+function resultCode(entry, terminalStatus) {
+if (entry.code) return text(entry.code, 'UNKNOWN_RESULT', 120);
+if (entry.status === 'deleted') return 'DELETED';
+if (entry.status === 'rejected') return 'PREFLIGHT_REJECTED';
+if (entry.status === 'failed') return 'DELETE_FAILED';
+return terminalStatus === 'cancelled' ? 'OPERATION_CANCELLED' : 'OPERATION_INTERRUPTED';
+}
+function resultMessage(entry, terminalStatus) {
+if (entry.message) return text(entry.message, 'No message was provided.');
+if (entry.status === 'deleted') return 'Section deleted.';
+if (entry.status === 'rejected') return 'The lesson was rejected during discovery.';
+if (entry.status === 'failed') return 'The validated deletion request failed.';
+return terminalStatus === 'cancelled'
+? 'Not attempted because the confirmed run was cancelled.'
+: 'Not attempted because the confirmed run was interrupted.';
+}
+function materializeResults(plan = {}, execution = {}, terminalStatus = null) {
+const byId = new Map();
+for (const entry of plan.rejected || []) byId.set(lessonKey(entry), { ...entry, status: 'rejected', attempts: 0 });
+for (const entry of execution.results || []) byId.set(lessonKey(entry), { ...entry });
+const eligible = new Map((plan.eligible || []).map((entry) => [lessonKey(entry), entry]));
+const ordered = [];
+const included = new Set();
+for (const id of plan.selectedLessonIds || []) {
+const key = String(id);
+let entry = byId.get(key);
+if (!entry && eligible.has(key)) entry = { ...eligible.get(key), status: 'not_attempted', attempts: 0 };
+if (!entry) entry = { lessonId: id, name: `Lesson ${id}`, status: 'not_attempted', attempts: 0, sectionName: plan.sectionName };
+ordered.push(entry);
+included.add(key);
+}
+for (const entry of [...byId.values(), ...eligible.values()]) {
+const key = lessonKey(entry);
+if (key !== null && included.has(key)) continue;
+ordered.push(byId.get(key) || { ...entry, status: 'not_attempted', attempts: 0 });
+if (key !== null) included.add(key);
+}
+return ordered.map((entry) => {
+const status = text(entry.status, 'not_attempted', 80);
+return { ...entry, status, attempts: Number.isSafeInteger(entry.attempts) && entry.attempts >= 0
+? entry.attempts
+: ATTEMPTED_STATUSES.has(status) ? 1 : 0, terminalStatus };
+});
+}
+function matchCount(entry) {
+if (Number.isSafeInteger(entry.matchCount) && entry.matchCount >= 0) return entry.matchCount;
+if (entry.sectionId) return 1;
+if (entry.code === 'SECTION_NOT_FOUND') return 0;
+const match = String(entry.message || '').match(/Found (\d+) sections/);
+return match ? Number(match[1]) : null;
+}
+function serializeResult(entry, plan, terminalStatus) {
+const status = entry.status;
+const code = resultCode(entry, terminalStatus);
+const message = resultMessage(entry, terminalStatus);
+const outcome = discoveryOutcome(entry);
+const lesson = Object.freeze({
+lessonId: entry.lessonId ?? null,
+marathonLessonId: entry.marathonLessonId ?? null,
+number: entry.number ?? null,
+name: text(entry.name, 'Unnamed lesson', 500)
+});
+return Object.freeze({
+itemId: lesson.lessonId === null ? null : `lesson-${lesson.lessonId}`,
+label: `${lesson.number ?? '?'}. ${lesson.name}`,
+status,
+code,
+message,
+attempts: entry.attempts,
+data: Object.freeze({
+lesson,
+section: Object.freeze({
+requestedName: text(entry.sectionName || plan.sectionName, 'Unnamed section', 500),
+matchedId: entry.sectionId ?? null,
+supportedType: entry.sectionId ? 'normal' : null
+}),
+discovery: Object.freeze({
+outcome,
+code: outcome === 'matched' ? 'DISCOVERY_MATCHED' : code,
+message: outcome === 'matched'
+? 'Exactly one supported normal lesson section matched the requested name.'
+: message,
+matchCount: matchCount(entry)
+}),
+finalOutcome: status,
+deletionFailure: status === 'failed'
+? Object.freeze({ code, message, attemptCount: entry.attempts })
+: null
+})
+});
+}
+function inferTerminalStatus(explicitStatus, fatalError, results) {
+if (TERMINAL_STATUSES.has(explicitStatus)) return explicitStatus;
+if (fatalError) return 'interrupted';
+return results.some((entry) => ['rejected', 'failed', 'not_attempted'].includes(entry.status))
+? 'completed_with_failures'
+: 'completed';
+}
+function buildExecutionHistoryInput({ plan, result = {}, startedAt, completedAt, marathonId, marathonName = null, terminalStatus = null, fatalError = null }) {
+const materializationStatus = TERMINAL_STATUSES.has(terminalStatus)
+? terminalStatus
+: fatalError || result.fatalError ? 'interrupted' : null;
+const materialized = materializeResults(plan, result, materializationStatus);
+const results = materialized.map((entry) => serializeResult(entry, plan, materializationStatus));
+const status = inferTerminalStatus(terminalStatus, fatalError || result.fatalError, results);
+const attempted = results.filter((entry) => ATTEMPTED_STATUSES.has(entry.status)).length;
+const notAttempted = results.filter((entry) => entry.status === 'not_attempted').length;
+const counts = Object.freeze({
+requested: results.length,
+eligible: Math.max(plan.eligible?.length || 0, attempted + notAttempted),
+attempted,
+successful: results.filter((entry) => entry.status === 'deleted').length,
+noOp: 0,
+skipped: results.filter((entry) => entry.status === 'rejected').length,
+failed: results.filter((entry) => entry.status === 'failed').length,
+notAttempted
+});
+return Object.freeze({
+operationType: OPERATION_TYPE,
+startedAt,
+completedAt,
+status,
+pageContext: Object.freeze({ marathonId, marathonName }),
+counts,
+results: Object.freeze(results),
+message: JSON.stringify({ sectionName: plan.sectionName, counts })
+});
+}
+function appendStatus(dialog, message) {
+const status = dialog.shadowRoot?.querySelector?.('.status');
+const current = status?.textContent || '';
+dialog.showStatus?.(`${current}${current ? ' ' : ''}${message}`);
+}
+function addHistoryButton(dialog, executionId, openHistory) {
+const document = dialog.ownerDocument || rootObject.document;
+const button = document?.createElement?.('button');
+if (!button) return;
+button.type = 'button';
+button.className = 'edvibe-batch-section-deletion-history';
+button.textContent = 'Open in history';
+button.addEventListener('click', () => openHistory?.(executionId));
+dialog.shadowRoot?.querySelector?.('footer')?.appendChild?.(button);
+}
+function createHistoryAwareFeature(options = {}) {
+const {
+createFeature = coreApi.createBatchSectionDeletionFeature,
+createDialog,
+persistExecution,
+getLocationHref = () => '',
+getMarathonName = () => null,
+now = () => new Date(),
+log = () => {},
+...featureOptions
+} = options;
+if (typeof createDialog !== 'function') throw new TypeError('createDialog is required');
+if (typeof persistExecution !== 'function') throw new TypeError('persistExecution is required');
+function createTrackedDialog() {
+const dialog = createDialog();
+const originalConfigure = dialog.configure.bind(dialog);
+let plan = null;
+let latestResult = null;
+let startedAt = null;
+let terminal = false;
+let sequence = 0;
+async function persist(result, terminalStatus = null, fatalError = null) {
+const currentSequence = sequence;
+try {
+const completedAt = now().toISOString();
+const input = buildExecutionHistoryInput({
+plan,
+result: result || latestResult || {},
+startedAt: startedAt || completedAt,
+completedAt,
+marathonId: parseMarathonId(getLocationHref()),
+marathonName: getMarathonName(),
+terminalStatus,
+fatalError
+});
+const history = await persistExecution(input);
+return currentSequence === sequence ? history : Object.freeze({ stored: false, stale: true });
+} catch (persistenceError) {
+log('Batch section deletion history persistence failed:', persistenceError);
+return Object.freeze({ stored: false, persistenceError });
+}
+}
+dialog.configure = (config = {}) => {
+const originalInspect = config.onInspect;
+const originalExecute = config.onExecute;
+const originalClose = config.onClose;
+const originalOpenHistory = config.onOpenHistory;
+return originalConfigure({
+...config,
+async onInspect(input) {
+const inspected = await originalInspect(input);
+sequence += 1;
+plan = enrichPlan(inspected, input?.selectedLessonIds || []);
+latestResult = { plan, results: [] };
+startedAt = now().toISOString();
+terminal = false;
+if (!plan.eligible.length) {
+terminal = true;
+void persist(latestResult).then((history) => {
+if (history?.stored) {
+appendStatus(dialog, 'Result saved to execution history.');
+if (history.record?.id) addHistoryButton(dialog, history.record.id, originalOpenHistory);
+} else if (history?.persistenceError) {
+appendStatus(dialog, 'The visible preflight is intact, but history could not be saved.');
+}
+});
+}
+return plan;
+},
+async onExecute(confirmedPlan, onProgress) {
+plan = enrichPlan(confirmedPlan, confirmedPlan.selectedLessonIds || []);
+startedAt = startedAt || now().toISOString();
+terminal = false;
+try {
+const result = await originalExecute(plan, (progress = {}) => {
+if (Array.isArray(progress.results)) latestResult = { plan, results: [...progress.results], fatalError: progress.fatalError || null };
+onProgress?.(progress);
+});
+latestResult = result;
+terminal = true;
+const history = await persist(result, result.fatalError ? 'interrupted' : null, result.fatalError || null);
+return { ...result, history };
+} catch (error) {
+terminal = true;
+await persist(latestResult, 'interrupted', error);
+throw error;
+}
+},
+onOpenHistory: originalOpenHistory,
+onClose() {
+if (plan && !terminal) {
+terminal = true;
+void persist(latestResult, 'cancelled');
+}
+originalClose?.();
+}
+});
+};
+return dialog;
+}
+return createFeature({ ...featureOptions, createDialog: createTrackedDialog, log });
+}
+function installHistoryAwareFeature(baseApi = coreApi) {
+return Object.freeze({
+...baseApi,
+createBatchSectionDeletionFeature(options = {}) {
+return createHistoryAwareFeature({
+...options,
+createFeature: baseApi.createBatchSectionDeletionFeature,
+getLocationHref: options.getLocationHref || (() => rootObject.location?.href || ''),
+getMarathonName: options.getMarathonName || (() => rootObject.document?.querySelector?.('h1')?.textContent?.trim() || rootObject.document?.title || null)
+});
+}
+});
+}
+return Object.freeze({
+OPERATION_TYPE,
+parseMarathonId,
+discoveryOutcome,
+enrichPlan,
+materializeResults,
+serializeResult,
+buildExecutionHistoryInput,
+createHistoryAwareFeature,
+installHistoryAwareFeature
+});
+});

--- a/src/features/batch-section-deletion-history.js
+++ b/src/features/batch-section-deletion-history.js
@@ -1,333 +1,478 @@
 (function initializeBatchSectionDeletionHistory(root, factory) {
-if (typeof module === 'object' && module.exports) {
-module.exports = factory(require('./batch-section-deletion.js'), root);
-} else {
-const coreApi = root.EdVibeBatchSectionDeletion;
-const historyApi = factory(coreApi, root);
-root.EdVibeBatchSectionDeletionHistory = historyApi;
-root.EdVibeBatchSectionDeletion = historyApi.installHistoryAwareFeature(coreApi);
-}
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('./batch-section-deletion.js'), root);
+    } else {
+        const coreApi = root.EdVibeBatchSectionDeletion;
+        const historyApi = factory(coreApi, root);
+        root.EdVibeBatchSectionDeletionHistory = historyApi;
+        root.EdVibeBatchSectionDeletion = historyApi.installHistoryAwareFeature(coreApi);
+    }
 })(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(coreApi, rootObject) {
-'use strict';
-const OPERATION_TYPE = 'batch-section-deletion';
-const TERMINAL_STATUSES = new Set(['completed', 'completed_with_failures', 'cancelled', 'interrupted']);
-const ATTEMPTED_STATUSES = new Set(['deleted', 'failed']);
-function text(value, fallback = '', maxLength = 1000) {
-const normalized = String(value ?? '').trim();
-if (!normalized) return fallback;
-return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
-}
-function parseMarathonId(url) {
-const match = String(url || '').match(/\/marathon\/(\d+)(?:\/|$)/);
-return match ? String(match[1]) : null;
-}
-function lessonKey(value) {
-const id = value?.lessonId ?? value?.LessonId;
-return id === undefined || id === null ? null : String(id);
-}
-function discoveryOutcome(entry = {}) {
-if (entry.discoveryOutcome) return text(entry.discoveryOutcome, 'inspection_failed', 120);
-return {
-SECTION_NOT_FOUND: 'not_found',
-SECTION_NAME_AMBIGUOUS: 'ambiguous',
-UNSUPPORTED_SECTION_TYPE: 'unsupported_section_type',
-INVALID_LESSON_RESPONSE: 'invalid_lesson_response'
-}[entry.code] || (entry.sectionId ? 'matched' : 'inspection_failed');
-}
-function enrichPlan(plan = {}, selectedLessonIds = []) {
-const sectionName = text(plan.sectionName, 'Unnamed section', 500);
-const eligible = (plan.eligible || []).map((entry) => Object.freeze({
-...entry,
-sectionName,
-sectionType: 'normal',
-discoveryOutcome: 'matched',
-matchCount: 1
-}));
-const rejected = (plan.rejected || []).map((entry) => Object.freeze({
-...entry,
-sectionName,
-sectionId: null,
-sectionType: null,
-discoveryOutcome: discoveryOutcome(entry),
-matchCount: entry.code === 'SECTION_NOT_FOUND' ? 0 : null,
-attempts: 0
-}));
-return Object.freeze({
-...plan,
-sectionName,
-selectedLessonIds: Object.freeze([...selectedLessonIds]),
-selectedCount: Number.isSafeInteger(plan.selectedCount) ? plan.selectedCount : selectedLessonIds.length,
-eligible: Object.freeze(eligible),
-rejected: Object.freeze(rejected)
-});
-}
-function resultCode(entry, terminalStatus) {
-if (entry.code) return text(entry.code, 'UNKNOWN_RESULT', 120);
-if (entry.status === 'deleted') return 'DELETED';
-if (entry.status === 'rejected') return 'PREFLIGHT_REJECTED';
-if (entry.status === 'failed') return 'DELETE_FAILED';
-return terminalStatus === 'cancelled' ? 'OPERATION_CANCELLED' : 'OPERATION_INTERRUPTED';
-}
-function resultMessage(entry, terminalStatus) {
-if (entry.message) return text(entry.message, 'No message was provided.');
-if (entry.status === 'deleted') return 'Section deleted.';
-if (entry.status === 'rejected') return 'The lesson was rejected during discovery.';
-if (entry.status === 'failed') return 'The validated deletion request failed.';
-return terminalStatus === 'cancelled'
-? 'Not attempted because the confirmed run was cancelled.'
-: 'Not attempted because the confirmed run was interrupted.';
-}
-function materializeResults(plan = {}, execution = {}, terminalStatus = null) {
-const byId = new Map();
-for (const entry of plan.rejected || []) byId.set(lessonKey(entry), { ...entry, status: 'rejected', attempts: 0 });
-for (const entry of execution.results || []) byId.set(lessonKey(entry), { ...entry });
-const eligible = new Map((plan.eligible || []).map((entry) => [lessonKey(entry), entry]));
-const ordered = [];
-const included = new Set();
-for (const id of plan.selectedLessonIds || []) {
-const key = String(id);
-let entry = byId.get(key);
-if (!entry && eligible.has(key)) entry = { ...eligible.get(key), status: 'not_attempted', attempts: 0 };
-if (!entry) entry = { lessonId: id, name: `Lesson ${id}`, status: 'not_attempted', attempts: 0, sectionName: plan.sectionName };
-ordered.push(entry);
-included.add(key);
-}
-for (const entry of [...byId.values(), ...eligible.values()]) {
-const key = lessonKey(entry);
-if (key !== null && included.has(key)) continue;
-ordered.push(byId.get(key) || { ...entry, status: 'not_attempted', attempts: 0 });
-if (key !== null) included.add(key);
-}
-return ordered.map((entry) => {
-const status = text(entry.status, 'not_attempted', 80);
-return { ...entry, status, attempts: Number.isSafeInteger(entry.attempts) && entry.attempts >= 0
-? entry.attempts
-: ATTEMPTED_STATUSES.has(status) ? 1 : 0, terminalStatus };
-});
-}
-function matchCount(entry) {
-if (Number.isSafeInteger(entry.matchCount) && entry.matchCount >= 0) return entry.matchCount;
-if (entry.sectionId) return 1;
-if (entry.code === 'SECTION_NOT_FOUND') return 0;
-const match = String(entry.message || '').match(/Found (\d+) sections/);
-return match ? Number(match[1]) : null;
-}
-function serializeResult(entry, plan, terminalStatus) {
-const status = entry.status;
-const code = resultCode(entry, terminalStatus);
-const message = resultMessage(entry, terminalStatus);
-const outcome = discoveryOutcome(entry);
-const lesson = Object.freeze({
-lessonId: entry.lessonId ?? null,
-marathonLessonId: entry.marathonLessonId ?? null,
-number: entry.number ?? null,
-name: text(entry.name, 'Unnamed lesson', 500)
-});
-return Object.freeze({
-itemId: lesson.lessonId === null ? null : `lesson-${lesson.lessonId}`,
-label: `${lesson.number ?? '?'}. ${lesson.name}`,
-status,
-code,
-message,
-attempts: entry.attempts,
-data: Object.freeze({
-lesson,
-section: Object.freeze({
-requestedName: text(entry.sectionName || plan.sectionName, 'Unnamed section', 500),
-matchedId: entry.sectionId ?? null,
-supportedType: entry.sectionId ? 'normal' : null
-}),
-discovery: Object.freeze({
-outcome,
-code: outcome === 'matched' ? 'DISCOVERY_MATCHED' : code,
-message: outcome === 'matched'
-? 'Exactly one supported normal lesson section matched the requested name.'
-: message,
-matchCount: matchCount(entry)
-}),
-finalOutcome: status,
-deletionFailure: status === 'failed'
-? Object.freeze({ code, message, attemptCount: entry.attempts })
-: null
-})
-});
-}
-function inferTerminalStatus(explicitStatus, fatalError, results) {
-if (TERMINAL_STATUSES.has(explicitStatus)) return explicitStatus;
-if (fatalError) return 'interrupted';
-return results.some((entry) => ['rejected', 'failed', 'not_attempted'].includes(entry.status))
-? 'completed_with_failures'
-: 'completed';
-}
-function buildExecutionHistoryInput({ plan, result = {}, startedAt, completedAt, marathonId, marathonName = null, terminalStatus = null, fatalError = null }) {
-const materializationStatus = TERMINAL_STATUSES.has(terminalStatus)
-? terminalStatus
-: fatalError || result.fatalError ? 'interrupted' : null;
-const materialized = materializeResults(plan, result, materializationStatus);
-const results = materialized.map((entry) => serializeResult(entry, plan, materializationStatus));
-const status = inferTerminalStatus(terminalStatus, fatalError || result.fatalError, results);
-const attempted = results.filter((entry) => ATTEMPTED_STATUSES.has(entry.status)).length;
-const notAttempted = results.filter((entry) => entry.status === 'not_attempted').length;
-const counts = Object.freeze({
-requested: results.length,
-eligible: Math.max(plan.eligible?.length || 0, attempted + notAttempted),
-attempted,
-successful: results.filter((entry) => entry.status === 'deleted').length,
-noOp: 0,
-skipped: results.filter((entry) => entry.status === 'rejected').length,
-failed: results.filter((entry) => entry.status === 'failed').length,
-notAttempted
-});
-return Object.freeze({
-operationType: OPERATION_TYPE,
-startedAt,
-completedAt,
-status,
-pageContext: Object.freeze({ marathonId, marathonName }),
-counts,
-results: Object.freeze(results),
-message: JSON.stringify({ sectionName: plan.sectionName, counts })
-});
-}
-function appendStatus(dialog, message) {
-const status = dialog.shadowRoot?.querySelector?.('.status');
-const current = status?.textContent || '';
-dialog.showStatus?.(`${current}${current ? ' ' : ''}${message}`);
-}
-function addHistoryButton(dialog, executionId, openHistory) {
-const document = dialog.ownerDocument || rootObject.document;
-const button = document?.createElement?.('button');
-if (!button) return;
-button.type = 'button';
-button.className = 'edvibe-batch-section-deletion-history';
-button.textContent = 'Open in history';
-button.addEventListener('click', () => openHistory?.(executionId));
-dialog.shadowRoot?.querySelector?.('footer')?.appendChild?.(button);
-}
-function createHistoryAwareFeature(options = {}) {
-const {
-createFeature = coreApi.createBatchSectionDeletionFeature,
-createDialog,
-persistExecution,
-getLocationHref = () => '',
-getMarathonName = () => null,
-now = () => new Date(),
-log = () => {},
-...featureOptions
-} = options;
-if (typeof createDialog !== 'function') throw new TypeError('createDialog is required');
-if (typeof persistExecution !== 'function') throw new TypeError('persistExecution is required');
-function createTrackedDialog() {
-const dialog = createDialog();
-const originalConfigure = dialog.configure.bind(dialog);
-let plan = null;
-let latestResult = null;
-let startedAt = null;
-let terminal = false;
-let sequence = 0;
-async function persist(result, terminalStatus = null, fatalError = null) {
-const currentSequence = sequence;
-try {
-const completedAt = now().toISOString();
-const input = buildExecutionHistoryInput({
-plan,
-result: result || latestResult || {},
-startedAt: startedAt || completedAt,
-completedAt,
-marathonId: parseMarathonId(getLocationHref()),
-marathonName: getMarathonName(),
-terminalStatus,
-fatalError
-});
-const history = await persistExecution(input);
-return currentSequence === sequence ? history : Object.freeze({ stored: false, stale: true });
-} catch (persistenceError) {
-log('Batch section deletion history persistence failed:', persistenceError);
-return Object.freeze({ stored: false, persistenceError });
-}
-}
-dialog.configure = (config = {}) => {
-const originalInspect = config.onInspect;
-const originalExecute = config.onExecute;
-const originalClose = config.onClose;
-const originalOpenHistory = config.onOpenHistory;
-return originalConfigure({
-...config,
-async onInspect(input) {
-const inspected = await originalInspect(input);
-sequence += 1;
-plan = enrichPlan(inspected, input?.selectedLessonIds || []);
-latestResult = { plan, results: [] };
-startedAt = now().toISOString();
-terminal = false;
-if (!plan.eligible.length) {
-terminal = true;
-void persist(latestResult).then((history) => {
-if (history?.stored) {
-appendStatus(dialog, 'Result saved to execution history.');
-if (history.record?.id) addHistoryButton(dialog, history.record.id, originalOpenHistory);
-} else if (history?.persistenceError) {
-appendStatus(dialog, 'The visible preflight is intact, but history could not be saved.');
-}
-});
-}
-return plan;
-},
-async onExecute(confirmedPlan, onProgress) {
-plan = enrichPlan(confirmedPlan, confirmedPlan.selectedLessonIds || []);
-startedAt = startedAt || now().toISOString();
-terminal = false;
-try {
-const result = await originalExecute(plan, (progress = {}) => {
-if (Array.isArray(progress.results)) latestResult = { plan, results: [...progress.results], fatalError: progress.fatalError || null };
-onProgress?.(progress);
-});
-latestResult = result;
-terminal = true;
-const history = await persist(result, result.fatalError ? 'interrupted' : null, result.fatalError || null);
-return { ...result, history };
-} catch (error) {
-terminal = true;
-await persist(latestResult, 'interrupted', error);
-throw error;
-}
-},
-onOpenHistory: originalOpenHistory,
-onClose() {
-if (plan && !terminal) {
-terminal = true;
-void persist(latestResult, 'cancelled');
-}
-originalClose?.();
-}
-});
-};
-return dialog;
-}
-return createFeature({ ...featureOptions, createDialog: createTrackedDialog, log });
-}
-function installHistoryAwareFeature(baseApi = coreApi) {
-return Object.freeze({
-...baseApi,
-createBatchSectionDeletionFeature(options = {}) {
-return createHistoryAwareFeature({
-...options,
-createFeature: baseApi.createBatchSectionDeletionFeature,
-getLocationHref: options.getLocationHref || (() => rootObject.location?.href || ''),
-getMarathonName: options.getMarathonName || (() => rootObject.document?.querySelector?.('h1')?.textContent?.trim() || rootObject.document?.title || null)
-});
-}
-});
-}
-return Object.freeze({
-OPERATION_TYPE,
-parseMarathonId,
-discoveryOutcome,
-enrichPlan,
-materializeResults,
-serializeResult,
-buildExecutionHistoryInput,
-createHistoryAwareFeature,
-installHistoryAwareFeature
-});
+    'use strict';
+
+    const OPERATION_TYPE = 'batch-section-deletion';
+    const TERMINAL_STATUSES = new Set([
+        'completed',
+        'completed_with_failures',
+        'cancelled',
+        'interrupted'
+    ]);
+    const ATTEMPTED_STATUSES = new Set(['deleted', 'failed']);
+
+    function text(value, fallback = '', maxLength = 1000) {
+        const normalized = String(value ?? '').trim();
+        if (!normalized) return fallback;
+        return normalized.length <= maxLength
+            ? normalized
+            : `${normalized.slice(0, maxLength - 1)}…`;
+    }
+
+    function parseMarathonId(url) {
+        const match = String(url || '').match(/\/marathon\/(\d+)(?:\/|$)/);
+        return match ? String(match[1]) : null;
+    }
+
+    function lessonKey(value) {
+        const id = value?.lessonId ?? value?.LessonId;
+        return id === undefined || id === null ? null : String(id);
+    }
+
+    function discoveryOutcome(entry = {}) {
+        if (entry.discoveryOutcome) {
+            return text(entry.discoveryOutcome, 'inspection_failed', 120);
+        }
+        return {
+            SECTION_NOT_FOUND: 'not_found',
+            SECTION_NAME_AMBIGUOUS: 'ambiguous',
+            UNSUPPORTED_SECTION_TYPE: 'unsupported_section_type',
+            INVALID_LESSON_RESPONSE: 'invalid_lesson_response'
+        }[entry.code] || (entry.sectionId ? 'matched' : 'inspection_failed');
+    }
+
+    function enrichPlan(plan = {}, selectedLessonIds = []) {
+        const sectionName = text(plan.sectionName, 'Unnamed section', 500);
+        const eligible = (plan.eligible || []).map((entry) => Object.freeze({
+            ...entry,
+            sectionName,
+            sectionType: 'normal',
+            discoveryOutcome: 'matched',
+            matchCount: 1
+        }));
+        const rejected = (plan.rejected || []).map((entry) => Object.freeze({
+            ...entry,
+            sectionName,
+            sectionId: null,
+            sectionType: null,
+            discoveryOutcome: discoveryOutcome(entry),
+            matchCount: entry.code === 'SECTION_NOT_FOUND' ? 0 : null,
+            attempts: 0
+        }));
+        return Object.freeze({
+            ...plan,
+            sectionName,
+            selectedLessonIds: Object.freeze([...selectedLessonIds]),
+            selectedCount: Number.isSafeInteger(plan.selectedCount)
+                ? plan.selectedCount
+                : selectedLessonIds.length,
+            eligible: Object.freeze(eligible),
+            rejected: Object.freeze(rejected)
+        });
+    }
+
+    function resultCode(entry, terminalStatus) {
+        if (entry.code) return text(entry.code, 'UNKNOWN_RESULT', 120);
+        if (entry.status === 'deleted') return 'DELETED';
+        if (entry.status === 'rejected') return 'PREFLIGHT_REJECTED';
+        if (entry.status === 'failed') return 'DELETE_FAILED';
+        return terminalStatus === 'cancelled'
+            ? 'OPERATION_CANCELLED'
+            : 'OPERATION_INTERRUPTED';
+    }
+
+    function resultMessage(entry, terminalStatus) {
+        if (entry.message) return text(entry.message, 'No message was provided.');
+        if (entry.status === 'deleted') return 'Section deleted.';
+        if (entry.status === 'rejected') return 'The lesson was rejected during discovery.';
+        if (entry.status === 'failed') return 'The validated deletion request failed.';
+        return terminalStatus === 'cancelled'
+            ? 'Not attempted because the confirmed run was cancelled.'
+            : 'Not attempted because the confirmed run was interrupted.';
+    }
+
+    function materializeResults(plan = {}, execution = {}, terminalStatus = null) {
+        const byId = new Map();
+        for (const entry of plan.rejected || []) {
+            byId.set(lessonKey(entry), { ...entry, status: 'rejected', attempts: 0 });
+        }
+        for (const entry of execution.results || []) {
+            byId.set(lessonKey(entry), { ...entry });
+        }
+        const eligible = new Map(
+            (plan.eligible || []).map((entry) => [lessonKey(entry), entry])
+        );
+        const ordered = [];
+        const included = new Set();
+
+        for (const id of plan.selectedLessonIds || []) {
+            const key = String(id);
+            let entry = byId.get(key);
+            if (!entry && eligible.has(key)) {
+                entry = {
+                    ...eligible.get(key),
+                    status: 'not_attempted',
+                    attempts: 0
+                };
+            }
+            if (!entry) {
+                entry = {
+                    lessonId: id,
+                    name: `Lesson ${id}`,
+                    status: 'not_attempted',
+                    attempts: 0,
+                    sectionName: plan.sectionName
+                };
+            }
+            ordered.push(entry);
+            included.add(key);
+        }
+
+        for (const entry of [...byId.values(), ...eligible.values()]) {
+            const key = lessonKey(entry);
+            if (key !== null && included.has(key)) continue;
+            ordered.push(byId.get(key) || {
+                ...entry,
+                status: 'not_attempted',
+                attempts: 0
+            });
+            if (key !== null) included.add(key);
+        }
+
+        return ordered.map((entry) => {
+            const status = text(entry.status, 'not_attempted', 80);
+            return {
+                ...entry,
+                status,
+                attempts: Number.isSafeInteger(entry.attempts) && entry.attempts >= 0
+                    ? entry.attempts
+                    : ATTEMPTED_STATUSES.has(status) ? 1 : 0,
+                terminalStatus
+            };
+        });
+    }
+
+    function matchCount(entry) {
+        if (Number.isSafeInteger(entry.matchCount) && entry.matchCount >= 0) {
+            return entry.matchCount;
+        }
+        if (entry.sectionId) return 1;
+        if (entry.code === 'SECTION_NOT_FOUND') return 0;
+        const match = String(entry.message || '').match(/Found (\d+) sections/);
+        return match ? Number(match[1]) : null;
+    }
+
+    function serializeResult(entry, plan, terminalStatus) {
+        const status = entry.status;
+        const code = resultCode(entry, terminalStatus);
+        const message = resultMessage(entry, terminalStatus);
+        const outcome = discoveryOutcome(entry);
+        const lesson = Object.freeze({
+            lessonId: entry.lessonId ?? null,
+            marathonLessonId: entry.marathonLessonId ?? null,
+            number: entry.number ?? null,
+            name: text(entry.name, 'Unnamed lesson', 500)
+        });
+        return Object.freeze({
+            itemId: lesson.lessonId === null ? null : `lesson-${lesson.lessonId}`,
+            label: `${lesson.number ?? '?'}. ${lesson.name}`,
+            status,
+            code,
+            message,
+            attempts: entry.attempts,
+            data: Object.freeze({
+                lesson,
+                section: Object.freeze({
+                    requestedName: text(
+                        entry.sectionName || plan.sectionName,
+                        'Unnamed section',
+                        500
+                    ),
+                    matchedId: entry.sectionId ?? null,
+                    supportedType: entry.sectionId ? 'normal' : null
+                }),
+                discovery: Object.freeze({
+                    outcome,
+                    code: outcome === 'matched' ? 'DISCOVERY_MATCHED' : code,
+                    message: outcome === 'matched'
+                        ? 'Exactly one supported normal lesson section matched the requested name.'
+                        : message,
+                    matchCount: matchCount(entry)
+                }),
+                finalOutcome: status,
+                deletionFailure: status === 'failed'
+                    ? Object.freeze({ code, message, attemptCount: entry.attempts })
+                    : null
+            })
+        });
+    }
+
+    function inferTerminalStatus(explicitStatus, fatalError, results) {
+        if (TERMINAL_STATUSES.has(explicitStatus)) return explicitStatus;
+        if (fatalError) return 'interrupted';
+        return results.some((entry) => [
+            'rejected',
+            'failed',
+            'not_attempted'
+        ].includes(entry.status))
+            ? 'completed_with_failures'
+            : 'completed';
+    }
+
+    function buildExecutionHistoryInput({
+        plan,
+        result = {},
+        startedAt,
+        completedAt,
+        marathonId,
+        marathonName = null,
+        terminalStatus = null,
+        fatalError = null
+    }) {
+        const materializationStatus = TERMINAL_STATUSES.has(terminalStatus)
+            ? terminalStatus
+            : fatalError || result.fatalError ? 'interrupted' : null;
+        const materialized = materializeResults(plan, result, materializationStatus);
+        const results = materialized.map((entry) => serializeResult(
+            entry,
+            plan,
+            materializationStatus
+        ));
+        const status = inferTerminalStatus(
+            terminalStatus,
+            fatalError || result.fatalError,
+            results
+        );
+        const attempted = results.filter((entry) => (
+            ATTEMPTED_STATUSES.has(entry.status)
+        )).length;
+        const notAttempted = results.filter((entry) => (
+            entry.status === 'not_attempted'
+        )).length;
+        const counts = Object.freeze({
+            requested: results.length,
+            eligible: Math.max(plan.eligible?.length || 0, attempted + notAttempted),
+            attempted,
+            successful: results.filter((entry) => entry.status === 'deleted').length,
+            noOp: 0,
+            skipped: results.filter((entry) => entry.status === 'rejected').length,
+            failed: results.filter((entry) => entry.status === 'failed').length,
+            notAttempted
+        });
+        return Object.freeze({
+            operationType: OPERATION_TYPE,
+            startedAt,
+            completedAt,
+            status,
+            pageContext: Object.freeze({ marathonId, marathonName }),
+            counts,
+            results: Object.freeze(results),
+            message: JSON.stringify({ sectionName: plan.sectionName, counts })
+        });
+    }
+
+    function appendStatus(dialog, message) {
+        const status = dialog.shadowRoot?.querySelector?.('.status');
+        const current = status?.textContent || '';
+        dialog.showStatus?.(`${current}${current ? ' ' : ''}${message}`);
+    }
+
+    function addHistoryButton(dialog, executionId, openHistory) {
+        const document = dialog.ownerDocument || rootObject.document;
+        const button = document?.createElement?.('button');
+        if (!button) return;
+        button.type = 'button';
+        button.className = 'edvibe-batch-section-deletion-history';
+        button.textContent = 'Open in history';
+        button.addEventListener('click', () => openHistory?.(executionId));
+        dialog.shadowRoot?.querySelector?.('footer')?.appendChild?.(button);
+    }
+
+    function createHistoryAwareFeature(options = {}) {
+        const {
+            createFeature = coreApi.createBatchSectionDeletionFeature,
+            createDialog,
+            persistExecution,
+            getLocationHref = () => '',
+            getMarathonName = () => null,
+            now = () => new Date(),
+            log = () => {},
+            ...featureOptions
+        } = options;
+        if (typeof createDialog !== 'function') {
+            throw new TypeError('createDialog is required');
+        }
+        if (typeof persistExecution !== 'function') {
+            throw new TypeError('persistExecution is required');
+        }
+
+        function createTrackedDialog() {
+            const dialog = createDialog();
+            const originalConfigure = dialog.configure.bind(dialog);
+            let plan = null;
+            let latestResult = null;
+            let startedAt = null;
+            let terminal = false;
+            let sequence = 0;
+
+            async function persist(result, terminalStatus = null, fatalError = null) {
+                const currentSequence = sequence;
+                try {
+                    const completedAt = now().toISOString();
+                    const input = buildExecutionHistoryInput({
+                        plan,
+                        result: result || latestResult || {},
+                        startedAt: startedAt || completedAt,
+                        completedAt,
+                        marathonId: parseMarathonId(getLocationHref()),
+                        marathonName: getMarathonName(),
+                        terminalStatus,
+                        fatalError
+                    });
+                    const history = await persistExecution(input);
+                    return currentSequence === sequence
+                        ? history
+                        : Object.freeze({ stored: false, stale: true });
+                } catch (persistenceError) {
+                    log(
+                        'Batch section deletion history persistence failed:',
+                        persistenceError
+                    );
+                    return Object.freeze({ stored: false, persistenceError });
+                }
+            }
+
+            dialog.configure = (config = {}) => {
+                const originalInspect = config.onInspect;
+                const originalExecute = config.onExecute;
+                const originalClose = config.onClose;
+                const originalOpenHistory = config.onOpenHistory;
+                return originalConfigure({
+                    ...config,
+                    async onInspect(input) {
+                        const inspected = await originalInspect(input);
+                        sequence += 1;
+                        plan = enrichPlan(inspected, input?.selectedLessonIds || []);
+                        latestResult = { plan, results: [] };
+                        startedAt = now().toISOString();
+                        terminal = false;
+                        if (!plan.eligible.length) {
+                            terminal = true;
+                            void persist(latestResult).then((history) => {
+                                if (history?.stored) {
+                                    appendStatus(
+                                        dialog,
+                                        'Result saved to execution history.'
+                                    );
+                                    if (history.record?.id) {
+                                        addHistoryButton(
+                                            dialog,
+                                            history.record.id,
+                                            originalOpenHistory
+                                        );
+                                    }
+                                } else if (history?.persistenceError) {
+                                    appendStatus(
+                                        dialog,
+                                        'The visible preflight is intact, but history could not be saved.'
+                                    );
+                                }
+                            });
+                        }
+                        return plan;
+                    },
+                    async onExecute(confirmedPlan, onProgress) {
+                        plan = enrichPlan(
+                            confirmedPlan,
+                            confirmedPlan.selectedLessonIds || []
+                        );
+                        startedAt = startedAt || now().toISOString();
+                        terminal = false;
+                        try {
+                            const result = await originalExecute(
+                                plan,
+                                (progress = {}) => {
+                                    if (Array.isArray(progress.results)) {
+                                        latestResult = {
+                                            plan,
+                                            results: [...progress.results],
+                                            fatalError: progress.fatalError || null
+                                        };
+                                    }
+                                    onProgress?.(progress);
+                                }
+                            );
+                            latestResult = result;
+                            terminal = true;
+                            const history = await persist(
+                                result,
+                                result.fatalError ? 'interrupted' : null,
+                                result.fatalError || null
+                            );
+                            return { ...result, history };
+                        } catch (error) {
+                            terminal = true;
+                            await persist(latestResult, 'interrupted', error);
+                            throw error;
+                        }
+                    },
+                    onOpenHistory: originalOpenHistory,
+                    onClose() {
+                        if (plan && !terminal) {
+                            terminal = true;
+                            void persist(latestResult, 'cancelled');
+                        }
+                        originalClose?.();
+                    }
+                });
+            };
+            return dialog;
+        }
+
+        return createFeature({
+            ...featureOptions,
+            createDialog: createTrackedDialog,
+            log
+        });
+    }
+
+    function installHistoryAwareFeature(baseApi = coreApi) {
+        return Object.freeze({
+            ...baseApi,
+            createBatchSectionDeletionFeature(options = {}) {
+                return createHistoryAwareFeature({
+                    ...options,
+                    createFeature: baseApi.createBatchSectionDeletionFeature,
+                    getLocationHref: options.getLocationHref
+                        || (() => rootObject.location?.href || ''),
+                    getMarathonName: options.getMarathonName
+                        || (() => (
+                            rootObject.document?.querySelector?.('h1')?.textContent?.trim()
+                            || rootObject.document?.title
+                            || null
+                        ))
+                });
+            }
+        });
+    }
+
+    return Object.freeze({
+        OPERATION_TYPE,
+        parseMarathonId,
+        discoveryOutcome,
+        enrichPlan,
+        materializeResults,
+        serializeResult,
+        buildExecutionHistoryInput,
+        createHistoryAwareFeature,
+        installHistoryAwareFeature
+    });
 });

--- a/src/features/batch-section-deletion-history.test.js
+++ b/src/features/batch-section-deletion-history.test.js
@@ -1,26 +1,158 @@
+'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const api = require('./batch-section-deletion.js');
-const recordApi = require('../shared/execution-history-record.js');
+const history = require('./batch-section-deletion-history.js');
+function createFakeDialog() {
+const status = { textContent: '', hidden: false };
+const footer = { appendChild() {} };
+return {
+status,
+options: null,
+shadowRoot: {
+querySelector(selector) {
+if (selector === '.status') return status;
+if (selector === 'footer') return footer;
+return null;
+}
+},
+ownerDocument: { createElement: () => null },
+configure(options) { this.options = options; return this; },
+showStatus(message) { status.textContent = message; }
+};
+}
+function samplePlan(overrides = {}) {
+const eligible = [{
+lessonId: 1,
+marathonLessonId: 11,
+number: 1,
+name: 'Welcome',
+sectionName: 'Promo',
+sectionId: 101,
+sectionType: 'normal',
+discoveryOutcome: 'matched'
+}];
+return {
+sectionName: 'Promo',
+selectedLessonIds: [1],
+selectedCount: 1,
+eligible,
+rejected: [],
+...overrides
+};
+}
+function createHarness(options = {}) {
+const dialog = createFakeDialog();
+const feature = history.createHistoryAwareFeature({
+createFeature: ({ createDialog }) => ({ dialog: createDialog() }),
+createDialog: () => dialog,
+persistExecution: options.persistExecution || (async () => ({ stored: true, record: { id: 'history-1' } })),
+getLocationHref: () => 'https://app.edvibe.com/marathon/77',
+getMarathonName: () => 'Autumn course',
+now: () => new Date('2026-08-06T10:00:00.000Z'),
+log: options.log || (() => {})
+});
+let closed = false;
+dialog.configure({
+async onInspect() { return options.plan || samplePlan(); },
+async onExecute(plan, onProgress) {
+const result = options.result || {
+plan,
+results: [{ ...plan.eligible[0], status: 'deleted', code: 'SECTION_DELETED', message: 'Deleted.', attempts: 1 }],
+fatalError: null,
+report: 'visible report'
+};
+onProgress?.({ results: result.results, fatalError: result.fatalError });
+return result;
+},
+onClose() { closed = true; }
+});
+return { dialog, feature, isClosed: () => closed };
+}
+test('persistence failure stays separate from and does not erase the visible result', async () => {
+const logs = [];
+const { dialog } = createHarness({
+persistExecution: async () => { throw new Error('database unavailable'); },
+log: (...args) => logs.push(args)
+});
+const plan = await dialog.options.onInspect({});
+const result = await dialog.options.onExecute(plan, () => {});
+assert.equal(result.report, 'visible report');
+assert.equal(result.history.stored, false);
+assert.equal(result.history.persistenceError.message, 'database unavailable');
+assert.equal(logs.length, 1);
+});
+test('successful terminal persistence is returned for the built-in history link', async () => {
+const persisted = [];
+const { dialog } = createHarness({
+persistExecution: async (input) => {
+persisted.push(input);
+return { stored: true, record: { id: 'history-42' } };
+}
+});
+const plan = await dialog.options.onInspect({});
+const result = await dialog.options.onExecute(plan, () => {});
+assert.equal(result.history.record.id, 'history-42');
+assert.equal(persisted[0].operationType, 'batch-section-deletion');
+assert.equal(persisted[0].status, 'completed');
+});
+test('closing an inspected immutable plan persists cancellation', async () => {
+const persisted = [];
+const { dialog, isClosed } = createHarness({
+persistExecution: async (input) => {
+persisted.push(input);
+return { stored: true };
+}
+});
+await dialog.options.onInspect({});
+dialog.options.onClose();
+await new Promise((resolve) => setImmediate(resolve));
+assert.equal(isClosed(), true);
+assert.equal(persisted[0].status, 'cancelled');
+assert.equal(persisted[0].results[0].status, 'not_attempted');
+assert.equal(persisted[0].results[0].attempts, 0);
+});
+test('all-rejected discovery is persisted as a terminal mixed-failure record', async () => {
+const rejected = {
+lessonId: 1,
+marathonLessonId: 11,
+number: 1,
+name: 'Welcome',
+sectionName: 'Promo',
+discoveryOutcome: 'not_found',
+status: 'rejected',
+code: 'SECTION_NOT_FOUND',
+message: 'Not found.',
+attempts: 0
+};
+const persisted = [];
+const { dialog } = createHarness({
+plan: samplePlan({ eligible: [], rejected: [rejected] }),
+persistExecution: async (input) => {
+persisted.push(input);
+return { stored: true, record: { id: 'history-rejected' } };
+}
+});
+await dialog.options.onInspect({});
+await new Promise((resolve) => setImmediate(resolve));
+assert.equal(persisted.length, 1);
+assert.equal(persisted[0].status, 'completed_with_failures');
+assert.equal(persisted[0].results[0].status, 'rejected');
+assert.match(dialog.status.textContent, /saved to execution history/i);
+});
 
-test('maps a representative batch result into the shared canonical contract', () => {
-    const plan = { sectionName: 'Archive', selectedCount: 3, eligible: [{ lessonId: 1 }, { lessonId: 2 }], rejected: [{ lessonId: 3 }] };
-    const input = api.buildExecutionHistoryInput({
-        marathonId: 42,
-        startedAt: '2026-08-06T04:00:00.000Z',
-        completedAt: '2026-08-06T04:01:00.000Z',
-        result: {
-            plan,
-            fatalError: null,
-            results: [
-                { lessonId: 3, marathonLessonId: 30, number: 3, name: 'Three', status: 'rejected', code: 'SECTION_NOT_FOUND', message: 'Missing.' },
-                { lessonId: 1, marathonLessonId: 10, number: 1, name: 'One', sectionId: 100, status: 'deleted', code: 'DELETED', message: 'Deleted.' },
-                { lessonId: 2, marathonLessonId: 20, number: 2, name: 'Two', sectionId: 200, status: 'failed', code: 'SERVER_REJECTED', message: 'Rejected.' }
-            ]
-        }
-    });
-    const record = recordApi.buildExecutionRecord(input, { cryptoApi: { randomUUID: () => 'history-1' } });
-    assert.equal(record.status, 'completed_with_failures');
-    assert.deepEqual(record.counts, { requested: 3, eligible: 2, attempted: 2, successful: 1, noOp: 0, skipped: 1, failed: 1, notAttempted: 0 });
-    assert.deepEqual(record.results.map((item) => item.code), ['SECTION_NOT_FOUND', 'DELETED', 'SERVER_REJECTED']);
+test('installed API preserves core exports and upgrades the existing factory wiring', () => {
+const originalDialog = () => createFakeDialog();
+const baseApi = {
+marker: 'core-export',
+createBatchSectionDeletionFeature(options) { return options; }
+};
+const installed = history.installHistoryAwareFeature(baseApi);
+const wired = installed.createBatchSectionDeletionFeature({
+createDialog: originalDialog,
+persistExecution: async () => ({ stored: true })
+});
+assert.equal(installed.marker, 'core-export');
+assert.notEqual(installed.createBatchSectionDeletionFeature, baseApi.createBatchSectionDeletionFeature);
+assert.equal(wired.persistExecution, undefined);
+assert.notEqual(wired.createDialog, originalDialog);
 });

--- a/src/features/batch-section-deletion-history.test.js
+++ b/src/features/batch-section-deletion-history.test.js
@@ -1,158 +1,197 @@
 'use strict';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const history = require('./batch-section-deletion-history.js');
+
 function createFakeDialog() {
-const status = { textContent: '', hidden: false };
-const footer = { appendChild() {} };
-return {
-status,
-options: null,
-shadowRoot: {
-querySelector(selector) {
-if (selector === '.status') return status;
-if (selector === 'footer') return footer;
-return null;
+    const status = { textContent: '', hidden: false };
+    const footer = { appendChild() {} };
+    return {
+        status,
+        options: null,
+        shadowRoot: {
+            querySelector(selector) {
+                if (selector === '.status') return status;
+                if (selector === 'footer') return footer;
+                return null;
+            }
+        },
+        ownerDocument: { createElement: () => null },
+        configure(options) {
+            this.options = options;
+            return this;
+        },
+        showStatus(message) {
+            status.textContent = message;
+        }
+    };
 }
-},
-ownerDocument: { createElement: () => null },
-configure(options) { this.options = options; return this; },
-showStatus(message) { status.textContent = message; }
-};
-}
+
 function samplePlan(overrides = {}) {
-const eligible = [{
-lessonId: 1,
-marathonLessonId: 11,
-number: 1,
-name: 'Welcome',
-sectionName: 'Promo',
-sectionId: 101,
-sectionType: 'normal',
-discoveryOutcome: 'matched'
-}];
-return {
-sectionName: 'Promo',
-selectedLessonIds: [1],
-selectedCount: 1,
-eligible,
-rejected: [],
-...overrides
-};
+    const eligible = [{
+        lessonId: 1,
+        marathonLessonId: 11,
+        number: 1,
+        name: 'Welcome',
+        sectionName: 'Promo',
+        sectionId: 101,
+        sectionType: 'normal',
+        discoveryOutcome: 'matched'
+    }];
+    return {
+        sectionName: 'Promo',
+        selectedLessonIds: [1],
+        selectedCount: 1,
+        eligible,
+        rejected: [],
+        ...overrides
+    };
 }
+
 function createHarness(options = {}) {
-const dialog = createFakeDialog();
-const feature = history.createHistoryAwareFeature({
-createFeature: ({ createDialog }) => ({ dialog: createDialog() }),
-createDialog: () => dialog,
-persistExecution: options.persistExecution || (async () => ({ stored: true, record: { id: 'history-1' } })),
-getLocationHref: () => 'https://app.edvibe.com/marathon/77',
-getMarathonName: () => 'Autumn course',
-now: () => new Date('2026-08-06T10:00:00.000Z'),
-log: options.log || (() => {})
-});
-let closed = false;
-dialog.configure({
-async onInspect() { return options.plan || samplePlan(); },
-async onExecute(plan, onProgress) {
-const result = options.result || {
-plan,
-results: [{ ...plan.eligible[0], status: 'deleted', code: 'SECTION_DELETED', message: 'Deleted.', attempts: 1 }],
-fatalError: null,
-report: 'visible report'
-};
-onProgress?.({ results: result.results, fatalError: result.fatalError });
-return result;
-},
-onClose() { closed = true; }
-});
-return { dialog, feature, isClosed: () => closed };
+    const dialog = createFakeDialog();
+    const feature = history.createHistoryAwareFeature({
+        createFeature: ({ createDialog }) => ({ dialog: createDialog() }),
+        createDialog: () => dialog,
+        persistExecution: options.persistExecution
+            || (async () => ({ stored: true, record: { id: 'history-1' } })),
+        getLocationHref: () => 'https://app.edvibe.com/marathon/77',
+        getMarathonName: () => 'Autumn course',
+        now: () => new Date('2026-08-06T10:00:00.000Z'),
+        log: options.log || (() => {})
+    });
+    let closed = false;
+    dialog.configure({
+        async onInspect() {
+            return options.plan || samplePlan();
+        },
+        async onExecute(plan, onProgress) {
+            const result = options.result || {
+                plan,
+                results: [{
+                    ...plan.eligible[0],
+                    status: 'deleted',
+                    code: 'SECTION_DELETED',
+                    message: 'Deleted.',
+                    attempts: 1
+                }],
+                fatalError: null,
+                report: 'visible report'
+            };
+            onProgress?.({
+                results: result.results,
+                fatalError: result.fatalError
+            });
+            return result;
+        },
+        onClose() {
+            closed = true;
+        }
+    });
+    return { dialog, feature, isClosed: () => closed };
 }
+
 test('persistence failure stays separate from and does not erase the visible result', async () => {
-const logs = [];
-const { dialog } = createHarness({
-persistExecution: async () => { throw new Error('database unavailable'); },
-log: (...args) => logs.push(args)
+    const logs = [];
+    const { dialog } = createHarness({
+        persistExecution: async () => {
+            throw new Error('database unavailable');
+        },
+        log: (...args) => logs.push(args)
+    });
+    const plan = await dialog.options.onInspect({});
+    const result = await dialog.options.onExecute(plan, () => {});
+
+    assert.equal(result.report, 'visible report');
+    assert.equal(result.history.stored, false);
+    assert.equal(result.history.persistenceError.message, 'database unavailable');
+    assert.equal(logs.length, 1);
 });
-const plan = await dialog.options.onInspect({});
-const result = await dialog.options.onExecute(plan, () => {});
-assert.equal(result.report, 'visible report');
-assert.equal(result.history.stored, false);
-assert.equal(result.history.persistenceError.message, 'database unavailable');
-assert.equal(logs.length, 1);
-});
+
 test('successful terminal persistence is returned for the built-in history link', async () => {
-const persisted = [];
-const { dialog } = createHarness({
-persistExecution: async (input) => {
-persisted.push(input);
-return { stored: true, record: { id: 'history-42' } };
-}
+    const persisted = [];
+    const { dialog } = createHarness({
+        persistExecution: async (input) => {
+            persisted.push(input);
+            return { stored: true, record: { id: 'history-42' } };
+        }
+    });
+    const plan = await dialog.options.onInspect({});
+    const result = await dialog.options.onExecute(plan, () => {});
+
+    assert.equal(result.history.record.id, 'history-42');
+    assert.equal(persisted[0].operationType, 'batch-section-deletion');
+    assert.equal(persisted[0].status, 'completed');
 });
-const plan = await dialog.options.onInspect({});
-const result = await dialog.options.onExecute(plan, () => {});
-assert.equal(result.history.record.id, 'history-42');
-assert.equal(persisted[0].operationType, 'batch-section-deletion');
-assert.equal(persisted[0].status, 'completed');
-});
+
 test('closing an inspected immutable plan persists cancellation', async () => {
-const persisted = [];
-const { dialog, isClosed } = createHarness({
-persistExecution: async (input) => {
-persisted.push(input);
-return { stored: true };
-}
+    const persisted = [];
+    const { dialog, isClosed } = createHarness({
+        persistExecution: async (input) => {
+            persisted.push(input);
+            return { stored: true };
+        }
+    });
+    await dialog.options.onInspect({});
+    dialog.options.onClose();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(isClosed(), true);
+    assert.equal(persisted[0].status, 'cancelled');
+    assert.equal(persisted[0].results[0].status, 'not_attempted');
+    assert.equal(persisted[0].results[0].attempts, 0);
 });
-await dialog.options.onInspect({});
-dialog.options.onClose();
-await new Promise((resolve) => setImmediate(resolve));
-assert.equal(isClosed(), true);
-assert.equal(persisted[0].status, 'cancelled');
-assert.equal(persisted[0].results[0].status, 'not_attempted');
-assert.equal(persisted[0].results[0].attempts, 0);
-});
+
 test('all-rejected discovery is persisted as a terminal mixed-failure record', async () => {
-const rejected = {
-lessonId: 1,
-marathonLessonId: 11,
-number: 1,
-name: 'Welcome',
-sectionName: 'Promo',
-discoveryOutcome: 'not_found',
-status: 'rejected',
-code: 'SECTION_NOT_FOUND',
-message: 'Not found.',
-attempts: 0
-};
-const persisted = [];
-const { dialog } = createHarness({
-plan: samplePlan({ eligible: [], rejected: [rejected] }),
-persistExecution: async (input) => {
-persisted.push(input);
-return { stored: true, record: { id: 'history-rejected' } };
-}
-});
-await dialog.options.onInspect({});
-await new Promise((resolve) => setImmediate(resolve));
-assert.equal(persisted.length, 1);
-assert.equal(persisted[0].status, 'completed_with_failures');
-assert.equal(persisted[0].results[0].status, 'rejected');
-assert.match(dialog.status.textContent, /saved to execution history/i);
+    const rejected = {
+        lessonId: 1,
+        marathonLessonId: 11,
+        number: 1,
+        name: 'Welcome',
+        sectionName: 'Promo',
+        discoveryOutcome: 'not_found',
+        status: 'rejected',
+        code: 'SECTION_NOT_FOUND',
+        message: 'Not found.',
+        attempts: 0
+    };
+    const persisted = [];
+    const { dialog } = createHarness({
+        plan: samplePlan({ eligible: [], rejected: [rejected] }),
+        persistExecution: async (input) => {
+            persisted.push(input);
+            return { stored: true, record: { id: 'history-rejected' } };
+        }
+    });
+    await dialog.options.onInspect({});
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(persisted.length, 1);
+    assert.equal(persisted[0].status, 'completed_with_failures');
+    assert.equal(persisted[0].results[0].status, 'rejected');
+    assert.match(dialog.status.textContent, /saved to execution history/i);
 });
 
 test('installed API preserves core exports and upgrades the existing factory wiring', () => {
-const originalDialog = () => createFakeDialog();
-const baseApi = {
-marker: 'core-export',
-createBatchSectionDeletionFeature(options) { return options; }
-};
-const installed = history.installHistoryAwareFeature(baseApi);
-const wired = installed.createBatchSectionDeletionFeature({
-createDialog: originalDialog,
-persistExecution: async () => ({ stored: true })
-});
-assert.equal(installed.marker, 'core-export');
-assert.notEqual(installed.createBatchSectionDeletionFeature, baseApi.createBatchSectionDeletionFeature);
-assert.equal(wired.persistExecution, undefined);
-assert.notEqual(wired.createDialog, originalDialog);
+    const originalDialog = () => createFakeDialog();
+    const baseApi = {
+        marker: 'core-export',
+        createBatchSectionDeletionFeature(options) {
+            return options;
+        }
+    };
+    const installed = history.installHistoryAwareFeature(baseApi);
+    const wired = installed.createBatchSectionDeletionFeature({
+        createDialog: originalDialog,
+        persistExecution: async () => ({ stored: true })
+    });
+
+    assert.equal(installed.marker, 'core-export');
+    assert.notEqual(
+        installed.createBatchSectionDeletionFeature,
+        baseApi.createBatchSectionDeletionFeature
+    );
+    assert.equal(wired.persistExecution, undefined);
+    assert.notEqual(wired.createDialog, originalDialog);
 });


### PR DESCRIPTION
## What changed
- wrap batch section deletion with a terminal execution-history lifecycle
- persist per-lesson discovery, matched normal-section identity, final outcomes, stable codes/messages, and retry-aware attempt counts
- record all-rejected, mixed, interrupted, and cancelled runs while keeping persistence failures separate
- wire the history wrapper through the extension manifest and add focused model/lifecycle coverage

## Why
Issue #7 needs audit-safe records built from immutable plans and execution results without storing raw lesson payloads, WebSocket data, or session-shaped values.

## Validation
- `node --test src/features/batch-section-deletion-history-record.test.js src/features/batch-section-deletion-history.test.js`
- `node -c src/features/batch-section-deletion-history.js`
- `node -c src/main.js`
- `python -m json.tool manifest.json`

The focused suite passes with 10 tests. The full repository suite was not available in the partial local workspace, so GitHub Actions remains the source of truth for full integration.

Closes #7