### PR TITLE
Migrate execution history dialog to Lit

### DIFF
--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -46,6 +46,9 @@ async function run() {
 
     const { runResetLessonsDialogTests } = await import('./reset-lessons-dialog-tests.js');
     await runResetLessonsDialogTests();
+
+    const { runExecutionHistoryDialogTests } = await import('./execution-history-dialog-tests.js');
+    await runExecutionHistoryDialogTests();
 }
 
 async function report(status, message) {

--- a/src/component-tests/execution-history-dialog-tests.js
+++ b/src/component-tests/execution-history-dialog-tests.js
@@ -1,0 +1,128 @@
+import {
+    createSummary,
+    formatExecutionStatus
+} from '../components/execution-history-dialog.js';
+import {
+    cleanup,
+    elementUpdated,
+    equal,
+    fixture,
+    shadowQuery
+} from './component-test-harness.js';
+
+function createRecord(id, operationType, status = 'completed') {
+    return {
+        id,
+        operationType,
+        status,
+        pageContext: {marathonId: 42, marathonName: 'Course'},
+        startedAt: '2026-08-01T10:00:00.000Z',
+        completedAt: '2026-08-01T10:01:00.000Z',
+        counts: {successful: 2, failed: 1, skipped: 0},
+        results: [{
+            status: 'failed',
+            label: 'User one',
+            message: 'Rejected',
+            code: 'bad-input',
+            attempts: 1,
+            data: {email: 'user@example.com'}
+        }]
+    };
+}
+
+export async function runExecutionHistoryDialogTests() {
+    equal(formatExecutionStatus('completed_with_failures'), 'Completed with failures');
+    const summary = createSummary(createRecord('summary', 'batch-demo'));
+    equal(summary.title, 'batch-demo');
+    equal(summary.subtitle, 'Course');
+    equal(summary.outcome, '2 successful · 1 failed · 0 skipped');
+
+    let records = [
+        createRecord('one', 'batch-demo'),
+        createRecord('two', 'batch-other', 'cancelled')
+    ];
+    const calls = {filters: [], exported: [], deleted: [], cleared: 0, preferences: []};
+    const service = {
+        async list(filters) {
+            calls.filters.push({...filters});
+            return [...records];
+        },
+        async get(id) {
+            return records.find((record) => record.id === id) || null;
+        },
+        async getPreferences() {
+            return {mode: 'limits', maxCount: 25, maxAgeDays: 30, autoExport: false};
+        },
+        async setPreferences(preferences) {
+            calls.preferences.push(preferences);
+        },
+        async exportFiltered(filters) {
+            calls.exported.push({type: 'filtered', filters: {...filters}});
+        },
+        async exportRecord(id) {
+            calls.exported.push({type: 'record', id});
+        },
+        async delete(id) {
+            calls.deleted.push(id);
+            records = records.filter((record) => record.id !== id);
+        },
+        async clear() {
+            calls.cleared += 1;
+            records = [];
+        }
+    };
+
+    let closeCalls = 0;
+    const dialog = await fixture('<edvibe-toolbox-execution-history-dialog></edvibe-toolbox-execution-history-dialog>');
+    dialog.configure({
+        stylesheetUrl: '/src/components/execution-history-dialog.css',
+        service,
+        onClose: () => { closeCalls += 1; }
+    });
+    dialog.confirm = () => true;
+    await dialog.initialize();
+    await elementUpdated(dialog);
+
+    equal(shadowQuery(dialog, '[data-role="record-count"]').textContent, '2 executions');
+    equal(shadowQuery(dialog, '[data-role="record-list"]').querySelectorAll('.record-card').length, 2);
+    equal(shadowQuery(dialog, '[name="maxCount"]').value, '25');
+    equal(shadowQuery(dialog, '[name="maxAgeDays"]').value, '30');
+
+    await dialog.openRecord('one');
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '[data-role="detail"] h3').textContent, 'batch-demo');
+    equal(shadowQuery(dialog, '[data-role="detail"]').textContent.includes('User one'), true);
+
+    dialog.setFilter('status', 'completed');
+    await dialog.loadRecords();
+    equal(calls.filters.at(-1).status, 'completed');
+
+    await dialog.handleAction('export-filtered');
+    equal(calls.exported.at(-1).type, 'filtered');
+    equal(calls.exported.at(-1).filters.status, 'completed');
+
+    await dialog.openRecord('one');
+    await dialog.handleAction('download-one');
+    equal(calls.exported.at(-1).id, 'one');
+
+    dialog.updatePreference('mode', 'indefinite');
+    dialog.updatePreference('autoExport', true);
+    await dialog.handleAction('save-preferences');
+    equal(calls.preferences.at(-1).mode, 'indefinite');
+    equal(calls.preferences.at(-1).autoExport, true);
+
+    await dialog.openRecord('one');
+    await dialog.handleAction('delete-one');
+    await elementUpdated(dialog);
+    equal(calls.deleted[0], 'one');
+    equal(shadowQuery(dialog, '[data-role="record-count"]').textContent, '1 execution');
+
+    await dialog.handleAction('clear-all');
+    await elementUpdated(dialog);
+    equal(calls.cleared, 1);
+    equal(shadowQuery(dialog, '[data-role="state"]').textContent, 'No executions match these filters.');
+
+    await dialog.handleAction('close');
+    equal(closeCalls, 1);
+    await cleanup();
+}

--- a/src/components/execution-history-dialog.js
+++ b/src/components/execution-history-dialog.js
@@ -1,319 +1,425 @@
-(function initializeExecutionHistoryDialog(root, factory) {
-    const api = factory(root);
-    if (typeof module === 'object' && module.exports) module.exports = api;
-    else root.EdVibeExecutionHistoryDialog = api;
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(root) {
-    'use strict';
+import { LitElement, html } from 'lit';
 
-    const EXECUTION_HISTORY_DIALOG_TAG = 'edvibe-toolbox-execution-history-dialog';
-    const STATUS_LABELS = Object.freeze({
-        completed: 'Completed',
-        completed_with_failures: 'Completed with failures',
-        cancelled: 'Cancelled',
-        interrupted: 'Interrupted'
-    });
-
-    function formatExecutionStatus(status) {
-        return STATUS_LABELS[status] || String(status || 'Unknown');
-    }
-
-    function formatExecutionDate(value, locale) {
-        const date = new Date(value);
-        return Number.isNaN(date.getTime()) ? String(value || '') : new Intl.DateTimeFormat(locale || undefined, {
-            dateStyle: 'medium',
-            timeStyle: 'short'
-        }).format(date);
-    }
-
-    function createSummary(record) {
-        return Object.freeze({
-            title: record.operationType,
-            subtitle: record.pageContext?.marathonName
-                || (record.pageContext?.marathonId ? `Marathon #${record.pageContext.marathonId}` : 'No marathon context'),
-            outcome: `${record.counts.successful} successful · ${record.counts.failed} failed · ${record.counts.skipped} skipped`
-        });
-    }
-
-    function createNode(documentApi, tagName, className = '', text = '') {
-        const element = documentApi.createElement(tagName);
-        if (className) element.className = className;
-        if (text !== '') element.textContent = String(text);
-        return element;
-    }
-
-    if (root.customElements && root.HTMLElement && !root.customElements.get(EXECUTION_HISTORY_DIALOG_TAG)) {
-        root.customElements.define(EXECUTION_HISTORY_DIALOG_TAG, class ExecutionHistoryDialog extends root.HTMLElement {
-            constructor() {
-                super();
-                this.attachShadow({ mode: 'open' });
-                this.options = null;
-                this.records = [];
-                this.selectedRecord = null;
-                this.connection = null;
-                this.shellRendered = false;
-            }
-
-            configure(options = {}) {
-                this.options = options;
-                if (this.isConnected) this.initialize();
-                return this;
-            }
-
-            connectedCallback() { this.initialize(); }
-            disconnectedCallback() { this.connection?.abort(); this.connection = null; }
-
-            initialize() {
-                if (!this.options) return;
-                const firstRender = !this.shellRendered;
-                if (firstRender) { this.shellRendered = true; this.renderShell(); }
-                if (this.connection) return;
-                this.connection = new AbortController();
-                const signal = this.connection.signal;
-                this.shadowRoot.addEventListener('click', (event) => this.handleClick(event), { signal });
-                this.shadowRoot.addEventListener('change', (event) => this.handleChange(event), { signal });
-                this.addEventListener('keydown', (event) => {
-                    if (event.key === 'Escape') this.options.onClose?.();
-                }, { signal });
-                if (!firstRender) return;
-                this.shadowRoot.querySelector('[data-action="close"]')?.focus();
-                this.loadPreferences();
-                this.loadRecords().then(() => {
-                    if (this.options.initialExecutionId) this.openRecord(this.options.initialExecutionId);
-                });
-            }
-
-            renderShell() {
-                this.shadowRoot.innerHTML = `
-                    <link rel="stylesheet" href="${String(this.options.stylesheetUrl || '')}">
-                    <div class="overlay"><section class="dialog" role="dialog" aria-modal="true" aria-labelledby="history-title">
-                        <header class="dialog-header"><div><p class="eyebrow">Edvibe Toolbox</p><h2 id="history-title">Execution history</h2><p class="header-copy">Browse terminal operation reports stored in this browser.</p></div><button class="icon-button" type="button" data-action="close" aria-label="Close">×</button></header>
-                        <div class="workspace">
-                            <aside class="browser-panel">
-                                <form class="filters" data-role="filters">
-                                    <label>Operation<select name="operationType"><option value="">All operations</option></select></label>
-                                    <label>Status<select name="status"><option value="">All statuses</option><option value="completed">Completed</option><option value="completed_with_failures">Completed with failures</option><option value="cancelled">Cancelled</option><option value="interrupted">Interrupted</option></select></label>
-                                    <label>Marathon<input name="marathonId" type="search" inputmode="numeric" placeholder="Any marathon"></label>
-                                    <div class="date-fields"><label>From<input name="from" type="date"></label><label>To<input name="to" type="date"></label></div>
-                                    <div class="filter-actions"><button type="submit">Apply</button><button type="button" class="secondary" data-action="reset-filters">Reset</button></div>
-                                </form>
-                                <div class="list-toolbar"><strong data-role="record-count">0 executions</strong><button type="button" class="secondary compact" data-action="export-filtered">Export filtered</button></div>
-                                <div class="state-card" data-role="state">Loading history…</div><div class="record-list" data-role="record-list" hidden></div>
-                            </aside>
-                            <main class="detail-panel" data-role="detail"></main>
-                        </div>
-                        <footer class="dialog-footer">
-                            <details class="retention-settings"><summary>Retention & automatic export</summary><div class="settings-grid">
-                                <label class="checkbox"><input type="checkbox" name="keepIndefinitely">Keep indefinitely</label>
-                                <label>Newest executions<input type="number" name="maxCount" min="1" step="1"></label>
-                                <label>Maximum age, days<input type="number" name="maxAgeDays" min="1" step="1"></label>
-                                <label class="checkbox"><input type="checkbox" name="autoExport">Download JSON after persistence</label>
-                                <button type="button" data-action="save-preferences">Save settings</button>
-                            </div></details>
-                            <div class="footer-actions"><button type="button" class="danger secondary" data-action="clear-all">Clear all history</button><button type="button" data-action="close">Close</button></div>
-                            <p class="toast" data-role="toast" role="status" hidden></p>
-                        </footer>
-                    </section></div>`;
-                this.shadowRoot.querySelector('[data-role="filters"]').addEventListener('submit', (event) => {
-                    event.preventDefault();
-                    this.loadRecords();
-                });
-                this.renderEmptyDetail();
-            }
-
-            get filters() {
-                const data = new FormData(this.shadowRoot.querySelector('[data-role="filters"]'));
-                return Object.fromEntries([...data.entries()].filter(([, value]) => value !== ''));
-            }
-
-            async loadRecords() {
-                this.showState('Loading history…');
-                try {
-                    this.records = await this.options.service.list(this.filters);
-                    this.populateOperationTypes();
-                    this.renderRecords();
-                } catch (error) {
-                    this.showState(error.message || 'Could not load execution history.', true);
-                }
-            }
-
-            populateOperationTypes() {
-                const select = this.shadowRoot.querySelector('[name="operationType"]');
-                const selected = select.value;
-                const existing = new Set([...select.options].map((option) => option.value));
-                for (const operationType of [...new Set(this.records.map((record) => record.operationType))].sort()) {
-                    if (existing.has(operationType)) continue;
-                    const option = this.ownerDocument.createElement('option');
-                    option.value = operationType;
-                    option.textContent = operationType;
-                    select.append(option);
-                }
-                select.value = selected;
-            }
-
-            showState(message, isError = false) {
-                const state = this.shadowRoot.querySelector('[data-role="state"]');
-                state.textContent = message;
-                state.classList.toggle('is-error', isError);
-                state.hidden = false;
-                this.shadowRoot.querySelector('[data-role="record-list"]').hidden = true;
-            }
-
-            renderRecords() {
-                const documentApi = this.ownerDocument;
-                const list = this.shadowRoot.querySelector('[data-role="record-list"]');
-                const state = this.shadowRoot.querySelector('[data-role="state"]');
-                this.shadowRoot.querySelector('[data-role="record-count"]').textContent = `${this.records.length} execution${this.records.length === 1 ? '' : 's'}`;
-                list.replaceChildren();
-                if (this.records.length === 0) { this.showState('No executions match these filters.'); return; }
-                for (const record of this.records) {
-                    const summary = createSummary(record);
-                    const button = createNode(documentApi, 'button', 'record-card');
-                    button.type = 'button';
-                    button.dataset.executionId = record.id;
-                    button.dataset.status = record.status;
-                    button.setAttribute('aria-pressed', String(this.selectedRecord?.id === record.id));
-                    const heading = createNode(documentApi, 'span', 'record-heading');
-                    heading.append(createNode(documentApi, 'strong', '', summary.title), createNode(documentApi, 'span', 'status-chip', formatExecutionStatus(record.status)));
-                    button.append(heading, createNode(documentApi, 'span', 'record-context', summary.subtitle), createNode(documentApi, 'span', 'record-outcome', summary.outcome), createNode(documentApi, 'time', '', formatExecutionDate(record.completedAt)));
-                    list.append(button);
-                }
-                state.hidden = true;
-                list.hidden = false;
-            }
-
-            renderEmptyDetail() {
-                this.selectedRecord = null;
-                const panel = this.shadowRoot.querySelector('[data-role="detail"]');
-                panel.innerHTML = '<div class="detail-placeholder"><span aria-hidden="true">↗</span><h3>Select an execution</h3><p>Its summary and ordered item outcomes will appear here.</p></div>';
-            }
-
-            async openRecord(executionId) {
-                try {
-                    const record = await this.options.service.get(executionId);
-                    if (!record) throw new Error('Execution record was not found.');
-                    this.selectedRecord = record;
-                    this.renderRecords();
-                    this.renderDetail(record);
-                } catch (error) {
-                    this.showToast(error.message || 'Could not open the execution.', true);
-                }
-            }
-
-            renderDetail(record) {
-                const documentApi = this.ownerDocument;
-                const panel = this.shadowRoot.querySelector('[data-role="detail"]');
-                panel.replaceChildren();
-                const header = createNode(documentApi, 'section', 'detail-header');
-                const heading = createNode(documentApi, 'div');
-                heading.append(createNode(documentApi, 'h3', '', record.operationType), createNode(documentApi, 'p', '', `${formatExecutionStatus(record.status)} · ${formatExecutionDate(record.completedAt)}`));
-                const actions = createNode(documentApi, 'div', 'detail-actions');
-                for (const [action, label, className] of [['download-one', 'Download JSON', 'secondary'], ['delete-one', 'Delete', 'danger secondary']]) {
-                    const button = createNode(documentApi, 'button', className, label); button.type = 'button'; button.dataset.action = action; actions.append(button);
-                }
-                header.append(heading, actions);
-
-                const context = createNode(documentApi, 'dl', 'summary-grid');
-                for (const [label, value] of [['Execution ID', record.id], ['Marathon', record.pageContext?.marathonName || record.pageContext?.marathonId || 'Not recorded'], ['Started', formatExecutionDate(record.startedAt)], ['Completed', formatExecutionDate(record.completedAt)]]) {
-                    const group = createNode(documentApi, 'div'); group.append(createNode(documentApi, 'dt', '', label), createNode(documentApi, 'dd', '', value)); context.append(group);
-                }
-
-                const counts = createNode(documentApi, 'section', 'counts');
-                for (const [key, value] of Object.entries(record.counts)) {
-                    const item = createNode(documentApi, 'div'); item.append(createNode(documentApi, 'strong', '', value), createNode(documentApi, 'span', '', key.replace(/[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`))); counts.append(item);
-                }
-
-                const outcomes = createNode(documentApi, 'section', 'outcomes');
-                outcomes.append(createNode(documentApi, 'h4', '', `Item outcomes (${record.results.length})`));
-                if (record.results.length === 0) outcomes.append(createNode(documentApi, 'p', 'muted', 'No per-item outcomes were recorded.'));
-                for (const result of record.results) outcomes.append(this.renderOutcome(result));
-                panel.append(header, context, counts, outcomes);
-            }
-
-            renderOutcome(result) {
-                const documentApi = this.ownerDocument;
-                const article = createNode(documentApi, 'article', 'outcome-card');
-                article.dataset.status = result.status;
-                const row = createNode(documentApi, 'div');
-                row.append(createNode(documentApi, 'strong', '', result.label), createNode(documentApi, 'span', 'status-chip', result.status));
-                article.append(row, createNode(documentApi, 'p', '', result.message), createNode(documentApi, 'small', '', `${result.code} · ${result.attempts} attempt${result.attempts === 1 ? '' : 's'}`));
-                if (result.data && Object.keys(result.data).length > 0) {
-                    const details = createNode(documentApi, 'details');
-                    details.append(createNode(documentApi, 'summary', '', 'Item details'), createNode(documentApi, 'pre', '', JSON.stringify(result.data, null, 2)));
-                    article.append(details);
-                }
-                return article;
-            }
-
-            async loadPreferences() {
-                try {
-                    const preferences = await this.options.service.getPreferences();
-                    this.shadowRoot.querySelector('[name="keepIndefinitely"]').checked = preferences.mode === 'indefinite';
-                    this.shadowRoot.querySelector('[name="maxCount"]').value = preferences.maxCount;
-                    this.shadowRoot.querySelector('[name="maxAgeDays"]').value = preferences.maxAgeDays;
-                    this.shadowRoot.querySelector('[name="autoExport"]').checked = preferences.autoExport;
-                    this.syncPreferenceControls();
-                } catch (error) { this.showToast(error.message || 'Could not load retention settings.', true); }
-            }
-
-            syncPreferenceControls() {
-                const indefinite = this.shadowRoot.querySelector('[name="keepIndefinitely"]').checked;
-                this.shadowRoot.querySelector('[name="maxCount"]').disabled = indefinite;
-                this.shadowRoot.querySelector('[name="maxAgeDays"]').disabled = indefinite;
-            }
-
-            async savePreferences() {
-                const preferences = {
-                    mode: this.shadowRoot.querySelector('[name="keepIndefinitely"]').checked ? 'indefinite' : 'limits',
-                    maxCount: Number(this.shadowRoot.querySelector('[name="maxCount"]').value),
-                    maxAgeDays: Number(this.shadowRoot.querySelector('[name="maxAgeDays"]').value),
-                    autoExport: this.shadowRoot.querySelector('[name="autoExport"]').checked
-                };
-                try { await this.options.service.setPreferences(preferences); this.showToast('Retention settings saved.'); }
-                catch (error) { this.showToast(error.message || 'Could not save retention settings.', true); }
-            }
-
-            async handleClick(event) {
-                const target = event.target.closest('[data-action], [data-execution-id]');
-                if (!target) return;
-                if (target.dataset.executionId) { await this.openRecord(target.dataset.executionId); return; }
-                const action = target.dataset.action;
-                if (action === 'close') this.options.onClose?.();
-                if (action === 'reset-filters') { this.shadowRoot.querySelector('[data-role="filters"]').reset(); await this.loadRecords(); }
-                if (action === 'export-filtered') await this.runAction(() => this.options.service.exportFiltered(this.filters), 'Filtered history exported.', 'Could not export history.');
-                if (action === 'download-one' && this.selectedRecord) await this.runAction(() => this.options.service.exportRecord(this.selectedRecord.id), 'Execution exported.', 'Could not export execution.');
-                if (action === 'delete-one' && this.selectedRecord && this.confirm(`Delete execution ${this.selectedRecord.id}?`)) {
-                    await this.runMutation(() => this.options.service.delete(this.selectedRecord.id), 'Execution deleted.', 'Could not delete the execution.');
-                }
-                if (action === 'clear-all' && this.confirm('Clear all execution history? This cannot be undone.')) {
-                    await this.runMutation(() => this.options.service.clear(), 'Execution history cleared.', 'Could not clear execution history.');
-                }
-                if (action === 'save-preferences') await this.savePreferences();
-            }
-
-            confirm(message) { return this.ownerDocument.defaultView.confirm(message); }
-
-            async runAction(action, successMessage, failureMessage) {
-                try { await action(); this.showToast(successMessage); }
-                catch (error) { this.showToast(error.message || failureMessage, true); }
-            }
-
-            async runMutation(action, successMessage, failureMessage) {
-                try { await action(); this.renderEmptyDetail(); await this.loadRecords(); this.showToast(successMessage); }
-                catch (error) { this.showToast(error.message || failureMessage, true); }
-            }
-
-            handleChange(event) {
-                if (event.target.name === 'keepIndefinitely') this.syncPreferenceControls();
-            }
-
-            showToast(message, isError = false) {
-                const toast = this.shadowRoot.querySelector('[data-role="toast"]');
-                toast.textContent = message;
-                toast.classList.toggle('is-error', isError);
-                toast.hidden = false;
-            }
-        });
-    }
-
-    return Object.freeze({ EXECUTION_HISTORY_DIALOG_TAG, formatExecutionStatus, formatExecutionDate, createSummary });
+const EXECUTION_HISTORY_DIALOG_TAG = 'edvibe-toolbox-execution-history-dialog';
+const STATUS_LABELS = Object.freeze({
+    completed: 'Completed',
+    completed_with_failures: 'Completed with failures',
+    cancelled: 'Cancelled',
+    interrupted: 'Interrupted'
 });
+
+function formatExecutionStatus(status) {
+    return STATUS_LABELS[status] || String(status || 'Unknown');
+}
+
+function formatExecutionDate(value, locale) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value || '') : new Intl.DateTimeFormat(locale || undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+    }).format(date);
+}
+
+function createSummary(record) {
+    return Object.freeze({
+        title: record.operationType,
+        subtitle: record.pageContext?.marathonName
+            || (record.pageContext?.marathonId
+                ? `Marathon #${record.pageContext.marathonId}`
+                : 'No marathon context'),
+        outcome: `${record.counts.successful} successful · ${record.counts.failed} failed · ${record.counts.skipped} skipped`
+    });
+}
+
+class ExecutionHistoryDialog extends LitElement {
+    static properties = {
+        options: {state: true},
+        records: {state: true},
+        selectedRecord: {state: true},
+        operationTypes: {state: true},
+        filterOperationType: {state: true},
+        filterStatus: {state: true},
+        filterMarathonId: {state: true},
+        filterFrom: {state: true},
+        filterTo: {state: true},
+        listState: {state: true},
+        listMessage: {state: true},
+        preferences: {state: true},
+        toastMessage: {state: true},
+        toastError: {state: true}
+    };
+
+    constructor() {
+        super();
+        this.options = null;
+        this.records = [];
+        this.selectedRecord = null;
+        this.operationTypes = [];
+        this.filterOperationType = '';
+        this.filterStatus = '';
+        this.filterMarathonId = '';
+        this.filterFrom = '';
+        this.filterTo = '';
+        this.listState = 'loading';
+        this.listMessage = 'Loading history…';
+        this.preferences = {
+            mode: 'limits',
+            maxCount: '',
+            maxAgeDays: '',
+            autoExport: false
+        };
+        this.toastMessage = '';
+        this.toastError = false;
+        this.initializationPromise = null;
+        this.handleKeydownBound = (event) => {
+            if (event.key === 'Escape') this.options?.onClose?.();
+        };
+    }
+
+    configure(options = {}) {
+        this.options = options && typeof options === 'object' ? options : {};
+        if (this.isConnected) this.initialize();
+        return this;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.addEventListener('keydown', this.handleKeydownBound);
+        this.initialize();
+    }
+
+    disconnectedCallback() {
+        this.removeEventListener('keydown', this.handleKeydownBound);
+        super.disconnectedCallback();
+    }
+
+    initialize() {
+        if (!this.options) return Promise.resolve();
+        if (this.initializationPromise) return this.initializationPromise;
+        this.initializationPromise = (async () => {
+            await this.updateComplete;
+            this.shadowRoot?.querySelector('[data-action="close"]')?.focus();
+            await this.loadPreferences();
+            await this.loadRecords();
+            if (this.options.initialExecutionId) {
+                await this.openRecord(this.options.initialExecutionId);
+            }
+        })();
+        return this.initializationPromise;
+    }
+
+    get filters() {
+        const entries = {
+            operationType: this.filterOperationType,
+            status: this.filterStatus,
+            marathonId: this.filterMarathonId,
+            from: this.filterFrom,
+            to: this.filterTo
+        };
+        return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== ''));
+    }
+
+    setFilter(name, value) {
+        const normalized = String(value || '');
+        if (name === 'operationType') this.filterOperationType = normalized;
+        if (name === 'status') this.filterStatus = normalized;
+        if (name === 'marathonId') this.filterMarathonId = normalized;
+        if (name === 'from') this.filterFrom = normalized;
+        if (name === 'to') this.filterTo = normalized;
+    }
+
+    async loadRecords() {
+        this.listState = 'loading';
+        this.listMessage = 'Loading history…';
+        try {
+            this.records = await this.options.service.list(this.filters);
+            this.operationTypes = [...new Set([
+                ...this.operationTypes,
+                ...this.records.map((record) => record.operationType)
+            ])].sort();
+            this.listState = this.records.length === 0 ? 'empty' : 'ready';
+            this.listMessage = this.records.length === 0
+                ? 'No executions match these filters.'
+                : '';
+        } catch (error) {
+            this.records = [];
+            this.listState = 'error';
+            this.listMessage = error.message || 'Could not load execution history.';
+        }
+    }
+
+    renderEmptyDetail() {
+        this.selectedRecord = null;
+    }
+
+    async openRecord(executionId) {
+        try {
+            const record = await this.options.service.get(executionId);
+            if (!record) throw new Error('Execution record was not found.');
+            this.selectedRecord = record;
+        } catch (error) {
+            this.showToast(error.message || 'Could not open the execution.', true);
+        }
+    }
+
+    async loadPreferences() {
+        try {
+            const preferences = await this.options.service.getPreferences();
+            this.preferences = {
+                mode: preferences.mode,
+                maxCount: preferences.maxCount,
+                maxAgeDays: preferences.maxAgeDays,
+                autoExport: Boolean(preferences.autoExport)
+            };
+        } catch (error) {
+            this.showToast(error.message || 'Could not load retention settings.', true);
+        }
+    }
+
+    updatePreference(name, value) {
+        this.preferences = {...this.preferences, [name]: value};
+    }
+
+    async savePreferences() {
+        const preferences = {
+            mode: this.preferences.mode,
+            maxCount: Number(this.preferences.maxCount),
+            maxAgeDays: Number(this.preferences.maxAgeDays),
+            autoExport: Boolean(this.preferences.autoExport)
+        };
+        try {
+            await this.options.service.setPreferences(preferences);
+            this.showToast('Retention settings saved.');
+        } catch (error) {
+            this.showToast(error.message || 'Could not save retention settings.', true);
+        }
+    }
+
+    async resetFilters() {
+        this.filterOperationType = '';
+        this.filterStatus = '';
+        this.filterMarathonId = '';
+        this.filterFrom = '';
+        this.filterTo = '';
+        await this.loadRecords();
+    }
+
+    confirm(message) {
+        return this.ownerDocument.defaultView.confirm(message);
+    }
+
+    async runAction(action, successMessage, failureMessage) {
+        try {
+            await action();
+            this.showToast(successMessage);
+        } catch (error) {
+            this.showToast(error.message || failureMessage, true);
+        }
+    }
+
+    async runMutation(action, successMessage, failureMessage) {
+        try {
+            await action();
+            this.renderEmptyDetail();
+            await this.loadRecords();
+            this.showToast(successMessage);
+        } catch (error) {
+            this.showToast(error.message || failureMessage, true);
+        }
+    }
+
+    async handleAction(action) {
+        if (action === 'close') this.options.onClose?.();
+        if (action === 'reset-filters') await this.resetFilters();
+        if (action === 'export-filtered') {
+            await this.runAction(
+                () => this.options.service.exportFiltered(this.filters),
+                'Filtered history exported.',
+                'Could not export history.'
+            );
+        }
+        if (action === 'download-one' && this.selectedRecord) {
+            await this.runAction(
+                () => this.options.service.exportRecord(this.selectedRecord.id),
+                'Execution exported.',
+                'Could not export execution.'
+            );
+        }
+        if (
+            action === 'delete-one'
+            && this.selectedRecord
+            && this.confirm(`Delete execution ${this.selectedRecord.id}?`)
+        ) {
+            await this.runMutation(
+                () => this.options.service.delete(this.selectedRecord.id),
+                'Execution deleted.',
+                'Could not delete the execution.'
+            );
+        }
+        if (action === 'clear-all' && this.confirm('Clear all execution history? This cannot be undone.')) {
+            await this.runMutation(
+                () => this.options.service.clear(),
+                'Execution history cleared.',
+                'Could not clear execution history.'
+            );
+        }
+        if (action === 'save-preferences') await this.savePreferences();
+    }
+
+    showToast(message, isError = false) {
+        this.toastMessage = String(message || '');
+        this.toastError = Boolean(isError);
+    }
+
+    renderRecord(record) {
+        const summary = createSummary(record);
+        return html`
+            <button type="button" class="record-card" data-execution-id=${record.id}
+                data-status=${record.status}
+                aria-pressed=${String(this.selectedRecord?.id === record.id)}
+                @click=${() => this.openRecord(record.id)}>
+                <span class="record-heading">
+                    <strong>${summary.title}</strong>
+                    <span class="status-chip">${formatExecutionStatus(record.status)}</span>
+                </span>
+                <span class="record-context">${summary.subtitle}</span>
+                <span class="record-outcome">${summary.outcome}</span>
+                <time>${formatExecutionDate(record.completedAt)}</time>
+            </button>
+        `;
+    }
+
+    renderOutcome(result) {
+        const hasData = result.data && Object.keys(result.data).length > 0;
+        return html`
+            <article class="outcome-card" data-status=${result.status}>
+                <div><strong>${result.label}</strong><span class="status-chip">${result.status}</span></div>
+                <p>${result.message}</p>
+                <small>${result.code} · ${result.attempts} attempt${result.attempts === 1 ? '' : 's'}</small>
+                ${hasData ? html`
+                    <details><summary>Item details</summary><pre>${JSON.stringify(result.data, null, 2)}</pre></details>
+                ` : ''}
+            </article>
+        `;
+    }
+
+    renderDetail() {
+        const record = this.selectedRecord;
+        if (!record) {
+            return html`
+                <div class="detail-placeholder">
+                    <span aria-hidden="true">↗</span>
+                    <h3>Select an execution</h3>
+                    <p>Its summary and ordered item outcomes will appear here.</p>
+                </div>
+            `;
+        }
+        const context = [
+            ['Execution ID', record.id],
+            ['Marathon', record.pageContext?.marathonName || record.pageContext?.marathonId || 'Not recorded'],
+            ['Started', formatExecutionDate(record.startedAt)],
+            ['Completed', formatExecutionDate(record.completedAt)]
+        ];
+        return html`
+            <section class="detail-header">
+                <div>
+                    <h3>${record.operationType}</h3>
+                    <p>${formatExecutionStatus(record.status)} · ${formatExecutionDate(record.completedAt)}</p>
+                </div>
+                <div class="detail-actions">
+                    <button type="button" class="secondary" @click=${() => this.handleAction('download-one')}>Download JSON</button>
+                    <button type="button" class="danger secondary" @click=${() => this.handleAction('delete-one')}>Delete</button>
+                </div>
+            </section>
+            <dl class="summary-grid">
+                ${context.map(([label, value]) => html`<div><dt>${label}</dt><dd>${value}</dd></div>`)}
+            </dl>
+            <section class="counts">
+                ${Object.entries(record.counts).map(([key, value]) => html`
+                    <div><strong>${value}</strong><span>${key.replace(/[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`)}</span></div>
+                `)}
+            </section>
+            <section class="outcomes">
+                <h4>Item outcomes (${record.results.length})</h4>
+                ${record.results.length === 0
+                    ? html`<p class="muted">No per-item outcomes were recorded.</p>`
+                    : record.results.map((result) => this.renderOutcome(result))}
+            </section>
+        `;
+    }
+
+    render() {
+        const listVisible = this.listState === 'ready';
+        const stateVisible = !listVisible;
+        const stateClass = `state-card${this.listState === 'error' ? ' is-error' : ''}`;
+        const indefinite = this.preferences.mode === 'indefinite';
+        const toastClass = `toast${this.toastError ? ' is-error' : ''}`;
+
+        return html`
+            <link rel="stylesheet" href=${String(this.options?.stylesheetUrl || '')}>
+            <div class="overlay">
+                <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="history-title">
+                    <header class="dialog-header">
+                        <div><p class="eyebrow">Edvibe Toolbox</p><h2 id="history-title">Execution history</h2><p class="header-copy">Browse terminal operation reports stored in this browser.</p></div>
+                        <button class="icon-button" type="button" data-action="close" aria-label="Close" @click=${() => this.handleAction('close')}>×</button>
+                    </header>
+                    <div class="workspace">
+                        <aside class="browser-panel">
+                            <form class="filters" data-role="filters" @submit=${(event) => { event.preventDefault(); this.loadRecords(); }}>
+                                <label>Operation<select name="operationType" .value=${this.filterOperationType} @change=${(event) => this.setFilter('operationType', event.currentTarget.value)}>
+                                    <option value="">All operations</option>
+                                    ${this.operationTypes.map((operationType) => html`<option value=${operationType}>${operationType}</option>`)}
+                                </select></label>
+                                <label>Status<select name="status" .value=${this.filterStatus} @change=${(event) => this.setFilter('status', event.currentTarget.value)}>
+                                    <option value="">All statuses</option><option value="completed">Completed</option><option value="completed_with_failures">Completed with failures</option><option value="cancelled">Cancelled</option><option value="interrupted">Interrupted</option>
+                                </select></label>
+                                <label>Marathon<input name="marathonId" type="search" inputmode="numeric" placeholder="Any marathon" .value=${this.filterMarathonId} @input=${(event) => this.setFilter('marathonId', event.currentTarget.value)}></label>
+                                <div class="date-fields">
+                                    <label>From<input name="from" type="date" .value=${this.filterFrom} @input=${(event) => this.setFilter('from', event.currentTarget.value)}></label>
+                                    <label>To<input name="to" type="date" .value=${this.filterTo} @input=${(event) => this.setFilter('to', event.currentTarget.value)}></label>
+                                </div>
+                                <div class="filter-actions"><button type="submit">Apply</button><button type="button" class="secondary" @click=${() => this.handleAction('reset-filters')}>Reset</button></div>
+                            </form>
+                            <div class="list-toolbar"><strong data-role="record-count">${this.records.length} execution${this.records.length === 1 ? '' : 's'}</strong><button type="button" class="secondary compact" @click=${() => this.handleAction('export-filtered')}>Export filtered</button></div>
+                            <div class=${stateClass} data-role="state" ?hidden=${!stateVisible}>${this.listMessage}</div>
+                            <div class="record-list" data-role="record-list" ?hidden=${!listVisible}>${this.records.map((record) => this.renderRecord(record))}</div>
+                        </aside>
+                        <main class="detail-panel" data-role="detail">${this.renderDetail()}</main>
+                    </div>
+                    <footer class="dialog-footer">
+                        <details class="retention-settings"><summary>Retention & automatic export</summary><div class="settings-grid">
+                            <label class="checkbox"><input type="checkbox" name="keepIndefinitely" .checked=${indefinite} @change=${(event) => this.updatePreference('mode', event.currentTarget.checked ? 'indefinite' : 'limits')}>Keep indefinitely</label>
+                            <label>Newest executions<input type="number" name="maxCount" min="1" step="1" .value=${String(this.preferences.maxCount)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxCount', event.currentTarget.value)}></label>
+                            <label>Maximum age, days<input type="number" name="maxAgeDays" min="1" step="1" .value=${String(this.preferences.maxAgeDays)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxAgeDays', event.currentTarget.value)}></label>
+                            <label class="checkbox"><input type="checkbox" name="autoExport" .checked=${this.preferences.autoExport} @change=${(event) => this.updatePreference('autoExport', event.currentTarget.checked)}>Download JSON after persistence</label>
+                            <button type="button" @click=${() => this.handleAction('save-preferences')}>Save settings</button>
+                        </div></details>
+                        <div class="footer-actions"><button type="button" class="danger secondary" @click=${() => this.handleAction('clear-all')}>Clear all history</button><button type="button" @click=${() => this.handleAction('close')}>Close</button></div>
+                        <p class=${toastClass} data-role="toast" role="status" ?hidden=${!this.toastMessage}>${this.toastMessage}</p>
+                    </footer>
+                </section>
+            </div>
+        `;
+    }
+}
+
+if (!customElements.get(EXECUTION_HISTORY_DIALOG_TAG)) {
+    customElements.define(EXECUTION_HISTORY_DIALOG_TAG, ExecutionHistoryDialog);
+}
+
+const executionHistoryDialogApi = Object.freeze({
+    EXECUTION_HISTORY_DIALOG_TAG,
+    ExecutionHistoryDialog,
+    formatExecutionStatus,
+    formatExecutionDate,
+    createSummary
+});
+globalThis.EdVibeExecutionHistoryDialog = executionHistoryDialogApi;
+
+export {
+    EXECUTION_HISTORY_DIALOG_TAG,
+    ExecutionHistoryDialog,
+    formatExecutionStatus,
+    formatExecutionDate,
+    createSummary
+};

--- a/src/components/execution-history-dialog.test.js
+++ b/src/components/execution-history-dialog.test.js
@@ -1,10 +1,30 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const api = require('./execution-history-dialog.js');
+const fs = require('node:fs');
+const path = require('node:path');
 
-test('formats stable status labels and generic record summaries', () => {
-    assert.equal(api.formatExecutionStatus('completed_with_failures'), 'Completed with failures');
-    assert.deepEqual(api.createSummary({
-        operationType: 'batch-demo', pageContext: { marathonName: 'Course' }, counts: { successful: 2, failed: 1, skipped: 3 }
-    }), { title: 'batch-demo', subtitle: 'Course', outcome: '2 successful · 1 failed · 3 skipped' });
+const componentPath = path.resolve(__dirname, 'execution-history-dialog.js');
+const source = fs.readFileSync(componentPath, 'utf8');
+
+test('execution history dialog is implemented with Lit and declarative views', () => {
+    assert.match(source, /import \{ LitElement, html \} from 'lit';/);
+    assert.match(source, /class ExecutionHistoryDialog extends LitElement/);
+    assert.match(source, /renderRecord\(record\)/);
+    assert.match(source, /renderDetail\(\)/);
+    assert.match(source, /renderOutcome\(result\)/);
+    assert.doesNotMatch(source, /shadowRoot\.innerHTML/);
+    assert.doesNotMatch(source, /replaceChildren\(/);
+    assert.doesNotMatch(source, /module\.exports/);
+});
+
+test('execution history dialog preserves filtering, retention, and mutation workflows', () => {
+    assert.match(source, /get filters\(\)/);
+    assert.match(source, /loadRecords\(\)/);
+    assert.match(source, /openRecord\(executionId\)/);
+    assert.match(source, /loadPreferences\(\)/);
+    assert.match(source, /savePreferences\(\)/);
+    assert.match(source, /exportFiltered\(this\.filters\)/);
+    assert.match(source, /service\.delete\(this\.selectedRecord\.id\)/);
+    assert.match(source, /service\.clear\(\)/);
+    assert.match(source, /globalThis\.EdVibeExecutionHistoryDialog = executionHistoryDialogApi;/);
 });


### PR DESCRIPTION
## Summary
- migrate execution history browsing, detail rendering, filters, retention settings, and notifications to Lit reactive state
- keep repository/service calls outside the component rendering layer
- preserve export, delete, clear, preference, close, and initial-record workflows
- replace imperative DOM construction with declarative Lit templates and add real-browser coverage for filtering, details, settings, export, delete, and clear flows

Closes #32