### PR TITLE
Add browser-based component testing infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "vite build --watch --mode development",
     "build": "vite build",
     "test": "node --require ./test-path-compat.cjs --test \"src/**/*.test.js\"",
-    "test:ci": "npm test"
+    "test:components": "node scripts/run-component-tests.mjs",
+    "test:ci": "npm test && npm run test:components"
   },
   "dependencies": {
     "jszip": "3.10.1",

--- a/scripts/run-component-tests.mjs
+++ b/scripts/run-component-tests.mjs
@@ -1,0 +1,134 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = fileURLToPath(new URL('../', import.meta.url));
+const testPage = '/src/component-tests/index.html';
+const mimeTypes = new Map([
+    ['.html', 'text/html; charset=utf-8'],
+    ['.js', 'text/javascript; charset=utf-8'],
+    ['.mjs', 'text/javascript; charset=utf-8'],
+    ['.css', 'text/css; charset=utf-8'],
+    ['.json', 'application/json; charset=utf-8']
+]);
+
+function browserCandidates() {
+    return [
+        process.env.CHROME_BIN,
+        process.env.CHROME_PATH,
+        'google-chrome-stable',
+        'google-chrome',
+        'chromium',
+        'chromium-browser',
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        process.env.PROGRAMFILES
+            ? `${process.env.PROGRAMFILES}\\Google\\Chrome\\Application\\chrome.exe`
+            : null,
+        process.env['PROGRAMFILES(X86)']
+            ? `${process.env['PROGRAMFILES(X86)']}\\Google\\Chrome\\Application\\chrome.exe`
+            : null
+    ].filter(Boolean);
+}
+
+function findBrowser() {
+    for (const candidate of browserCandidates()) {
+        const result = spawnSync(candidate, ['--version'], {
+            encoding: 'utf-8',
+            stdio: 'ignore'
+        });
+        if (!result.error && result.status === 0) {
+            return candidate;
+        }
+    }
+    throw new Error(
+        'Chrome or Chromium is required for component tests. Set CHROME_BIN to the browser executable.'
+    );
+}
+
+function createStaticServer() {
+    return createServer(async (request, response) => {
+        try {
+            const requestUrl = new URL(request.url || '/', 'http://localhost');
+            const pathname = requestUrl.pathname === '/' ? testPage : requestUrl.pathname;
+            const relativePath = decodeURIComponent(pathname).replace(/^\/+/, '');
+            const filePath = resolve(repositoryRoot, relativePath);
+            if (!filePath.startsWith(repositoryRoot)) {
+                response.writeHead(403).end('Forbidden');
+                return;
+            }
+
+            const body = await readFile(filePath);
+            response.writeHead(200, {
+                'Content-Type': mimeTypes.get(extname(filePath)) || 'application/octet-stream',
+                'Cache-Control': 'no-store'
+            });
+            response.end(body);
+        } catch (error) {
+            response.writeHead(404, {'Content-Type': 'text/plain; charset=utf-8'});
+            response.end(String(error?.message || error));
+        }
+    });
+}
+
+function runBrowser(browser, url) {
+    return new Promise((resolveRun, rejectRun) => {
+        const child = spawn(browser, [
+            '--headless=new',
+            '--disable-gpu',
+            '--disable-dev-shm-usage',
+            '--no-sandbox',
+            '--dump-dom',
+            '--virtual-time-budget=5000',
+            url
+        ], {stdio: ['ignore', 'pipe', 'pipe']});
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf-8');
+        child.stderr.setEncoding('utf-8');
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+        const timeout = setTimeout(() => {
+            child.kill('SIGKILL');
+            rejectRun(new Error('Component tests timed out after 15 seconds.'));
+        }, 15_000);
+
+        child.on('error', (error) => {
+            clearTimeout(timeout);
+            rejectRun(error);
+        });
+        child.on('close', (code) => {
+            clearTimeout(timeout);
+            if (code !== 0) {
+                rejectRun(new Error(`Browser exited with code ${code}.\n${stderr}`));
+                return;
+            }
+            resolveRun({stdout, stderr});
+        });
+    });
+}
+
+const server = createStaticServer();
+try {
+    const browser = findBrowser();
+    await new Promise((resolveListen, rejectListen) => {
+        server.once('error', rejectListen);
+        server.listen(0, '127.0.0.1', resolveListen);
+    });
+
+    const address = server.address();
+    const url = `http://127.0.0.1:${address.port}${testPage}`;
+    const {stdout, stderr} = await runBrowser(browser, url);
+    if (!stdout.includes('data-test-status="passed"')) {
+        const failure = stdout.match(/<pre id="test-result">([\s\S]*?)<\/pre>/)?.[1];
+        throw new Error(
+            `Component tests failed${failure ? `: ${failure}` : '.'}\n${stderr}`
+        );
+    }
+    console.log(`Component tests passed in ${browser}.`);
+} finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+}

--- a/src/component-tests/browser-fixture-element.js
+++ b/src/component-tests/browser-fixture-element.js
@@ -1,0 +1,29 @@
+class BrowserFixtureElement extends HTMLElement {
+    static observedAttributes = ['label'];
+
+    constructor() {
+        super();
+        this.attachShadow({mode: 'open'});
+    }
+
+    connectedCallback() {
+        this.render();
+    }
+
+    attributeChangedCallback() {
+        if (this.isConnected) {
+            this.render();
+        }
+    }
+
+    render() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = this.getAttribute('label') || 'Run';
+        this.shadowRoot.replaceChildren(button);
+    }
+}
+
+if (!customElements.get('browser-fixture-element')) {
+    customElements.define('browser-fixture-element', BrowserFixtureElement);
+}

--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -1,0 +1,45 @@
+import './browser-fixture-element.js';
+import {
+    assert,
+    cleanup,
+    click,
+    elementUpdated,
+    equal,
+    fixture,
+    keydown,
+    shadowQuery
+} from './component-test-harness.js';
+
+async function run() {
+    const element = await fixture('<browser-fixture-element label="Initial"></browser-fixture-element>');
+    assert(element instanceof HTMLElement, 'Fixture should mount a real custom element.');
+    assert(element.shadowRoot instanceof ShadowRoot, 'Fixture should expose a real ShadowRoot.');
+    equal(shadowQuery(element, 'button').textContent, 'Initial');
+
+    let clicks = 0;
+    let lastKey = null;
+    const button = shadowQuery(element, 'button');
+    button.addEventListener('click', () => { clicks += 1; });
+    button.addEventListener('keydown', (event) => { lastKey = event.key; });
+    click(button);
+    keydown(button, 'Enter');
+    equal(clicks, 1, 'Mouse interaction helper should dispatch a browser click event.');
+    equal(lastKey, 'Enter', 'Keyboard interaction helper should dispatch a browser keyboard event.');
+
+    element.setAttribute('label', 'Updated');
+    await elementUpdated(element);
+    equal(shadowQuery(element, 'button').textContent, 'Updated');
+
+    await cleanup();
+    equal(element.isConnected, false, 'cleanup() should remove mounted fixtures.');
+}
+
+try {
+    await run();
+    document.documentElement.dataset.testStatus = 'passed';
+    document.querySelector('#test-result').textContent = 'PASS';
+} catch (error) {
+    document.documentElement.dataset.testStatus = 'failed';
+    document.querySelector('#test-result').textContent = error?.stack || String(error);
+    console.error(error);
+}

--- a/src/component-tests/component-test-harness.js
+++ b/src/component-tests/component-test-harness.js
@@ -1,0 +1,69 @@
+const fixtures = new Set();
+
+export async function fixture(markup) {
+    const template = document.createElement('template');
+    template.innerHTML = markup.trim();
+    const element = template.content.firstElementChild;
+    if (!element) {
+        throw new Error('fixture() requires markup with a root element.');
+    }
+
+    document.body.append(element);
+    fixtures.add(element);
+    await elementUpdated(element);
+    return element;
+}
+
+export async function elementUpdated(element) {
+    if (element?.updateComplete && typeof element.updateComplete.then === 'function') {
+        await element.updateComplete;
+    } else {
+        await Promise.resolve();
+    }
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+export function shadowQuery(element, selector) {
+    const match = element?.shadowRoot?.querySelector(selector);
+    if (!match) {
+        throw new Error(`Expected ${selector} in the component shadow root.`);
+    }
+    return match;
+}
+
+export function click(element) {
+    element.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        composed: true,
+        cancelable: true
+    }));
+}
+
+export function keydown(element, key) {
+    element.dispatchEvent(new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        composed: true,
+        cancelable: true
+    }));
+}
+
+export async function cleanup() {
+    for (const element of fixtures) {
+        element.remove();
+    }
+    fixtures.clear();
+    await Promise.resolve();
+}
+
+export function assert(condition, message = 'Expected condition to be truthy.') {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+export function equal(actual, expected, message) {
+    if (!Object.is(actual, expected)) {
+        throw new Error(message || `Expected ${String(actual)} to equal ${String(expected)}.`);
+    }
+}

--- a/src/component-tests/index.html
+++ b/src/component-tests/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Component tests</title>
+</head>
+<body>
+    <pre id="test-result">RUNNING</pre>
+    <script type="module" src="./browser-tests.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a committed real-browser component test runner using headless Chrome/Chromium
- add shared fixture helpers for mounting, update waits, Shadow DOM queries, browser events, and cleanup
- add a minimal Custom Elements + Shadow DOM fixture test
- keep the existing Node suite intact and include component tests in `test:ci`

Closes #28