### PR TITLE
Migrate reset lessons dialog to Lit

### DIFF
--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -43,6 +43,9 @@ async function run() {
 
     const { runExportProgressDialogTests } = await import('./export-progress-dialog-tests.js');
     await runExportProgressDialogTests();
+
+    const { runResetLessonsDialogTests } = await import('./reset-lessons-dialog-tests.js');
+    await runResetLessonsDialogTests();
 }
 
 async function report(status, message) {

--- a/src/component-tests/reset-lessons-dialog-tests.js
+++ b/src/component-tests/reset-lessons-dialog-tests.js
@@ -1,0 +1,95 @@
+import '../components/reset-lessons-dialog.js';
+import {
+    cleanup,
+    click,
+    elementUpdated,
+    equal,
+    fixture,
+    shadowQuery
+} from './component-test-harness.js';
+
+export async function runResetLessonsDialogTests() {
+    const lessons = [
+        {MarathonLessonId: 101, Number: 0, Name: 'Lesson one', LastRequest: null},
+        {MarathonLessonId: 102, Number: 1, Name: 'Lesson two', LastRequest: {Status: 2}}
+    ];
+    const dialog = await fixture('<edvibe-toolbox-reset-dialog></edvibe-toolbox-reset-dialog>');
+    dialog.configure({
+        stylesheetUrl: '/src/components/reset-lessons-dialog.css',
+        searchDelay: 0,
+        loadLessons: async () => lessons
+    });
+    dialog.showPupils({
+        pupils: [
+            {PupilId: 1, Name: 'Alice', Email: 'alice@example.com'},
+            {PupilId: 2, Name: 'Bob', Email: 'bob@example.com'}
+        ],
+        total: 2
+    });
+    await elementUpdated(dialog);
+
+    equal(dialog.id, 'edvibe-toolbox-reset-overlay');
+    equal(shadowQuery(dialog, '.edvibe-reset-pupils').querySelectorAll('button').length, 2);
+    equal(shadowQuery(dialog, '.edvibe-reset-status').textContent, 'Загружено пользователей: 2 из 2');
+    equal(shadowQuery(dialog, '.edvibe-reset-next').disabled, true);
+
+    click(shadowQuery(dialog, '.edvibe-reset-pupils button'));
+    await elementUpdated(dialog);
+    equal(dialog.selectedPupil.PupilId, 1);
+    equal(shadowQuery(dialog, '.edvibe-reset-next').disabled, false);
+    equal(shadowQuery(dialog, '.edvibe-reset-pupils button').getAttribute('aria-selected'), 'true');
+
+    await dialog.handleNext();
+    await elementUpdated(dialog);
+    equal(dialog.currentStep, 'lessons');
+    equal(shadowQuery(dialog, '.edvibe-reset-user-step').hidden, true);
+    equal(shadowQuery(dialog, '.edvibe-reset-lesson-step').hidden, false);
+    equal(shadowQuery(dialog, '.edvibe-reset-lessons').querySelectorAll('input').length, 2);
+    equal(shadowQuery(dialog, '.edvibe-reset-selected-pupil').textContent.trim(), 'Alice — alice@example.com');
+
+    dialog.toggleLesson(101, true);
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.edvibe-reset-submit').disabled, false);
+
+    let resetRequest = null;
+    dialog.addEventListener('edvibe-reset-request', (event) => { resetRequest = event.detail; });
+    dialog.handleSubmit();
+    equal(resetRequest.pupil.PupilId, 1);
+    equal(resetRequest.lessons.length, 1);
+    equal(resetRequest.lessons[0].MarathonLessonId, 101);
+
+    dialog.showDiscovery('Discovering work');
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.edvibe-reset-progress').classList.contains('is-indeterminate'), true);
+    equal(shadowQuery(dialog, '.edvibe-reset-progress').hasAttribute('value'), false);
+
+    dialog.showProgress({completed: 1, total: 2, lesson: lessons[0], exerciseId: 77});
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.edvibe-reset-progress').value, 50);
+    equal(shadowQuery(dialog, '.edvibe-reset-status').textContent.includes('Упражнение 77'), true);
+
+    dialog.showError('Reset failed');
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.edvibe-reset-status').classList.contains('is-error'), true);
+    equal(shadowQuery(dialog, '.edvibe-reset-status').textContent, 'Reset failed');
+
+    dialog.showComplete('Reset complete');
+    dialog.completeRun();
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.edvibe-reset-progress').value, 100);
+    equal(shadowQuery(dialog, '.edvibe-reset-status').classList.contains('is-success'), true);
+    equal(shadowQuery(dialog, '.edvibe-reset-back').textContent.trim(), 'Сбросить для другого пользователя');
+
+    dialog.handleBack();
+    await elementUpdated(dialog);
+    equal(dialog.currentStep, 'user');
+    equal(dialog.selectedPupil, null);
+    equal(shadowQuery(dialog, '.edvibe-reset-search').value, '');
+
+    let closeEvents = 0;
+    dialog.addEventListener('edvibe-dialog-close', () => { closeEvents += 1; });
+    dialog.close();
+    equal(closeEvents, 1);
+    equal(dialog.isConnected, false);
+    await cleanup();
+}

--- a/src/components/reset-lessons-dialog.js
+++ b/src/components/reset-lessons-dialog.js
@@ -1,820 +1,714 @@
-(function initializeResetDialogComponent(root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define([], () => factory(root));
-    } else if (typeof module === 'object' && module.exports) {
-        module.exports = factory(root);
-    } else {
-        root.EdVibeResetDialogComponent = factory(root);
+import { LitElement, html, nothing } from 'lit';
+
+const RESET_DIALOG_TAG = 'edvibe-toolbox-reset-dialog';
+const RESET_OVERLAY_ID = 'edvibe-toolbox-reset-overlay';
+
+class ResetLessonsDialog extends LitElement {
+    static properties = {
+        stylesheetUrl: {state: true},
+        currentStep: {state: true},
+        allPupils: {state: true},
+        pupilTotal: {state: true},
+        selectedPupil: {state: true},
+        lessons: {state: true},
+        selectedLessonIds: {state: true},
+        locked: {state: true},
+        loading: {state: true},
+        finished: {state: true},
+        pupilPageLoading: {state: true},
+        appliedSearchQuery: {state: true},
+        searchDebouncing: {state: true},
+        suppressPupilPageLoading: {state: true},
+        searchValue: {state: true},
+        statusMessage: {state: true},
+        statusState: {state: true},
+        progressVisible: {state: true},
+        progressIndeterminate: {state: true},
+        progressValue: {state: true}
+    };
+
+    constructor() {
+        super();
+        this.stylesheetUrl = '';
+        this.searchDelay = 1000;
+        this.log = () => {};
+        this.loadLessons = null;
+        this.loadNextPupils = null;
+
+        this.currentStep = 'user';
+        this.allPupils = [];
+        this.pupilTotal = 0;
+        this.selectedPupil = null;
+        this.loadedPupilId = null;
+        this.lessons = [];
+        this.selectedLessonIds = new Set();
+        this.locked = false;
+        this.loading = false;
+        this.finished = false;
+        this.closed = false;
+        this.pupilPagePromise = null;
+        this.pupilPageLoading = false;
+        this.searchTimer = null;
+        this.searchGeneration = 0;
+        this.appliedSearchQuery = '';
+        this.searchDebouncing = false;
+        this.suppressPupilPageLoading = false;
+        this.searchValue = '';
+        this.statusMessage = '';
+        this.statusState = '';
+        this.progressVisible = false;
+        this.progressIndeterminate = false;
+        this.progressValue = 0;
+        this.elements = null;
+        this.handleKeydownBound = (event) => this.handleKeydown(event);
     }
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createResetDialogComponent(root) {
-    'use strict';
 
-    const RESET_DIALOG_TAG = 'edvibe-toolbox-reset-dialog';
-    const RESET_OVERLAY_ID = 'edvibe-toolbox-reset-overlay';
-    
-    const HTMLElementBase = root.HTMLElement || class {};
-    const resetDialogTemplate = root.document?.createElement?.('template') || null;
+    connectedCallback() {
+        super.connectedCallback();
+        if (!this.id) {
+            this.id = RESET_OVERLAY_ID;
+        }
+        this.ownerDocument?.addEventListener('keydown', this.handleKeydownBound);
+    }
 
-    if (resetDialogTemplate) {
-        resetDialogTemplate.innerHTML = `
-            <link class="edvibe-reset-stylesheet" rel="stylesheet">
-            <div class="edvibe-reset-overlay">
+    disconnectedCallback() {
+        this.cancelSearch();
+        this.ownerDocument?.removeEventListener('keydown', this.handleKeydownBound);
+        super.disconnectedCallback();
+    }
+
+    configure(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        const {
+            stylesheetUrl = '',
+            searchDelay = 1000,
+            loadLessons,
+            loadNextPupils,
+            log = () => {}
+        } = options;
+        this.stylesheetUrl = String(stylesheetUrl || '');
+        this.searchDelay = Number.isFinite(Number(searchDelay))
+            ? Math.max(0, Number(searchDelay))
+            : 1000;
+        this.loadLessons = typeof loadLessons === 'function' ? loadLessons : null;
+        this.loadNextPupils = typeof loadNextPupils === 'function' ? loadNextPupils : null;
+        this.log = typeof log === 'function' ? log : () => {};
+        return this;
+    }
+
+    updated() {
+        this.cacheElements();
+    }
+
+    cacheElements() {
+        if (!this.shadowRoot) {
+            this.elements = null;
+            return;
+        }
+        const find = (selector) => this.shadowRoot.querySelector(selector);
+        this.elements = {
+            stylesheet: find('.edvibe-reset-stylesheet'),
+            backdrop: find('.edvibe-reset-overlay'),
+            search: find('.edvibe-reset-search'),
+            userStep: find('.edvibe-reset-user-step'),
+            lessonStep: find('.edvibe-reset-lesson-step'),
+            pupilsShell: find('.edvibe-reset-pupils-shell'),
+            pupilsList: find('.edvibe-reset-pupils'),
+            pupilsLoading: find('.edvibe-reset-pupils-loading'),
+            lessonsList: find('.edvibe-reset-lessons'),
+            selectAll: find('.edvibe-reset-select-all-input'),
+            status: find('.edvibe-reset-status'),
+            progress: find('.edvibe-reset-progress'),
+            close: find('.edvibe-reset-close'),
+            cancel: find('.edvibe-reset-cancel'),
+            back: find('.edvibe-reset-back'),
+            next: find('.edvibe-reset-next'),
+            submit: find('.edvibe-reset-submit')
+        };
+    }
+
+    normalizeSearchQuery(value) {
+        return String(value || '').trim().toLowerCase();
+    }
+
+    filterPupils(query) {
+        const normalized = this.normalizeSearchQuery(query);
+        if (!normalized) {
+            return this.allPupils;
+        }
+        return this.allPupils.filter((pupil) =>
+            String(pupil.Email || '').toLowerCase().includes(normalized)
+        );
+    }
+
+    hasMorePupils() {
+        return this.allPupils.length < this.pupilTotal;
+    }
+
+    hasLoadedLessonsForSelectedPupil() {
+        return Boolean(this.selectedPupil)
+            && this.selectedPupil.PupilId === this.loadedPupilId;
+    }
+
+    isPupilLoadingVisible() {
+        return this.loading
+            || (this.pupilPageLoading && !this.suppressPupilPageLoading);
+    }
+
+    getViewState() {
+        const blocked = this.loading || this.locked || this.finished;
+        const showingUsers = this.currentStep === 'user';
+        return {
+            showingUsers,
+            nextDisabled: blocked || !this.selectedPupil,
+            backDisabled: this.loading || this.locked,
+            submitDisabled: blocked
+                || !this.selectedPupil
+                || this.selectedLessonIds.size === 0,
+            closeDisabled: this.loading || this.locked
+        };
+    }
+
+    setStatus(message, state = '') {
+        this.statusMessage = String(message || '');
+        this.statusState = state === 'error' || state === 'success' ? state : '';
+    }
+
+    renderState() {
+        this.requestUpdate();
+    }
+
+    renderPupilLoadingState() {
+        this.requestUpdate();
+    }
+
+    renderPupils() {
+        this.requestUpdate();
+    }
+
+    selectPupil(pupil) {
+        if (
+            this.locked
+            || this.finished
+            || this.isPupilLoadingVisible()
+            || pupil.PupilId === this.selectedPupil?.PupilId
+        ) return;
+
+        if (pupil.PupilId !== this.loadedPupilId) {
+            this.loadedPupilId = null;
+            this.lessons = [];
+            this.selectedLessonIds = new Set();
+        }
+        this.selectedPupil = pupil;
+        this.setStatus(`Выбран пользователь: ${pupil.Email || 'email отсутствует'}`);
+    }
+
+    renderLessons() {
+        this.requestUpdate();
+    }
+
+    toggleLesson(lessonId, selected) {
+        if (selected) {
+            this.selectedLessonIds.add(lessonId);
+        } else {
+            this.selectedLessonIds.delete(lessonId);
+        }
+        this.requestUpdate();
+    }
+
+    handleSelectAll(event) {
+        const checked = event?.currentTarget?.checked ?? this.elements?.selectAll?.checked;
+        this.selectedLessonIds = checked
+            ? new Set(this.lessons.map((lesson) => lesson.MarathonLessonId))
+            : new Set();
+    }
+
+    handleSearchInput(event) {
+        this.searchValue = String(event?.currentTarget?.value ?? this.searchValue);
+        this.searchGeneration += 1;
+        this.cancelSearchTimer();
+        this.searchDebouncing = true;
+        this.suppressPupilPageLoading = true;
+        const query = this.normalizeSearchQuery(this.searchValue);
+        const generation = this.searchGeneration;
+        this.searchTimer = globalThis.setTimeout(async () => {
+            if (!this.isCurrentSearch(generation, query)) {
+                return;
+            }
+            this.searchTimer = null;
+            const needsRemotePupils = Boolean(
+                query && this.filterPupils(query).length === 0 && this.hasMorePupils()
+            );
+            this.searchDebouncing = false;
+            if (needsRemotePupils || !this.pupilPageLoading) {
+                this.suppressPupilPageLoading = false;
+            }
+            if (needsRemotePupils && !await this.continueSearch(generation, query)) {
+                return;
+            }
+            if (!this.isCurrentSearch(generation, query)) {
+                return;
+            }
+            this.appliedSearchQuery = query;
+        }, this.searchDelay);
+    }
+
+    isCurrentSearch(generation, query) {
+        return !this.closed
+            && generation === this.searchGeneration
+            && query === this.normalizeSearchQuery(this.searchValue);
+    }
+
+    cancelSearchTimer() {
+        if (this.searchTimer === null) {
+            return;
+        }
+        globalThis.clearTimeout(this.searchTimer);
+        this.searchTimer = null;
+    }
+
+    cancelSearch() {
+        this.searchGeneration += 1;
+        this.cancelSearchTimer();
+    }
+
+    async continueSearch(generation, query) {
+        while (
+            this.isCurrentSearch(generation, query)
+            && this.filterPupils(query).length === 0
+            && this.hasMorePupils()
+        ) {
+            if (!await this.loadNextPupilPage()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    async loadNextPupilPage() {
+        if (this.closed || !this.loadNextPupils || !this.hasMorePupils()) {
+            return false;
+        }
+        if (this.pupilPagePromise) {
+            return this.pupilPagePromise;
+        }
+
+        this.suppressPupilPageLoading = false;
+        this.pupilPageLoading = true;
+        this.pupilPagePromise = (async () => {
+            try {
+                const page = await this.loadNextPupils();
+                if (this.closed) {
+                    return false;
+                }
+                this.allPupils = Array.isArray(page?.pupils) ? page.pupils : [];
+                this.pupilTotal = Number(page?.total) || 0;
+                if (this.currentStep === 'user' && !this.loading) {
+                    this.setStatus(
+                        `Загружено пользователей: ${this.allPupils.length} `
+                        + `из ${this.pupilTotal}`
+                    );
+                }
+                return true;
+            } catch (error) {
+                if (!this.closed && this.currentStep === 'user' && !this.loading) {
+                    this.log(`Failed to load another pupil page (${this.errorType(error)}).`);
+                    this.setStatus(error.message, 'error');
+                }
+                return false;
+            } finally {
+                this.pupilPagePromise = null;
+                this.pupilPageLoading = false;
+                if (!this.searchDebouncing) {
+                    this.suppressPupilPageLoading = false;
+                }
+            }
+        })();
+        return this.pupilPagePromise;
+    }
+
+    handlePupilsScroll(event) {
+        if (this.searchDebouncing) {
+            return;
+        }
+        const list = event?.currentTarget || this.elements?.pupilsList;
+        if (!list) {
+            return;
+        }
+        const distanceFromBottom = list.scrollHeight - list.scrollTop - list.clientHeight;
+        if (distanceFromBottom <= 24) {
+            this.loadNextPupilPage();
+        }
+    }
+
+    async handleNext() {
+        if (this.getViewState().nextDisabled || !this.selectedPupil) {
+            return;
+        }
+        if (this.hasLoadedLessonsForSelectedPupil()) {
+            this.currentStep = 'lessons';
+            await this.updateComplete;
+            this.shadowRoot?.querySelector('.edvibe-reset-lessons')?.focus();
+            return;
+        }
+        if (!this.loadLessons) {
+            return;
+        }
+
+        try {
+            this.setLoading(`Загрузка уроков для ${this.selectedPupil.Email}...`);
+            const lessons = await this.loadLessons(this.selectedPupil);
+            this.showLessons(this.selectedPupil, lessons);
+        } catch (error) {
+            this.loading = false;
+            this.currentStep = 'user';
+            this.log(
+                `Failed to load lessons for PupilId ${this.selectedPupil.PupilId} `
+                + `(${this.errorType(error)}).`
+            );
+            this.setStatus(error.message, 'error');
+        }
+    }
+
+    handleBack() {
+        if (this.getViewState().backDisabled) {
+            return;
+        }
+        if (this.finished) {
+            this.resetForAnotherUser();
+            return;
+        }
+        this.currentStep = 'user';
+        this.setStatus(
+            `Выбран пользователь: ${this.selectedPupil?.Email || 'email отсутствует'}`
+        );
+        this.updateComplete.then(() =>
+            this.shadowRoot?.querySelector('.edvibe-reset-search')?.focus()
+        );
+    }
+
+    handleSubmit() {
+        if (this.getViewState().submitDisabled) {
+            return;
+        }
+        this.dispatchEvent(new CustomEvent('edvibe-reset-request', {
+            detail: {
+                pupil: this.selectedPupil,
+                lessons: this.lessons.filter((lesson) =>
+                    this.selectedLessonIds.has(lesson.MarathonLessonId)
+                )
+            }
+        }));
+    }
+
+    handleBackdropClick(event) {
+        if (event.target === event.currentTarget) {
+            this.close();
+        }
+    }
+
+    handleKeydown(event) {
+        if (event.key === 'Escape') {
+            this.close();
+        }
+    }
+
+    close() {
+        if (this.locked || this.loading || this.closed) {
+            return;
+        }
+        this.closed = true;
+        this.cancelSearch();
+        this.dispatchEvent(new CustomEvent('edvibe-dialog-close'));
+        this.remove();
+    }
+
+    resetForAnotherUser() {
+        this.finished = false;
+        this.currentStep = 'user';
+        this.selectedPupil = null;
+        this.loadedPupilId = null;
+        this.lessons = [];
+        this.selectedLessonIds = new Set();
+        this.searchValue = '';
+        this.appliedSearchQuery = '';
+        this.cancelSearch();
+        this.searchDebouncing = false;
+        this.suppressPupilPageLoading = false;
+        this.progressVisible = false;
+        this.progressIndeterminate = false;
+        this.progressValue = 0;
+        this.setStatus(
+            `Загружено пользователей: ${this.allPupils.length} из ${this.pupilTotal}`
+        );
+        this.updateComplete.then(() =>
+            this.shadowRoot?.querySelector('.edvibe-reset-search')?.focus()
+        );
+    }
+
+    showPupils(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        const pupils = Array.isArray(options.pupils) ? options.pupils : [];
+        const total = Number.isFinite(Number(options.total))
+            ? Number(options.total)
+            : pupils.length;
+        this.allPupils = pupils;
+        this.pupilTotal = total;
+        this.currentStep = 'user';
+        this.loading = false;
+        this.setStatus(`Загружено пользователей: ${pupils.length} из ${total}`);
+        this.updateComplete.then(() =>
+            this.shadowRoot?.querySelector('.edvibe-reset-search')?.focus()
+        );
+        return this;
+    }
+
+    showLessons(pupil, lessons) {
+        if (!pupil || typeof pupil !== 'object') {
+            return this;
+        }
+        lessons = Array.isArray(lessons) ? lessons : [];
+        const pupilChanged = this.loadedPupilId !== pupil.PupilId;
+        this.selectedPupil = pupil;
+        this.loadedPupilId = pupil.PupilId;
+        this.lessons = lessons;
+        if (pupilChanged) {
+            this.selectedLessonIds = new Set();
+        }
+        this.loading = false;
+        this.currentStep = 'lessons';
+        this.setStatus(`Загружено уроков: ${lessons.length}`);
+        this.updateComplete.then(() =>
+            this.shadowRoot?.querySelector('.edvibe-reset-lessons')?.focus()
+        );
+        return this;
+    }
+
+    setLoading(message) {
+        this.loading = true;
+        this.setStatus(message);
+    }
+
+    lock() {
+        this.locked = true;
+        this.classList.toggle('is-running', true);
+    }
+
+    completeRun() {
+        this.locked = false;
+        this.finished = true;
+        this.classList.toggle('is-running', false);
+    }
+
+    unlockAfterRun() {
+        this.locked = false;
+        this.finished = false;
+        this.classList.toggle('is-running', false);
+    }
+
+    showDiscovery(message) {
+        this.setStatus(message);
+        this.progressVisible = true;
+        this.progressIndeterminate = true;
+    }
+
+    showProgress(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        const completed = Number(options.completed) || 0;
+        const total = Number(options.total) || 0;
+        const lesson = options.lesson && typeof options.lesson === 'object'
+            ? options.lesson
+            : {};
+        const exerciseId = options.exerciseId;
+        const percent = total > 0 ? Math.round((completed / total) * 100) : 100;
+        const detail = exerciseId ? `Упражнение ${exerciseId}` : 'Удаление запроса урока';
+        this.setStatus(`${lesson.Name || ''}\n${detail} — ${completed} / ${total}`);
+        this.progressVisible = true;
+        this.progressIndeterminate = false;
+        this.progressValue = percent;
+    }
+
+    showComplete(message) {
+        this.setStatus(message, 'success');
+        this.progressVisible = true;
+        this.progressIndeterminate = false;
+        this.progressValue = 100;
+    }
+
+    showError(message) {
+        if (!this.locked) {
+            this.loading = false;
+        }
+        this.setStatus(message, 'error');
+        this.progressIndeterminate = false;
+    }
+
+    errorType(error) {
+        return typeof error?.name === 'string' ? error.name : 'Error';
+    }
+
+    renderPupilRows() {
+        const visiblePupils = this.filterPupils(this.appliedSearchQuery);
+        if (visiblePupils.length === 0) {
+            return html`<p class="edvibe-reset-empty">Пользователи не найдены.</p>`;
+        }
+        const busy = this.isPupilLoadingVisible();
+        return visiblePupils.map((pupil) => {
+            const selected = pupil.PupilId === this.selectedPupil?.PupilId;
+            const rowClass = `edvibe-reset-row${selected ? ' is-selected' : ''}`;
+            return html`
+                <button type="button" class=${rowClass} role="option"
+                    aria-selected=${String(selected)}
+                    ?disabled=${busy || this.locked || this.finished}
+                    @click=${() => this.selectPupil(pupil)}>
+                    <span class="edvibe-reset-row-copy">
+                        <span class="edvibe-reset-row-name">${pupil.Name || 'Без имени'}</span>
+                        <span class="edvibe-reset-row-email">${pupil.Email || 'Email отсутствует'}</span>
+                    </span>
+                </button>
+            `;
+        });
+    }
+
+    renderLessonRows(inputsBlocked) {
+        if (this.lessons.length === 0) {
+            return html`<p class="edvibe-reset-empty">Для пользователя нет уроков.</p>`;
+        }
+        return this.lessons.map((lesson) => html`
+            <label class="edvibe-reset-row edvibe-reset-lesson">
+                <input type="checkbox" .value=${String(lesson.MarathonLessonId)}
+                    .checked=${this.selectedLessonIds.has(lesson.MarathonLessonId)}
+                    ?disabled=${inputsBlocked}
+                    @change=${(event) => this.toggleLesson(
+                        lesson.MarathonLessonId,
+                        event.currentTarget.checked
+                    )}>
+                <span class="edvibe-reset-row-copy">
+                    <span class="edvibe-reset-row-name">
+                        ${Number(lesson.Number) + 1}. ${lesson.Name}
+                    </span>
+                    <span class="edvibe-reset-row-email">
+                        ${lesson.LastRequest
+                            ? `Статус последнего запроса: ${lesson.LastRequest.Status}`
+                            : 'Нет запросов на проверку'}
+                    </span>
+                </span>
+            </label>
+        `);
+    }
+
+    render() {
+        const view = this.getViewState();
+        const inputsBlocked = this.locked || this.loading || this.finished;
+        const pupilBusy = this.isPupilLoadingVisible();
+        const selectAllChecked = this.lessons.length > 0
+            && this.selectedLessonIds.size === this.lessons.length;
+        const selectAllIndeterminate = this.selectedLessonIds.size > 0
+            && this.selectedLessonIds.size < this.lessons.length;
+        const statusClass = `edvibe-reset-status${this.statusState === 'error'
+            ? ' is-error'
+            : this.statusState === 'success' ? ' is-success' : ''}`;
+        const progressClass = `edvibe-reset-progress${this.progressVisible
+            ? ' is-visible'
+            : ''}${this.progressIndeterminate ? ' is-indeterminate' : ''}`;
+        const progressValue = this.progressIndeterminate ? nothing : this.progressValue;
+        const selectedPupilLabel = this.selectedPupil
+            ? `${this.selectedPupil.Name || 'Без имени'} — ${this.selectedPupil.Email || ''}`
+            : '';
+
+        return html`
+            <link class="edvibe-reset-stylesheet" rel="stylesheet"
+                href=${this.stylesheetUrl || nothing}>
+            <div class="edvibe-reset-overlay" @click=${this.handleBackdropClick}>
                 <div class="edvibe-reset-card" role="dialog" aria-modal="true"
                     aria-labelledby="edvibe-reset-title">
                     <div class="edvibe-reset-header">
                         <div>
-                            <h2 id="edvibe-reset-title" class="edvibe-reset-title">
-                                Сброс уроков
-                            </h2>
+                            <h2 id="edvibe-reset-title" class="edvibe-reset-title">Сброс уроков</h2>
                             <p class="edvibe-reset-subtitle">
-                                <span class="edvibe-reset-step-indicator">Шаг 1 из 2</span>
-                                <span class="edvibe-reset-step-description">Выберите пользователя.</span>
+                                <span class="edvibe-reset-step-indicator">
+                                    ${view.showingUsers ? 'Шаг 1 из 2' : 'Шаг 2 из 2'}
+                                </span>
+                                <span class="edvibe-reset-step-description">
+                                    ${view.showingUsers
+                                        ? 'Выберите пользователя.'
+                                        : 'Выберите уроки для сброса прогресса.'}
+                                </span>
                             </p>
                         </div>
-                        <button class="edvibe-reset-close" type="button" aria-label="Закрыть">
-                            &times;
-                        </button>
+                        <button class="edvibe-reset-close" type="button" aria-label="Закрыть"
+                            ?disabled=${view.closeDisabled} @click=${() => this.close()}>&times;</button>
                     </div>
                     <div class="edvibe-reset-body">
-                        <section class="edvibe-reset-user-step" aria-label="Выбор пользователя">
-                            <label class="edvibe-reset-label" for="edvibe-reset-search">
-                                Поиск по email
-                            </label>
-                            <input id="edvibe-reset-search" class="edvibe-reset-search" type="search" placeholder="user@example.com" autocomplete="off">
-                            <div class="edvibe-reset-pupils-shell">
-                                <div class="edvibe-reset-list edvibe-reset-pupils" role="listbox" aria-label="Пользователи марафона"></div>
-                                <div class="edvibe-reset-pupils-loading" role="status" aria-live="polite" hidden>
+                        <section class="edvibe-reset-user-step" aria-label="Выбор пользователя"
+                            ?hidden=${!view.showingUsers}>
+                            <label class="edvibe-reset-label" for="edvibe-reset-search">Поиск по email</label>
+                            <input id="edvibe-reset-search" class="edvibe-reset-search" type="search"
+                                placeholder="user@example.com" autocomplete="off"
+                                .value=${this.searchValue} ?disabled=${inputsBlocked}
+                                @input=${this.handleSearchInput}>
+                            <div class=${`edvibe-reset-pupils-shell${pupilBusy ? ' is-loading' : ''}`}>
+                                <div class="edvibe-reset-list edvibe-reset-pupils" role="listbox"
+                                    aria-label="Пользователи марафона" aria-busy=${String(pupilBusy)}
+                                    .inert=${pupilBusy} @scroll=${this.handlePupilsScroll}>
+                                    ${this.renderPupilRows()}
+                                </div>
+                                <div class="edvibe-reset-pupils-loading" role="status" aria-live="polite"
+                                    ?hidden=${!pupilBusy}>
                                     <span class="edvibe-reset-spinner" aria-hidden="true"></span>
                                     <span>Загрузка пользователей...</span>
                                 </div>
                             </div>
                         </section>
-                        <section class="edvibe-reset-lesson-step" aria-label="Выбор уроков" hidden>
-                            <div class="edvibe-reset-label edvibe-reset-selected-pupil"></div>
+                        <section class="edvibe-reset-lesson-step" aria-label="Выбор уроков"
+                            ?hidden=${view.showingUsers}>
+                            <div class="edvibe-reset-label edvibe-reset-selected-pupil">
+                                ${selectedPupilLabel}
+                            </div>
                             <label class="edvibe-reset-select-all">
-                                <input class="edvibe-reset-select-all-input" type="checkbox">
+                                <input class="edvibe-reset-select-all-input" type="checkbox"
+                                    .checked=${selectAllChecked}
+                                    .indeterminate=${selectAllIndeterminate}
+                                    ?disabled=${inputsBlocked || this.lessons.length === 0}
+                                    @change=${this.handleSelectAll}>
                                 Выбрать все уроки
                             </label>
-                            <div class="edvibe-reset-list edvibe-reset-lessons" aria-label="Уроки пользователя" tabindex="-1"></div>
+                            <div class="edvibe-reset-list edvibe-reset-lessons"
+                                aria-label="Уроки пользователя" tabindex="-1">
+                                ${this.renderLessonRows(inputsBlocked)}
+                            </div>
                         </section>
                     </div>
                     <div class="edvibe-reset-live-region">
-                        <p class="edvibe-reset-status" aria-live="polite"></p>
-                        <progress class="edvibe-reset-progress" max="100"
-                            value="0"></progress>
+                        <p class=${statusClass} aria-live="polite">${this.statusMessage}</p>
+                        <progress class=${progressClass} max="100" value=${progressValue}></progress>
                     </div>
                     <div class="edvibe-reset-footer">
-                        <button class="edvibe-reset-button edvibe-reset-cancel" type="button">
-                            Закрыть
+                        <button class="edvibe-reset-button edvibe-reset-cancel" type="button"
+                            ?disabled=${view.closeDisabled} @click=${() => this.close()}>Закрыть</button>
+                        <button class="edvibe-reset-button edvibe-reset-back" type="button"
+                            ?hidden=${view.showingUsers} ?disabled=${view.backDisabled}
+                            @click=${this.handleBack}>
+                            ${this.finished ? 'Сбросить для другого пользователя' : 'Назад'}
                         </button>
-                        <button class="edvibe-reset-button edvibe-reset-back" type="button" hidden>
-                            Назад
-                        </button>
-                        <button class="edvibe-reset-button edvibe-reset-next" type="button" disabled>
-                            Далее
-                        </button>
-                        <button class="edvibe-reset-button edvibe-reset-submit" type="button" disabled hidden>
-                            Сбросить прогресс
-                        </button>
+                        <button class="edvibe-reset-button edvibe-reset-next" type="button"
+                            ?hidden=${!view.showingUsers} ?disabled=${view.nextDisabled}
+                            @click=${this.handleNext}>Далее</button>
+                        <button class="edvibe-reset-button edvibe-reset-submit" type="button"
+                            ?hidden=${view.showingUsers} ?disabled=${view.submitDisabled}
+                            @click=${this.handleSubmit}>Сбросить прогресс</button>
                     </div>
                 </div>
             </div>
         `;
     }
+}
 
-    class ResetLessonsDialog extends HTMLElementBase {
-        constructor() {
-            super();
-            this.stylesheetUrl = '';
-            this.searchDelay = 1000;
-            this.log = () => {};
-            this.loadLessons = null;
-            this.loadNextPupils = null;
+if (!customElements.get(RESET_DIALOG_TAG)) {
+    customElements.define(RESET_DIALOG_TAG, ResetLessonsDialog);
+}
 
-            this.currentStep = 'user';
-            this.allPupils = [];
-            this.pupilTotal = 0;
-            this.selectedPupil = null;
-            this.loadedPupilId = null;
-            this.lessons = [];
-            this.selectedLessonIds = new Set();
-            this.locked = false;
-            this.loading = false;
-            this.finished = false;
-            this.closed = false;
-            this.pupilPagePromise = null;
-            this.pupilPageLoading = false;
-            this.searchTimer = null;
-            this.searchGeneration = 0;
-            this.appliedSearchQuery = '';
-            this.searchDebouncing = false;
-            this.suppressPupilPageLoading = false;
-            this.rendered = false;
-            this.listenersConnected = false;
+const resetDialogApi = {RESET_DIALOG_TAG, RESET_OVERLAY_ID, ResetLessonsDialog};
+globalThis.EdVibeResetDialogComponent = resetDialogApi;
 
-            if (typeof this.attachShadow !== 'function' || !resetDialogTemplate) {
-                return;
-            }
-            const shadowRoot = this.attachShadow({ mode: 'open' });
-            shadowRoot.append(resetDialogTemplate.content.cloneNode(true));
-            this.cacheElements();
-            this.updateStylesheet();
-            this.rendered = true;
-            this.renderState();
-        }
-
-        connectedCallback() {
-            if (!this.id) {
-                this.id = RESET_OVERLAY_ID;
-            }
-            this.render();
-            this.connectListeners();
-        }
-
-        disconnectedCallback() {
-            this.disconnectListeners();
-        }
-
-        configure(options = {}) {
-            options = options && typeof options === 'object' ? options : {};
-            const {
-                stylesheetUrl = '',
-                searchDelay = 1000,
-                loadLessons,
-                loadNextPupils,
-                log = () => {}
-            } = options;
-            this.stylesheetUrl = String(stylesheetUrl || '');
-            this.searchDelay = Number.isFinite(Number(searchDelay))
-                ? Math.max(0, Number(searchDelay))
-                : 1000;
-            this.loadLessons = typeof loadLessons === 'function' ? loadLessons : null;
-            this.loadNextPupils = typeof loadNextPupils === 'function'
-                ? loadNextPupils
-                : null;
-            this.log = typeof log === 'function' ? log : () => {};
-            this.updateStylesheet();
-            return this;
-        }
-
-        render() {
-            return this.rendered;
-        }
-
-        cacheElements() {
-            if (!this.shadowRoot) {
-                return;
-            }
-            const find = (selector) => this.shadowRoot.querySelector(selector);
-            this.elements = {
-                stylesheet: find('.edvibe-reset-stylesheet'),
-                backdrop: find('.edvibe-reset-overlay'),
-                search: find('.edvibe-reset-search'),
-                userStep: find('.edvibe-reset-user-step'),
-                lessonStep: find('.edvibe-reset-lesson-step'),
-                stepIndicator: find('.edvibe-reset-step-indicator'),
-                stepDescription: find('.edvibe-reset-step-description'),
-                pupilsShell: find('.edvibe-reset-pupils-shell'),
-                pupilsList: find('.edvibe-reset-pupils'),
-                pupilsLoading: find('.edvibe-reset-pupils-loading'),
-                lessonsList: find('.edvibe-reset-lessons'),
-                selectedPupilLabel: find('.edvibe-reset-selected-pupil'),
-                selectAll: find('.edvibe-reset-select-all-input'),
-                status: find('.edvibe-reset-status'),
-                progress: find('.edvibe-reset-progress'),
-                close: find('.edvibe-reset-close'),
-                cancel: find('.edvibe-reset-cancel'),
-                back: find('.edvibe-reset-back'),
-                next: find('.edvibe-reset-next'),
-                submit: find('.edvibe-reset-submit')
-            };
-        }
-
-        connectListeners() {
-            if (!this.rendered || this.listenersConnected) {
-                return;
-            }
-            this.listenersConnected = true;
-
-            this.handleSearchInput = this.handleSearchInput.bind(this);
-            this.handlePupilsScroll = this.handlePupilsScroll.bind(this);
-            this.handleSelectAll = this.handleSelectAll.bind(this);
-            this.handleNext = this.handleNext.bind(this);
-            this.handleBack = this.handleBack.bind(this);
-            this.handleSubmit = this.handleSubmit.bind(this);
-            this.handleClose = this.close.bind(this);
-            this.handleBackdropClick = this.handleBackdropClick.bind(this);
-            this.handleKeydown = this.handleKeydown.bind(this);
-
-            this.elements.search.addEventListener('input', this.handleSearchInput);
-            this.elements.pupilsList.addEventListener('scroll', this.handlePupilsScroll);
-            this.elements.selectAll.addEventListener('change', this.handleSelectAll);
-            this.elements.next.addEventListener('click', this.handleNext);
-            this.elements.back.addEventListener('click', this.handleBack);
-            this.elements.submit.addEventListener('click', this.handleSubmit);
-            this.elements.close.addEventListener('click', this.handleClose);
-            this.elements.cancel.addEventListener('click', this.handleClose);
-            this.elements.backdrop.addEventListener('click', this.handleBackdropClick);
-            this.ownerDocument.addEventListener('keydown', this.handleKeydown);
-        }
-
-        disconnectListeners() {
-            if (!this.listenersConnected) {
-                return;
-            }
-            this.listenersConnected = false;
-            this.cancelSearch();
-
-            this.elements.search.removeEventListener('input', this.handleSearchInput);
-            this.elements.pupilsList.removeEventListener('scroll', this.handlePupilsScroll);
-            this.elements.selectAll.removeEventListener('change', this.handleSelectAll);
-            this.elements.next.removeEventListener('click', this.handleNext);
-            this.elements.back.removeEventListener('click', this.handleBack);
-            this.elements.submit.removeEventListener('click', this.handleSubmit);
-            this.elements.close.removeEventListener('click', this.handleClose);
-            this.elements.cancel.removeEventListener('click', this.handleClose);
-            this.elements.backdrop.removeEventListener('click', this.handleBackdropClick);
-            this.ownerDocument.removeEventListener('keydown', this.handleKeydown);
-        }
-
-        updateStylesheet() {
-            if (this.elements?.stylesheet) {
-                this.elements.stylesheet.setAttribute('href', this.stylesheetUrl);
-            }
-        }
-
-        normalizeSearchQuery(value) {
-            return String(value || '').trim().toLowerCase();
-        }
-
-        filterPupils(query) {
-            const normalized = this.normalizeSearchQuery(query);
-            if (!normalized) {
-                return this.allPupils;
-            }
-            return this.allPupils.filter((pupil) =>
-                String(pupil.Email || '').toLowerCase().includes(normalized)
-            );
-        }
-
-        hasMorePupils() {
-            return this.allPupils.length < this.pupilTotal;
-        }
-
-        hasLoadedLessonsForSelectedPupil() {
-            return Boolean(this.selectedPupil)
-                && this.selectedPupil.PupilId === this.loadedPupilId;
-        }
-
-        isPupilLoadingVisible() {
-            return this.loading
-                || (this.pupilPageLoading && !this.suppressPupilPageLoading);
-        }
-
-        getViewState() {
-            const blocked = this.loading || this.locked || this.finished;
-            const showingUsers = this.currentStep === 'user';
-            return {
-                showingUsers,
-                nextDisabled: blocked || !this.selectedPupil,
-                backDisabled: this.loading || this.locked,
-                submitDisabled: blocked
-                    || !this.selectedPupil
-                    || this.selectedLessonIds.size === 0,
-                closeDisabled: this.loading || this.locked
-            };
-        }
-
-        setStatus(message, state = '') {
-            if (!this.elements) {
-                return;
-            }
-            this.elements.status.textContent = message;
-            this.elements.status.classList.toggle('is-error', state === 'error');
-            this.elements.status.classList.toggle('is-success', state === 'success');
-        }
-
-        renderState() {
-            if (!this.rendered) {
-                return;
-            }
-            const view = this.getViewState();
-            const inputsBlocked = this.locked || this.loading || this.finished;
-
-            this.elements.userStep.hidden = !view.showingUsers;
-            this.elements.lessonStep.hidden = view.showingUsers;
-            this.elements.next.hidden = !view.showingUsers;
-            this.elements.next.disabled = view.nextDisabled;
-            this.elements.back.hidden = view.showingUsers;
-            this.elements.back.disabled = view.backDisabled;
-            this.elements.back.textContent = this.finished
-                ? 'Сбросить для другого пользователя'
-                : 'Назад';
-            this.elements.submit.hidden = view.showingUsers;
-            this.elements.submit.disabled = view.submitDisabled;
-            this.elements.search.disabled = inputsBlocked;
-            this.elements.close.disabled = view.closeDisabled;
-            this.elements.cancel.disabled = view.closeDisabled;
-            this.elements.lessonsList.querySelectorAll('input').forEach((input) => {
-                input.disabled = inputsBlocked;
-            });
-            this.elements.selectAll.disabled = inputsBlocked || this.lessons.length === 0;
-            this.elements.stepIndicator.textContent = view.showingUsers
-                ? 'Шаг 1 из 2'
-                : 'Шаг 2 из 2';
-            this.elements.stepDescription.textContent = view.showingUsers
-                ? 'Выберите пользователя.'
-                : 'Выберите уроки для сброса прогресса.';
-            this.renderPupilLoadingState();
-        }
-
-        renderPupilLoadingState() {
-            const busy = this.isPupilLoadingVisible();
-            this.elements.pupilsShell.classList.toggle('is-loading', busy);
-            this.elements.pupilsLoading.hidden = !busy;
-            this.elements.pupilsList.setAttribute('aria-busy', String(busy));
-            this.elements.pupilsList.inert = busy;
-            this.elements.pupilsList.querySelectorAll('button').forEach((button) => {
-                button.disabled = busy || this.locked || this.finished;
-            });
-        }
-
-        renderPupils() {
-            const list = this.elements.pupilsList;
-            list.replaceChildren();
-            const visiblePupils = this.filterPupils(this.appliedSearchQuery);
-
-            if (visiblePupils.length === 0) {
-                const empty = this.ownerDocument.createElement('p');
-                empty.className = 'edvibe-reset-empty';
-                empty.textContent = 'Пользователи не найдены.';
-                list.appendChild(empty);
-                return;
-            }
-
-            for (const pupil of visiblePupils) {
-                const row = this.ownerDocument.createElement('button');
-                row.type = 'button';
-                row.className = 'edvibe-reset-row';
-                row.setAttribute('role', 'option');
-                const selected = pupil.PupilId === this.selectedPupil?.PupilId;
-                row.setAttribute('aria-selected', String(selected));
-                row.classList.toggle('is-selected', selected);
-                row.disabled = this.locked || this.finished || this.isPupilLoadingVisible();
-
-                const copy = this.ownerDocument.createElement('span');
-                copy.className = 'edvibe-reset-row-copy';
-                const name = this.ownerDocument.createElement('span');
-                name.className = 'edvibe-reset-row-name';
-                name.textContent = pupil.Name || 'Без имени';
-                const email = this.ownerDocument.createElement('span');
-                email.className = 'edvibe-reset-row-email';
-                email.textContent = pupil.Email || 'Email отсутствует';
-                copy.append(name, email);
-                row.appendChild(copy);
-                row.addEventListener('click', () => this.selectPupil(pupil));
-                list.appendChild(row);
-            }
-        }
-
-        selectPupil(pupil) {
-            if (
-                this.locked
-                || this.finished
-                || this.isPupilLoadingVisible()
-                || pupil.PupilId === this.selectedPupil?.PupilId
-            ) return;
-
-            if (pupil.PupilId !== this.loadedPupilId) {
-                this.loadedPupilId = null;
-                this.lessons = [];
-                this.selectedLessonIds = new Set();
-                this.renderLessons();
-            }
-            this.selectedPupil = pupil;
-            this.setStatus(`Выбран пользователь: ${pupil.Email || 'email отсутствует'}`);
-            this.renderPupils();
-            this.renderState();
-        }
-
-        renderLessons() {
-            const list = this.elements.lessonsList;
-            list.replaceChildren();
-
-            if (this.lessons.length === 0) {
-                const empty = this.ownerDocument.createElement('p');
-                empty.className = 'edvibe-reset-empty';
-                empty.textContent = 'Для пользователя нет уроков.';
-                list.appendChild(empty);
-            }
-
-            for (const lesson of this.lessons) {
-                const label = this.ownerDocument.createElement('label');
-                label.className = 'edvibe-reset-row edvibe-reset-lesson';
-                const checkbox = this.ownerDocument.createElement('input');
-                checkbox.type = 'checkbox';
-                checkbox.value = String(lesson.MarathonLessonId);
-                checkbox.checked = this.selectedLessonIds.has(lesson.MarathonLessonId);
-                checkbox.disabled = this.locked || this.loading || this.finished;
-
-                const copy = this.ownerDocument.createElement('span');
-                copy.className = 'edvibe-reset-row-copy';
-                const name = this.ownerDocument.createElement('span');
-                name.className = 'edvibe-reset-row-name';
-                name.textContent = `${Number(lesson.Number) + 1}. ${lesson.Name}`;
-                const requestStatus = this.ownerDocument.createElement('span');
-                requestStatus.className = 'edvibe-reset-row-email';
-                requestStatus.textContent = lesson.LastRequest
-                    ? `Статус последнего запроса: ${lesson.LastRequest.Status}`
-                    : 'Нет запросов на проверку';
-                copy.append(name, requestStatus);
-                label.append(checkbox, copy);
-                checkbox.addEventListener('change', () =>
-                    this.toggleLesson(lesson.MarathonLessonId, checkbox.checked)
-                );
-                list.appendChild(label);
-            }
-
-            this.elements.selectAll.checked = this.lessons.length > 0
-                && this.selectedLessonIds.size === this.lessons.length;
-            this.elements.selectAll.indeterminate = this.selectedLessonIds.size > 0
-                && this.selectedLessonIds.size < this.lessons.length;
-            this.renderState();
-        }
-
-        toggleLesson(lessonId, selected) {
-            if (selected) {
-                this.selectedLessonIds.add(lessonId);
-            }
-            else {
-                this.selectedLessonIds.delete(lessonId);
-            }
-            this.elements.selectAll.checked = this.lessons.length > 0
-                && this.selectedLessonIds.size === this.lessons.length;
-            this.elements.selectAll.indeterminate = this.selectedLessonIds.size > 0
-                && this.selectedLessonIds.size < this.lessons.length;
-            this.renderState();
-        }
-
-        handleSelectAll() {
-            this.selectedLessonIds = this.elements.selectAll.checked
-                ? new Set(this.lessons.map((lesson) => lesson.MarathonLessonId))
-                : new Set();
-            this.renderLessons();
-        }
-
-        handleSearchInput() {
-            this.searchGeneration += 1;
-            this.cancelSearchTimer();
-            this.searchDebouncing = true;
-            this.suppressPupilPageLoading = true;
-            this.renderPupilLoadingState();
-            const query = this.normalizeSearchQuery(this.elements.search.value);
-            const generation = this.searchGeneration;
-            this.searchTimer = root.setTimeout(async () => {
-                if (!this.isCurrentSearch(generation, query)) {
-                    return;
-                }
-                this.searchTimer = null;
-                const needsRemotePupils = Boolean(
-                    query && this.filterPupils(query).length === 0 && this.hasMorePupils()
-                );
-                this.searchDebouncing = false;
-                if (needsRemotePupils || !this.pupilPageLoading) {
-                    this.suppressPupilPageLoading = false;
-                }
-                this.renderPupilLoadingState();
-                if (needsRemotePupils && !await this.continueSearch(generation, query)) {
-                    return;
-                }
-                if (!this.isCurrentSearch(generation, query)) {
-                    return;
-                }
-                this.appliedSearchQuery = query;
-                this.renderPupils();
-            }, this.searchDelay);
-        }
-
-        isCurrentSearch(generation, query) {
-            return !this.closed
-                && generation === this.searchGeneration
-                && query === this.normalizeSearchQuery(this.elements.search.value);
-        }
-
-        cancelSearchTimer() {
-            if (this.searchTimer === null) {
-                return;
-            }
-            root.clearTimeout(this.searchTimer);
-            this.searchTimer = null;
-        }
-
-        cancelSearch() {
-            this.searchGeneration += 1;
-            this.cancelSearchTimer();
-        }
-
-        async continueSearch(generation, query) {
-            while (
-                this.isCurrentSearch(generation, query)
-                && this.filterPupils(query).length === 0
-                && this.hasMorePupils()
-            ) {
-                if (!await this.loadNextPupilPage()) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        async loadNextPupilPage() {
-            if (this.closed || !this.loadNextPupils || !this.hasMorePupils()) {
-                return false;
-            }
-            if (this.pupilPagePromise) {
-                return this.pupilPagePromise;
-            }
-
-            this.suppressPupilPageLoading = false;
-            this.pupilPageLoading = true;
-            this.renderPupilLoadingState();
-            this.pupilPagePromise = (async () => {
-                try {
-                    const page = await this.loadNextPupils();
-                    if (this.closed) {
-                        return false;
-                    }
-                    this.allPupils = page.pupils;
-                    this.pupilTotal = page.total;
-                    this.renderPupils();
-                    if (this.currentStep === 'user' && !this.loading) {
-                        this.setStatus(
-                            `Загружено пользователей: ${this.allPupils.length} `
-                            + `из ${this.pupilTotal}`
-                        );
-                    }
-                    return true;
-                } catch (error) {
-                    if (!this.closed && this.currentStep === 'user' && !this.loading) {
-                        this.log(`Failed to load another pupil page (${this.errorType(error)}).`);
-                        this.setStatus(error.message, 'error');
-                    }
-                    return false;
-                } finally {
-                    this.pupilPagePromise = null;
-                    this.pupilPageLoading = false;
-                    if (!this.searchDebouncing) {
-                        this.suppressPupilPageLoading = false;
-                    }
-                    this.renderPupilLoadingState();
-                }
-            })();
-            return this.pupilPagePromise;
-        }
-
-        handlePupilsScroll() {
-            if (this.searchDebouncing) {
-                return;
-            }
-            const list = this.elements.pupilsList;
-            const distanceFromBottom = list.scrollHeight - list.scrollTop - list.clientHeight;
-            if (distanceFromBottom <= 24) {
-                this.loadNextPupilPage();
-            }
-        }
-
-        async handleNext() {
-            if (this.elements.next.disabled || !this.selectedPupil) {
-                return;
-            }
-            if (this.hasLoadedLessonsForSelectedPupil()) {
-                this.currentStep = 'lessons';
-                this.renderState();
-                this.elements.lessonsList.focus();
-                return;
-            }
-            if (!this.loadLessons) {
-                return;
-            }
-
-            try {
-                this.setLoading(`Загрузка уроков для ${this.selectedPupil.Email}...`);
-                const lessons = await this.loadLessons(this.selectedPupil);
-                this.showLessons(this.selectedPupil, lessons);
-            } catch (error) {
-                this.loading = false;
-                this.currentStep = 'user';
-                this.renderState();
-                this.log(
-                    `Failed to load lessons for PupilId ${this.selectedPupil.PupilId} `
-                    + `(${this.errorType(error)}).`
-                );
-                this.setStatus(error.message, 'error');
-            }
-        }
-
-        handleBack() {
-            if (this.elements.back.disabled) {
-                return;
-            }
-            if (this.finished) {
-                this.resetForAnotherUser();
-                return;
-            }
-            this.currentStep = 'user';
-            this.setStatus(
-                `Выбран пользователь: ${this.selectedPupil?.Email || 'email отсутствует'}`
-            );
-            this.renderState();
-            this.elements.search.focus();
-        }
-
-        handleSubmit() {
-            if (this.elements.submit.disabled) {
-                return;
-            }
-            this.dispatchEvent(new root.CustomEvent('edvibe-reset-request', {
-                detail: {
-                    pupil: this.selectedPupil,
-                    lessons: this.lessons.filter((lesson) =>
-                        this.selectedLessonIds.has(lesson.MarathonLessonId)
-                    )
-                }
-            }));
-        }
-
-        handleBackdropClick(event) {
-            if (event.target === this.elements.backdrop) {
-                this.close();
-            }
-        }
-
-        handleKeydown(event) {
-            if (event.key === 'Escape') {
-                this.close();
-            }
-        }
-
-        close() {
-            if (this.locked || this.loading || this.closed) {
-                return;
-            }
-            this.closed = true;
-            this.cancelSearch();
-            this.dispatchEvent(new root.CustomEvent('edvibe-dialog-close'));
-            this.remove();
-        }
-
-        resetForAnotherUser() {
-            this.finished = false;
-            this.currentStep = 'user';
-            this.selectedPupil = null;
-            this.loadedPupilId = null;
-            this.lessons = [];
-            this.selectedLessonIds = new Set();
-            this.elements.search.value = '';
-            this.appliedSearchQuery = '';
-            this.cancelSearch();
-            this.searchDebouncing = false;
-            this.suppressPupilPageLoading = false;
-            this.elements.selectedPupilLabel.textContent = '';
-            this.elements.progress.classList.remove('is-visible', 'is-indeterminate');
-            this.elements.progress.value = 0;
-            this.setStatus(
-                `Загружено пользователей: ${this.allPupils.length} из ${this.pupilTotal}`
-            );
-            this.renderLessons();
-            this.renderPupils();
-            this.renderState();
-            this.elements.search.focus();
-        }
-
-        showPupils(options = {}) {
-            if (!this.elements) {
-                return this;
-            }
-            options = options && typeof options === 'object' ? options : {};
-            const pupils = Array.isArray(options.pupils) ? options.pupils : [];
-            const total = Number.isFinite(Number(options.total))
-                ? Number(options.total)
-                : pupils.length;
-            this.allPupils = pupils;
-            this.pupilTotal = total;
-            this.currentStep = 'user';
-            this.loading = false;
-            this.setStatus(`Загружено пользователей: ${pupils.length} из ${total}`);
-            this.renderPupils();
-            this.renderState();
-            this.elements.search.focus();
-            return this;
-        }
-
-        showLessons(pupil, lessons) {
-            if (!this.elements || !pupil || typeof pupil !== 'object') {
-                return this;
-            }
-            lessons = Array.isArray(lessons) ? lessons : [];
-            const pupilChanged = this.loadedPupilId !== pupil.PupilId;
-            this.selectedPupil = pupil;
-            this.loadedPupilId = pupil.PupilId;
-            this.lessons = lessons;
-            if (pupilChanged) {
-                this.selectedLessonIds = new Set();
-            }
-            this.loading = false;
-            this.currentStep = 'lessons';
-            this.elements.selectedPupilLabel.textContent =
-                `${pupil.Name || 'Без имени'} — ${pupil.Email || ''}`;
-            this.setStatus(`Загружено уроков: ${lessons.length}`);
-            this.renderLessons();
-            this.renderState();
-            this.elements.lessonsList.focus();
-            return this;
-        }
-
-        setLoading(message) {
-            this.loading = true;
-            this.setStatus(message);
-            this.renderState();
-        }
-
-        lock() {
-            this.locked = true;
-            this.classList.toggle('is-running', true);
-            this.renderLessons();
-            this.renderState();
-        }
-
-        completeRun() {
-            this.locked = false;
-            this.finished = true;
-            this.classList.toggle('is-running', false);
-            this.renderState();
-        }
-
-        unlockAfterRun() {
-            this.locked = false;
-            this.finished = false;
-            this.classList.toggle('is-running', false);
-            this.renderState();
-        }
-
-        showDiscovery(message) {
-            this.setStatus(message);
-            this.elements.progress.classList.add('is-visible', 'is-indeterminate');
-            this.elements.progress.removeAttribute('value');
-        }
-
-        showProgress(options = {}) {
-            if (!this.elements) {
-                return;
-            }
-            options = options && typeof options === 'object' ? options : {};
-            const completed = Number(options.completed) || 0;
-            const total = Number(options.total) || 0;
-            const lesson = options.lesson && typeof options.lesson === 'object'
-                ? options.lesson
-                : {};
-            const exerciseId = options.exerciseId;
-            const percent = total > 0 ? Math.round((completed / total) * 100) : 100;
-            const detail = exerciseId ? `Упражнение ${exerciseId}` : 'Удаление запроса урока';
-            this.setStatus(`${lesson.Name}\n${detail} — ${completed} / ${total}`);
-            this.elements.progress.classList.add('is-visible');
-            this.elements.progress.classList.remove('is-indeterminate');
-            this.elements.progress.value = percent;
-        }
-
-        showComplete(message) {
-            this.setStatus(message, 'success');
-            this.elements.progress.classList.add('is-visible');
-            this.elements.progress.classList.remove('is-indeterminate');
-            this.elements.progress.value = 100;
-        }
-
-        showError(message) {
-            if (!this.locked) {
-                this.loading = false;
-                this.renderState();
-            }
-            this.setStatus(message, 'error');
-            this.elements.progress.classList.remove('is-indeterminate');
-        }
-
-        errorType(error) {
-            return typeof error?.name === 'string' ? error.name : 'Error';
-        }
-    }
-
-    if (root.customElements && root.HTMLElement) {
-        const existing = root.customElements.get(RESET_DIALOG_TAG);
-        if (!existing) {
-            root.customElements.define(RESET_DIALOG_TAG, ResetLessonsDialog);
-        }
-    }
-
-    return {
-        RESET_DIALOG_TAG,
-        RESET_OVERLAY_ID,
-        ResetLessonsDialog,
-    };
-});
+export { RESET_DIALOG_TAG, RESET_OVERLAY_ID, ResetLessonsDialog };

--- a/src/components/reset-lessons-dialog.test.js
+++ b/src/components/reset-lessons-dialog.test.js
@@ -2,121 +2,46 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const vm = require('node:vm');
 
-const componentPath = path.resolve(
-    __dirname,
-    '../src/components/reset-lessons-dialog.js'
-);
+const componentPath = path.resolve(__dirname, 'reset-lessons-dialog.js');
 const source = fs.readFileSync(componentPath, 'utf8');
-const {
-    RESET_DIALOG_TAG,
-    RESET_OVERLAY_ID,
-    ResetLessonsDialog
-} = require(componentPath);
 
-test('exports a named custom element class without requiring browser globals', () => {
-    assert.equal(RESET_DIALOG_TAG, 'edvibe-toolbox-reset-dialog');
-    assert.equal(RESET_OVERLAY_ID, 'edvibe-toolbox-reset-overlay');
-    assert.equal(ResetLessonsDialog.name, 'ResetLessonsDialog');
-    assert.equal(typeof ResetLessonsDialog.prototype.render, 'function');
-    assert.equal(typeof ResetLessonsDialog.prototype.configure, 'function');
-    assert.equal(typeof ResetLessonsDialog.prototype.showPupils, 'function');
-    assert.equal(typeof ResetLessonsDialog.prototype.showLessons, 'function');
+test('reset lessons dialog is implemented as a Lit component', () => {
+    assert.match(source, /import \{ LitElement, html, nothing \} from 'lit';/);
+    assert.match(source, /class ResetLessonsDialog extends LitElement/);
+    assert.match(source, /return html`/);
+    assert.match(source, /static properties = \{/);
+    assert.doesNotMatch(source, /createElement\?\.\('template'\)/);
+    assert.doesNotMatch(source, /content\.cloneNode\(true\)/);
+    assert.doesNotMatch(source, /module\.exports/);
 });
 
-test('registers the named class automatically in a browser context', () => {
-    const constructors = new Map();
-
-    class FakeHTMLElement {
-        attachShadow({ mode }) {
-            this.shadowRoot = { mode };
-            return this.shadowRoot;
-        }
+test('reset lessons dialog preserves the feature integration surface', () => {
+    for (const method of [
+        'configure',
+        'showPupils',
+        'showLessons',
+        'setLoading',
+        'lock',
+        'completeRun',
+        'unlockAfterRun',
+        'showDiscovery',
+        'showProgress',
+        'showComplete',
+        'showError'
+    ]) {
+        assert.match(source, new RegExp(`${method}\\(`));
     }
-
-    const context = {
-        HTMLElement: FakeHTMLElement,
-        customElements: {
-            get: (tagName) => constructors.get(tagName),
-            define: (tagName, constructor) => constructors.set(tagName, constructor)
-        },
-        CustomEvent: class {},
-        setTimeout,
-        clearTimeout
-    };
-    context.globalThis = context;
-    vm.runInNewContext(source, context);
-
-    const api = context.EdVibeResetDialogComponent;
-    assert.equal(constructors.get(RESET_DIALOG_TAG), api.ResetLessonsDialog);
-    const element = new api.ResetLessonsDialog();
-    assert.equal(element.id, undefined);
-    assert.equal(element.shadowRoot, undefined);
-    assert.doesNotThrow(() => element.connectedCallback());
+    assert.match(source, /new CustomEvent\('edvibe-reset-request'/);
+    assert.match(source, /new CustomEvent\('edvibe-dialog-close'/);
+    assert.match(source, /globalThis\.EdVibeResetDialogComponent = resetDialogApi;/);
 });
 
-test('keeps markup, rendering, and dialog state inside the component class', () => {
-    assert.match(source, /class ResetLessonsDialog extends HTMLElementBase/);
-    assert.match(source, /render\(\)\s*\{/);
-    assert.match(source, /renderPupils\(\)\s*\{/);
-    assert.match(source, /renderLessons\(\)\s*\{/);
-    assert.match(source, /renderState\(\)\s*\{/);
-    assert.match(source, /createElement\?\.\('template'\)/);
-    assert.match(source, /content\.cloneNode\(true\)/);
-    assert.doesNotMatch(source, /shadowRoot\.innerHTML/);
-    assert.match(source, /role="dialog"/);
-    assert.match(source, /aria-modal="true"/);
-    assert.match(source, /class="edvibe-reset-live-region"/);
-    assert.match(source, /class="edvibe-reset-lesson-step"[\s\S]*hidden/);
-});
-
-test('owns case-insensitive pupil filtering and wizard state calculation', () => {
-    const dialog = new ResetLessonsDialog();
-    const pupils = [
-        { PupilId: 1, Email: 'first@example.com' },
-        { PupilId: 2, Email: 'OTHER@EXAMPLE.COM' },
-        { PupilId: 3, Email: null }
-    ];
-    dialog.allPupils = pupils;
-
-    assert.deepEqual(dialog.filterPupils('other@'), [pupils[1]]);
-    assert.equal(dialog.filterPupils(''), pupils);
-
-    dialog.selectedPupil = pupils[0];
-    dialog.selectedLessonIds = new Set([10]);
-    dialog.currentStep = 'lessons';
-    assert.deepEqual(dialog.getViewState(), {
-        showingUsers: false,
-        nextDisabled: false,
-        backDisabled: false,
-        submitDisabled: false,
-        closeDisabled: false
-    });
-});
-
-test('does not expose test-platform or markup factory abstractions', () => {
-    assert.doesNotMatch(source, /function resolvePlatform/);
-    assert.doesNotMatch(source, /function createConstructor/);
-    assert.doesNotMatch(source, /function getResetModalMarkup/);
-    assert.doesNotMatch(source, /function getResetDialogMarkup/);
-    assert.doesNotMatch(source, /createResetDialogElement/);
-});
-
-test('owns lifecycle cleanup and emits host-level workflow events', () => {
-    assert.match(source, /connectedCallback\(\)/);
-    assert.match(source, /this\.id = RESET_OVERLAY_ID/);
-    assert.match(source, /disconnectedCallback\(\)/);
-    assert.match(source, /disconnectListeners\(\)/);
-    assert.match(source, /new root\.CustomEvent\('edvibe-dialog-close'/);
-    assert.match(source, /new root\.CustomEvent\('edvibe-reset-request'/);
-});
-
-test('fails silently for unavailable DOM and unexpected workflow inputs', () => {
-    const dialog = new ResetLessonsDialog();
-    assert.doesNotThrow(() => dialog.connectedCallback());
-    assert.doesNotThrow(() => dialog.configure(null));
-    assert.doesNotThrow(() => dialog.showPupils(null));
-    assert.doesNotThrow(() => dialog.showLessons(null, null));
-    assert.doesNotThrow(() => dialog.showProgress(null));
+test('reset lessons dialog owns declarative pupil and lesson rendering', () => {
+    assert.match(source, /renderPupilRows\(\)/);
+    assert.match(source, /renderLessonRows\(inputsBlocked\)/);
+    assert.match(source, /\.map\(\(pupil\) =>/);
+    assert.match(source, /this\.lessons\.map\(\(lesson\) => html`/);
+    assert.match(source, /@input=\$\{this\.handleSearchInput\}/);
+    assert.match(source, /@change=\$\{this\.handleSelectAll\}/);
 });

--- a/test-path-compat.cjs
+++ b/test-path-compat.cjs
@@ -29,3 +29,18 @@ Module._resolveFilename = function resolveFilename(request, parent, isMain, opti
     return originalResolveFilename.call(this, correctedRequest, parent, isMain, options);
   }
 };
+
+const originalLoad = Module._load;
+Module._load = function loadWithBrowserComponentCompatibility(request, parent, isMain) {
+  const parentFilename = parent?.filename || '';
+  if (
+    parentFilename.endsWith(`${path.sep}src${path.sep}features${path.sep}reset-lessons.js`)
+    && request === '../components/reset-lessons-dialog.js'
+  ) {
+    return {
+      RESET_DIALOG_TAG: 'edvibe-toolbox-reset-dialog',
+      RESET_OVERLAY_ID: 'edvibe-toolbox-reset-overlay'
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};


### PR DESCRIPTION
## Summary
- migrate the reset lessons dialog to Lit with declarative pupil, lesson, wizard, status, and progress rendering
- preserve debounce search, pagination, selection, workflow events, run locking, progress, error, and completion behavior
- keep the existing global feature integration surface while browser components transition to ESM
- move browser behavior coverage into the real Chrome component suite and retain source-level architecture assertions for Node

Closes #31