### PR TITLE
Migrate action recorder dialog to Lit

### DIFF
--- a/src/component-tests/action-recorder-dialog-tests.js
+++ b/src/component-tests/action-recorder-dialog-tests.js
@@ -1,0 +1,111 @@
+import '../components/action-recorder-dialog.js';
+import {
+    cleanup,
+    click,
+    elementUpdated,
+    equal,
+    fixture,
+    shadowQuery
+} from './component-test-harness.js';
+
+export async function runActionRecorderDialogTests() {
+    const calls = {start: 0, stop: 0, clear: 0, export: 0, copyRecipe: 0, close: 0, requests: []};
+    const dialog = await fixture('<edvibe-toolbox-action-recorder></edvibe-toolbox-action-recorder>');
+    dialog.configure({
+        stylesheetUrl: '/src/components/action-recorder-dialog.css',
+        onStart: () => { calls.start += 1; },
+        onStop: () => { calls.stop += 1; },
+        onClear: () => { calls.clear += 1; },
+        onExport: () => { calls.export += 1; },
+        onCopyRecipe: () => { calls.copyRecipe += 1; },
+        onCopyRequest: (sequence) => calls.requests.push(sequence),
+        onClose: () => { calls.close += 1; }
+    });
+    dialog.confirm = () => true;
+
+    const session = {
+        startedAt: '2026-08-01T10:00:00.000Z',
+        stoppedAt: '2026-08-01T10:00:05.000Z',
+        frameCount: 4,
+        storedBytes: 2048,
+        operations: [
+            {
+                sequence: 1,
+                controller: 'PageController',
+                method: 'Run',
+                projectName: 'Page',
+                requestId: 'r1',
+                origin: 'page',
+                durationMs: 25,
+                requestValue: {id: 1},
+                response: {isSuccess: true}
+            },
+            {
+                sequence: 2,
+                controller: 'ToolboxController',
+                method: 'Inspect',
+                projectName: 'Toolbox',
+                requestId: 'r2',
+                origin: 'toolbox',
+                durationMs: null,
+                requestValue: {id: 2},
+                response: null
+            }
+        ],
+        otherFrames: [{kind: 'ping'}]
+    };
+
+    dialog.setState({status: 'recording', session: {...session, stoppedAt: null}, notice: 'Recording'});
+    await elementUpdated(dialog);
+    equal(dialog.id, 'edvibe-toolbox-action-recorder');
+    equal(shadowQuery(dialog, '.state-label').textContent, 'Идёт запись');
+    equal(shadowQuery(dialog, '.operation-count').textContent, '1');
+    equal(shadowQuery(dialog, '.recorder-stop').hidden, false);
+    equal(shadowQuery(dialog, '.recorder-start').hidden, true);
+    equal(shadowQuery(dialog, '.recorder-notice').textContent, 'Recording');
+
+    click(shadowQuery(dialog, '.copy-request'));
+    equal(calls.requests[0], 1);
+
+    dialog.showToolbox = true;
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.operation-count').textContent, '2');
+    equal(shadowQuery(dialog, '.operation-list').querySelectorAll('.operation').length, 2);
+
+    click(shadowQuery(dialog, '.recorder-minimize'));
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.recorder-overlay').hidden, true);
+    equal(shadowQuery(dialog, '.recorder-indicator').hidden, false);
+    equal(shadowQuery(dialog, '.recorder-indicator').classList.contains('is-recording'), true);
+
+    dialog.handleClose();
+    await elementUpdated(dialog);
+    equal(calls.close, 0);
+    equal(dialog.minimized, true);
+    dialog.restore();
+    await elementUpdated(dialog);
+    equal(dialog.minimized, false);
+
+    click(shadowQuery(dialog, '.recorder-stop'));
+    click(shadowQuery(dialog, '.recorder-copy'));
+    click(shadowQuery(dialog, '.recorder-export'));
+    equal(calls.stop, 1);
+    equal(calls.copyRecipe, 1);
+    equal(calls.export, 1);
+
+    dialog.setState({status: 'stopped', session, copyFallback: 'manual recipe'});
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.state-label').textContent, 'Запись остановлена');
+    equal(shadowQuery(dialog, '.elapsed').textContent, '0:05');
+    equal(shadowQuery(dialog, '.byte-count').textContent, '2.0 КиБ');
+    equal(shadowQuery(dialog, '.other-count').textContent, '1');
+    equal(shadowQuery(dialog, '.copy-fallback').hidden, false);
+    equal(shadowQuery(dialog, '.copy-fallback textarea').value, 'manual recipe');
+
+    click(shadowQuery(dialog, '.recorder-clear'));
+    equal(calls.clear, 1);
+    dialog.handleClose();
+    equal(calls.close, 1);
+
+    await cleanup();
+}

--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -49,6 +49,9 @@ async function run() {
 
     const { runExecutionHistoryDialogTests } = await import('./execution-history-dialog-tests.js');
     await runExecutionHistoryDialogTests();
+
+    const { runActionRecorderDialogTests } = await import('./action-recorder-dialog-tests.js');
+    await runActionRecorderDialogTests();
 }
 
 async function report(status, message) {

--- a/src/components/action-recorder-dialog.js
+++ b/src/components/action-recorder-dialog.js
@@ -1,475 +1,284 @@
-(function initializeActionRecorderDialog(root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define([], () => factory(root));
-    } else if (typeof module === 'object' && module.exports) {
-        module.exports = factory(root);
-    } else {
-        root.EdVibeActionRecorderDialog = factory(root);
+import { LitElement, html, nothing } from 'lit';
+
+const RECORDER_DIALOG_TAG = 'edvibe-toolbox-action-recorder';
+const RECORDER_DIALOG_ID = 'edvibe-toolbox-action-recorder';
+
+class ActionRecorderDialog extends LitElement {
+    static properties = {
+        stylesheetUrl: {state: true},
+        state: {state: true},
+        minimized: {state: true},
+        showToolbox: {state: true},
+        elapsedLabel: {state: true}
+    };
+
+    constructor() {
+        super();
+        this.stylesheetUrl = '';
+        this.callbacks = {};
+        this.state = {status: 'idle', session: null};
+        this.minimized = false;
+        this.showToolbox = false;
+        this.elapsedLabel = '';
+        this.elapsedTimer = null;
     }
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createRecorderDialogModule(root) {
-    'use strict';
 
-    const RECORDER_DIALOG_TAG = 'edvibe-toolbox-action-recorder';
-    const RECORDER_DIALOG_ID = 'edvibe-toolbox-action-recorder';
-    const HTMLElementBase = root.HTMLElement || class {};
-    const recorderTemplate = root.document?.createElement?.('template') || null;
+    connectedCallback() {
+        super.connectedCallback();
+        if (!this.id) {
+            this.id = RECORDER_DIALOG_ID;
+        }
+        this.syncElapsedTimer();
+    }
 
-    if (recorderTemplate) {
-        recorderTemplate.innerHTML = `
-            <link class="recorder-stylesheet" rel="stylesheet">
-            <button class="recorder-indicator" type="button" hidden
-                aria-label="Открыть запись WebSocket">
-                <span></span>
-                <strong>REC</strong>
-                <span class="indicator-count">0</span>
+    disconnectedCallback() {
+        this.stopElapsedTimer();
+        super.disconnectedCallback();
+    }
+
+    configure(options = {}) {
+        options = options && typeof options === 'object' ? options : {};
+        if (options.stylesheetUrl !== undefined) {
+            this.stylesheetUrl = String(options.stylesheetUrl || '');
+        }
+        for (const name of [
+            'onStart', 'onStop', 'onClear', 'onExport',
+            'onCopyRequest', 'onCopyRecipe', 'onClose'
+        ]) {
+            if (typeof options[name] === 'function') {
+                this.callbacks[name] = options[name];
+            }
+        }
+        return this;
+    }
+
+    mount() {
+        if (!this.isConnected && globalThis.document?.body) {
+            globalThis.document.body.appendChild(this);
+        }
+    }
+
+    restore() {
+        this.minimized = false;
+    }
+
+    setState(state) {
+        this.state = state && typeof state === 'object'
+            ? state
+            : {status: 'idle', session: null};
+        this.elapsedLabel = this.calculateElapsed();
+        this.syncElapsedTimer();
+        return this;
+    }
+
+    confirm(message) {
+        return globalThis.confirm(message);
+    }
+
+    handleStart() {
+        if (this.state.session && !this.confirm('Удалить предыдущую запись и начать новую?')) {
+            return;
+        }
+        this.callbacks.onStart?.();
+    }
+
+    handleClear() {
+        if (!this.state.session || this.confirm('Удалить текущую запись?')) {
+            this.callbacks.onClear?.();
+        }
+    }
+
+    handleClose() {
+        if (this.state.status === 'recording') {
+            this.minimized = true;
+            return;
+        }
+        this.callbacks.onClose?.();
+    }
+
+    formatBytes(bytes) {
+        if (bytes < 1024) return `${bytes} Б`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} КиБ`;
+        return `${(bytes / 1024 / 1024).toFixed(1)} МиБ`;
+    }
+
+    operationStatus(operation) {
+        if (!operation.response) return 'Ожидается';
+        if (operation.response.isSuccess === true) return 'Успешно';
+        if (operation.response.isSuccess === false) return 'Ошибка';
+        return 'Ответ получен';
+    }
+
+    visibleOperations() {
+        return (this.state.session?.operations || []).filter(
+            (operation) => this.showToolbox || operation.origin === 'page'
+        );
+    }
+
+    calculateElapsed() {
+        const startedAt = this.state.session?.startedAt;
+        if (!startedAt) return '';
+        const started = Date.parse(startedAt);
+        if (Number.isNaN(started)) return '';
+        const end = this.state.session.stoppedAt
+            ? Date.parse(this.state.session.stoppedAt)
+            : Date.now();
+        const elapsedSeconds = Math.max(0, Math.floor((end - started) / 1000));
+        const minutes = Math.floor(elapsedSeconds / 60);
+        const seconds = String(elapsedSeconds % 60).padStart(2, '0');
+        return `${minutes}:${seconds}`;
+    }
+
+    syncElapsedTimer() {
+        this.stopElapsedTimer();
+        if (this.state.status !== 'recording' || !this.isConnected) return;
+        this.elapsedTimer = globalThis.setInterval(() => {
+            this.elapsedLabel = this.calculateElapsed();
+        }, 1000);
+    }
+
+    stopElapsedTimer() {
+        if (this.elapsedTimer !== null) {
+            globalThis.clearInterval(this.elapsedTimer);
+            this.elapsedTimer = null;
+        }
+    }
+
+    renderJsonBlock(label, value) {
+        return html`<div><strong>${label}</strong><pre>${JSON.stringify(value, null, 2)}</pre></div>`;
+    }
+
+    renderOperation(operation) {
+        const resultClass = `operation-result is-${
+            operation.response?.isSuccess === false ? 'error' : 'normal'
+        }`;
+        return html`
+            <details class="operation">
+                <summary>
+                    <span class="operation-sequence">${String(operation.sequence).padStart(2, '0')}</span>
+                    <strong class="operation-name">${operation.controller}.${operation.method}</strong>
+                    <span class="operation-duration">${operation.durationMs === null ? '—' : `${operation.durationMs} мс`}</span>
+                    <span class=${resultClass}>${this.operationStatus(operation)}</span>
+                </summary>
+                <div class="operation-content">
+                    <p>${[
+                        `Project: ${operation.projectName || '—'}`,
+                        `RequestId: ${operation.requestId}`,
+                        `Origin: ${operation.origin}`
+                    ].join(' · ')}</p>
+                    ${this.renderJsonBlock('Запрос Value', operation.requestValue)}
+                    ${this.renderJsonBlock('Ответ', operation.response)}
+                    <button type="button" class="button copy-request"
+                        @click=${() => this.callbacks.onCopyRequest?.(operation.sequence)}>
+                        Копировать запрос
+                    </button>
+                </div>
+            </details>
+        `;
+    }
+
+    render() {
+        const recording = this.state.status === 'recording';
+        const hasSession = Boolean(this.state.session);
+        const operations = this.state.session?.operations || [];
+        const visibleOperations = this.visibleOperations();
+        const otherFrames = this.state.session?.otherFrames || [];
+        const labels = {
+            idle: 'Готово к записи',
+            recording: 'Идёт запись',
+            stopped: 'Запись остановлена',
+            'limit-reached': 'Достигнут лимит'
+        };
+        const indicatorClass = `recorder-indicator${recording ? ' is-recording' : ''}`;
+        const copyFallback = String(this.state.copyFallback || '');
+
+        return html`
+            <link class="recorder-stylesheet" rel="stylesheet"
+                href=${this.stylesheetUrl || nothing}>
+            <button class=${indicatorClass} type="button" ?hidden=${!this.minimized}
+                aria-label="Открыть запись WebSocket" @click=${() => this.restore()}>
+                <span></span><strong>REC</strong>
+                <span class="indicator-count">${visibleOperations.length}</span>
             </button>
-            <div class="recorder-overlay">
-                <section class="recorder-panel" role="dialog"
-                    aria-labelledby="recorder-title">
+            <div class="recorder-overlay" ?hidden=${this.minimized}>
+                <section class="recorder-panel" role="dialog" aria-labelledby="recorder-title">
                     <header class="recorder-header">
                         <div>
                             <h2 id="recorder-title">Запись действий WebSocket</h2>
-                            <p class="recorder-subtitle">
-                                Выполните одно действие в Edvibe и изучите обмен сообщениями.
-                            </p>
+                            <p class="recorder-subtitle">Выполните одно действие в Edvibe и изучите обмен сообщениями.</p>
                         </div>
                         <div class="header-actions">
-                            <button class="icon-button recorder-minimize"
-                                type="button" aria-label="Свернуть">−</button>
-                            <button class="icon-button recorder-close"
-                                type="button" aria-label="Закрыть">&times;</button>
+                            <button class="icon-button recorder-minimize" type="button" aria-label="Свернуть"
+                                @click=${() => { this.minimized = true; }}>−</button>
+                            <button class="icon-button recorder-close" type="button" aria-label="Закрыть"
+                                @click=${() => this.handleClose()}>&times;</button>
                         </div>
                     </header>
                     <div class="recorder-toolbar">
-                        <div class="recorder-state">
+                        <div class="recorder-state" data-status=${this.state.status}>
                             <span class="state-dot"></span>
-                            <strong class="state-label">Готово к записи</strong>
-                            <span class="elapsed"></span>
+                            <strong class="state-label">${labels[this.state.status] || labels.idle}</strong>
+                            <span class="elapsed">${this.elapsedLabel}</span>
                         </div>
                         <div class="toolbar-actions">
-                            <button class="button primary recorder-start"
-                                type="button">Начать запись</button>
-                            <button class="button danger recorder-stop"
-                                type="button" hidden>Остановить</button>
-                            <button class="button recorder-clear"
-                                type="button" disabled>Очистить</button>
-                            <button class="button recorder-copy"
-                                type="button" disabled>Копировать рецепт</button>
-                            <button class="button recorder-export"
-                                type="button" disabled>Экспорт JSON</button>
+                            <button class="button primary recorder-start" type="button" ?hidden=${recording}
+                                @click=${() => this.handleStart()}>Начать запись</button>
+                            <button class="button danger recorder-stop" type="button" ?hidden=${!recording}
+                                @click=${() => this.callbacks.onStop?.()}>Остановить</button>
+                            <button class="button recorder-clear" type="button" ?disabled=${!hasSession}
+                                @click=${() => this.handleClear()}>Очистить</button>
+                            <button class="button recorder-copy" type="button"
+                                ?disabled=${!hasSession || operations.length === 0}
+                                @click=${() => this.callbacks.onCopyRecipe?.()}>Копировать рецепт</button>
+                            <button class="button recorder-export" type="button" ?disabled=${!hasSession}
+                                @click=${() => this.callbacks.onExport?.()}>Экспорт JSON</button>
                         </div>
                     </div>
                     <div class="recorder-body">
                         <aside class="privacy-warning">
-                            Запись может содержать данные учеников, уроки, ответы и
-                            идентификаторы. Проверьте файл перед отправкой или коммитом.
+                            Запись может содержать данные учеников, уроки, ответы и идентификаторы.
+                            Проверьте файл перед отправкой или коммитом.
                         </aside>
                         <div class="recorder-summary">
-                            <span><strong class="operation-count">0</strong> операций</span>
-                            <span><strong class="frame-count">0</strong> кадров</span>
-                            <span><strong class="byte-count">0 Б</strong> текста</span>
-                            <label>
-                                <input class="show-toolbox" type="checkbox">
-                                Показать трафик Toolbox
-                            </label>
+                            <span><strong class="operation-count">${visibleOperations.length}</strong> операций</span>
+                            <span><strong class="frame-count">${this.state.session?.frameCount || 0}</strong> кадров</span>
+                            <span><strong class="byte-count">${this.formatBytes(this.state.session?.storedBytes || 0)}</strong> текста</span>
+                            <label><input class="show-toolbox" type="checkbox" .checked=${this.showToolbox}
+                                @change=${(event) => { this.showToolbox = event.currentTarget.checked; }}>
+                                Показать трафик Toolbox</label>
                         </div>
-                        <p class="recorder-notice" role="status" hidden></p>
+                        <p class="recorder-notice" role="status" ?hidden=${!this.state.notice}>${this.state.notice || ''}</p>
                         <section>
                             <h3>Операции</h3>
-                            <div class="operation-list"></div>
-                            <p class="empty-operations">
+                            <div class="operation-list">${visibleOperations.map((operation) => this.renderOperation(operation))}</div>
+                            <p class="empty-operations" ?hidden=${visibleOperations.length > 0}>
                                 Запустите запись и выполните действие в Edvibe.
                             </p>
                         </section>
                         <details class="other-section">
-                            <summary>
-                                Другие кадры (<span class="other-count">0</span>)
-                            </summary>
-                            <div class="other-list"></div>
+                            <summary>Другие кадры (<span class="other-count">${otherFrames.length}</span>)</summary>
+                            <div class="other-list">${otherFrames.map((frame) => html`<pre>${JSON.stringify(frame, null, 2)}</pre>`)}</div>
                         </details>
-                        <label class="copy-fallback" hidden>
+                        <label class="copy-fallback" ?hidden=${!copyFallback}>
                             Скопируйте текст вручную
-                            <textarea readonly></textarea>
+                            <textarea readonly .value=${copyFallback}></textarea>
                         </label>
                     </div>
                 </section>
             </div>
         `;
     }
+}
 
-    class ActionRecorderDialog extends HTMLElementBase {
-        constructor() {
-            super();
-            this.stylesheetUrl = '';
-            this.callbacks = {};
-            this.state = { status: 'idle', session: null };
-            this.minimized = false;
-            this.showToolbox = false;
-            this.elapsedTimer = null;
-            this.rendered = false;
-            this.listenersConnected = false;
-            if (typeof this.attachShadow !== 'function' || !recorderTemplate) {
-                return;
-            }
-            const shadowRoot = this.attachShadow({ mode: 'open' });
-            shadowRoot.append(recorderTemplate.content.cloneNode(true));
-            this.cacheElements();
-            this.updateStylesheet();
-            this.rendered = true;
-        }
+if (!customElements.get(RECORDER_DIALOG_TAG)) {
+    customElements.define(RECORDER_DIALOG_TAG, ActionRecorderDialog);
+}
 
-        connectedCallback() {
-            if (!this.id) {
-                this.id = RECORDER_DIALOG_ID;
-            }
-            this.render();
-            this.connectListeners();
-            this.renderState();
-        }
+const actionRecorderDialogApi = {
+    RECORDER_DIALOG_TAG,
+    RECORDER_DIALOG_ID,
+    ActionRecorderDialog
+};
+globalThis.EdVibeActionRecorderDialog = actionRecorderDialogApi;
 
-        disconnectedCallback() {
-            this.disconnectListeners();
-            this.stopElapsedTimer();
-        }
-
-        configure(options = {}) {
-            options = options && typeof options === 'object' ? options : {};
-            if (options.stylesheetUrl !== undefined) {
-                this.stylesheetUrl = String(options.stylesheetUrl || '');
-            }
-            for (const name of [
-                'onStart', 'onStop', 'onClear', 'onExport',
-                'onCopyRequest', 'onCopyRecipe', 'onClose'
-            ]) {
-                if (typeof options[name] === 'function') {
-                    this.callbacks[name] = options[name];
-                }
-            }
-            this.updateStylesheet();
-            return this;
-        }
-
-        mount() {
-            if (!this.isConnected && root.document?.body) {
-                root.document.body.appendChild(this);
-            }
-        }
-
-        restore() {
-            this.minimized = false;
-            this.renderState();
-        }
-
-        setState(state) {
-            this.state = state && typeof state === 'object'
-                ? state
-                : { status: 'idle', session: null };
-            this.renderState();
-            return this;
-        }
-
-        render() {
-            return this.rendered;
-        }
-
-        cacheElements() {
-            if (!this.shadowRoot) {
-                return;
-            }
-            const find = (selector) => this.shadowRoot.querySelector(selector);
-            this.elements = {
-                stylesheet: find('.recorder-stylesheet'),
-                overlay: find('.recorder-overlay'),
-                indicator: find('.recorder-indicator'),
-                indicatorCount: find('.indicator-count'),
-                minimize: find('.recorder-minimize'),
-                close: find('.recorder-close'),
-                start: find('.recorder-start'),
-                stop: find('.recorder-stop'),
-                clear: find('.recorder-clear'),
-                copy: find('.recorder-copy'),
-                export: find('.recorder-export'),
-                state: find('.recorder-state'),
-                stateLabel: find('.state-label'),
-                elapsed: find('.elapsed'),
-                operationCount: find('.operation-count'),
-                frameCount: find('.frame-count'),
-                byteCount: find('.byte-count'),
-                showToolbox: find('.show-toolbox'),
-                notice: find('.recorder-notice'),
-                operationList: find('.operation-list'),
-                empty: find('.empty-operations'),
-                otherCount: find('.other-count'),
-                otherList: find('.other-list'),
-                copyFallback: find('.copy-fallback'),
-                copyFallbackText: find('.copy-fallback textarea')
-            };
-        }
-
-        connectListeners() {
-            if (!this.rendered || this.listenersConnected) {
-                return;
-            }
-            this.listenersConnected = true;
-            this.handleStart = () => {
-                if (
-                    this.state.session
-                    && !root.confirm('Удалить предыдущую запись и начать новую?')
-                ) return;
-                this.callbacks.onStart?.();
-            };
-            this.handleStop = () => this.callbacks.onStop?.();
-            this.handleClear = () => {
-                if (!this.state.session || root.confirm('Удалить текущую запись?')) {
-                    this.callbacks.onClear?.();
-                }
-            };
-            this.handleCopy = () => this.callbacks.onCopyRecipe?.();
-            this.handleExport = () => this.callbacks.onExport?.();
-            this.handleMinimize = () => {
-                this.minimized = true;
-                this.renderState();
-            };
-            this.handleClose = () => {
-                if (this.state.status === 'recording') {
-                    this.minimized = true;
-                    this.renderState();
-                    return;
-                }
-                this.callbacks.onClose?.();
-            };
-            this.handleRestore = () => this.restore();
-            this.handleToolboxToggle = () => {
-                this.showToolbox = this.elements.showToolbox.checked;
-                this.renderOperations();
-            };
-
-            this.elements.start.addEventListener('click', this.handleStart);
-            this.elements.stop.addEventListener('click', this.handleStop);
-            this.elements.clear.addEventListener('click', this.handleClear);
-            this.elements.copy.addEventListener('click', this.handleCopy);
-            this.elements.export.addEventListener('click', this.handleExport);
-            this.elements.minimize.addEventListener('click', this.handleMinimize);
-            this.elements.close.addEventListener('click', this.handleClose);
-            this.elements.indicator.addEventListener('click', this.handleRestore);
-            this.elements.showToolbox.addEventListener('change', this.handleToolboxToggle);
-        }
-
-        disconnectListeners() {
-            if (!this.listenersConnected) {
-                return;
-            }
-            this.listenersConnected = false;
-            this.elements.start.removeEventListener('click', this.handleStart);
-            this.elements.stop.removeEventListener('click', this.handleStop);
-            this.elements.clear.removeEventListener('click', this.handleClear);
-            this.elements.copy.removeEventListener('click', this.handleCopy);
-            this.elements.export.removeEventListener('click', this.handleExport);
-            this.elements.minimize.removeEventListener('click', this.handleMinimize);
-            this.elements.close.removeEventListener('click', this.handleClose);
-            this.elements.indicator.removeEventListener('click', this.handleRestore);
-            this.elements.showToolbox.removeEventListener('change', this.handleToolboxToggle);
-        }
-
-        updateStylesheet() {
-            this.elements?.stylesheet?.setAttribute('href', this.stylesheetUrl);
-        }
-
-        formatBytes(bytes) {
-            if (bytes < 1024) {
-                return `${bytes} Б`;
-            }
-            if (bytes < 1024 * 1024) {
-                return `${(bytes / 1024).toFixed(1)} КиБ`;
-            }
-            return `${(bytes / 1024 / 1024).toFixed(1)} МиБ`;
-        }
-
-        operationStatus(operation) {
-            if (!operation.response) {
-                return 'Ожидается';
-            }
-            if (operation.response.isSuccess === true) {
-                return 'Успешно';
-            }
-            if (operation.response.isSuccess === false) {
-                return 'Ошибка';
-            }
-            return 'Ответ получен';
-        }
-
-        createJsonBlock(label, value) {
-            const wrapper = root.document.createElement('div');
-            const heading = root.document.createElement('strong');
-            const pre = root.document.createElement('pre');
-            heading.textContent = label;
-            pre.textContent = JSON.stringify(value, null, 2);
-            wrapper.append(heading, pre);
-            return wrapper;
-        }
-
-        renderOperations() {
-            if (!this.rendered) {
-                return;
-            }
-            const operations = (this.state.session?.operations || []).filter(
-                (operation) => this.showToolbox || operation.origin === 'page'
-            );
-            this.elements.operationList.replaceChildren();
-            this.elements.empty.hidden = operations.length > 0;
-
-            for (const operation of operations) {
-                const details = root.document.createElement('details');
-                const summary = root.document.createElement('summary');
-                const sequence = root.document.createElement('span');
-                const name = root.document.createElement('strong');
-                const duration = root.document.createElement('span');
-                const result = root.document.createElement('span');
-                const content = root.document.createElement('div');
-                const metadata = root.document.createElement('p');
-                const copy = root.document.createElement('button');
-
-                details.className = 'operation';
-                sequence.textContent = String(operation.sequence).padStart(2, '0');
-                sequence.className = 'operation-sequence';
-                name.textContent = `${operation.controller}.${operation.method}`;
-                name.className = 'operation-name';
-                duration.textContent = operation.durationMs === null
-                    ? '—'
-                    : `${operation.durationMs} мс`;
-                duration.className = 'operation-duration';
-                result.textContent = this.operationStatus(operation);
-                result.className = `operation-result is-${
-                    operation.response?.isSuccess === false ? 'error' : 'normal'
-                }`;
-                summary.append(sequence, name, duration, result);
-
-                content.className = 'operation-content';
-                metadata.textContent = [
-                    `Project: ${operation.projectName || '—'}`,
-                    `RequestId: ${operation.requestId}`,
-                    `Origin: ${operation.origin}`
-                ].join(' · ');
-                content.append(
-                    metadata,
-                    this.createJsonBlock('Запрос Value', operation.requestValue),
-                    this.createJsonBlock('Ответ', operation.response)
-                );
-                copy.type = 'button';
-                copy.className = 'button copy-request';
-                copy.textContent = 'Копировать запрос';
-                copy.addEventListener('click', () =>
-                    this.callbacks.onCopyRequest?.(operation.sequence)
-                );
-                content.append(copy);
-                details.append(summary, content);
-                this.elements.operationList.append(details);
-            }
-        }
-
-        renderOtherFrames() {
-            if (!this.rendered) {
-                return;
-            }
-            const frames = this.state.session?.otherFrames || [];
-            this.elements.otherCount.textContent = String(frames.length);
-            this.elements.otherList.replaceChildren();
-            for (const frame of frames) {
-                const pre = root.document.createElement('pre');
-                pre.textContent = JSON.stringify(frame, null, 2);
-                this.elements.otherList.append(pre);
-            }
-        }
-
-        updateElapsed() {
-            if (!this.rendered) {
-                return;
-            }
-            const startedAt = this.state.session?.startedAt;
-            if (!startedAt) {
-                this.elements.elapsed.textContent = '';
-                return;
-            }
-            const end = this.state.session.stoppedAt
-                ? Date.parse(this.state.session.stoppedAt)
-                : Date.now();
-            const elapsedSeconds = Math.max(
-                0,
-                Math.floor((end - Date.parse(startedAt)) / 1000)
-            );
-            const minutes = Math.floor(elapsedSeconds / 60);
-            const seconds = String(elapsedSeconds % 60).padStart(2, '0');
-            this.elements.elapsed.textContent = `${minutes}:${seconds}`;
-        }
-
-        startElapsedTimer() {
-            this.stopElapsedTimer();
-            if (this.state.status !== 'recording') {
-                return;
-            }
-            this.elapsedTimer = root.setInterval?.(() => this.updateElapsed(), 1000);
-        }
-
-        stopElapsedTimer() {
-            if (this.elapsedTimer !== null) {
-                root.clearInterval?.(this.elapsedTimer);
-                this.elapsedTimer = null;
-            }
-        }
-
-        renderState() {
-            if (!this.rendered) {
-                return;
-            }
-            const recording = this.state.status === 'recording';
-            const hasSession = Boolean(this.state.session);
-            const operations = this.state.session?.operations || [];
-            const visibleCount = operations.filter((operation) =>
-                this.showToolbox || operation.origin === 'page'
-            ).length;
-            const labels = {
-                idle: 'Готово к записи',
-                recording: 'Идёт запись',
-                stopped: 'Запись остановлена',
-                'limit-reached': 'Достигнут лимит'
-            };
-
-            this.elements.overlay.hidden = this.minimized;
-            this.elements.indicator.hidden = !this.minimized;
-            this.elements.indicator.classList.toggle('is-recording', recording);
-            this.elements.indicatorCount.textContent = String(visibleCount);
-            this.elements.state.dataset.status = this.state.status;
-            this.elements.stateLabel.textContent = labels[this.state.status] || labels.idle;
-            this.elements.start.hidden = recording;
-            this.elements.stop.hidden = !recording;
-            this.elements.clear.disabled = !hasSession;
-            this.elements.copy.disabled = !hasSession || operations.length === 0;
-            this.elements.export.disabled = !hasSession;
-            this.elements.operationCount.textContent = String(visibleCount);
-            this.elements.frameCount.textContent = String(
-                this.state.session?.frameCount || 0
-            );
-            this.elements.byteCount.textContent = this.formatBytes(
-                this.state.session?.storedBytes || 0
-            );
-            this.elements.notice.textContent = this.state.notice || '';
-            this.elements.notice.hidden = !this.state.notice;
-            this.elements.copyFallback.hidden = !this.state.copyFallback;
-            this.elements.copyFallbackText.value = this.state.copyFallback || '';
-            this.updateElapsed();
-            this.startElapsedTimer();
-            this.renderOperations();
-            this.renderOtherFrames();
-        }
-    }
-
-    if (root.customElements && !root.customElements.get(RECORDER_DIALOG_TAG)) {
-        root.customElements.define(RECORDER_DIALOG_TAG, ActionRecorderDialog);
-    }
-
-    return {
-        RECORDER_DIALOG_TAG,
-        RECORDER_DIALOG_ID,
-        ActionRecorderDialog
-    };
-});
+export { RECORDER_DIALOG_TAG, RECORDER_DIALOG_ID, ActionRecorderDialog };

--- a/src/components/action-recorder-dialog.test.js
+++ b/src/components/action-recorder-dialog.test.js
@@ -2,78 +2,29 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const vm = require('node:vm');
 
-const componentPath = path.resolve(
-    __dirname,
-    '../src/components/action-recorder-dialog.js'
-);
+const componentPath = path.resolve(__dirname, 'action-recorder-dialog.js');
 const source = fs.readFileSync(componentPath, 'utf8');
-const {
-    RECORDER_DIALOG_TAG,
-    RECORDER_DIALOG_ID,
-    ActionRecorderDialog
-} = require(componentPath);
 
-test('exports a browser-safe recorder custom element', () => {
-    assert.equal(RECORDER_DIALOG_TAG, 'edvibe-toolbox-action-recorder');
-    assert.equal(RECORDER_DIALOG_ID, 'edvibe-toolbox-action-recorder');
-    assert.equal(ActionRecorderDialog.name, 'ActionRecorderDialog');
-    assert.equal(typeof ActionRecorderDialog.prototype.configure, 'function');
-    assert.equal(typeof ActionRecorderDialog.prototype.setState, 'function');
-    assert.equal(typeof ActionRecorderDialog.prototype.restore, 'function');
+test('action recorder dialog uses Lit for recorder state and operation rendering', () => {
+    assert.match(source, /import \{ LitElement, html, nothing \} from 'lit';/);
+    assert.match(source, /class ActionRecorderDialog extends LitElement/);
+    assert.match(source, /renderOperation\(operation\)/);
+    assert.match(source, /visibleOperations\(\)/);
+    assert.match(source, /render\(\) \{/);
+    assert.doesNotMatch(source, /createElement\?\.\('template'\)/);
+    assert.doesNotMatch(source, /replaceChildren\(/);
+    assert.doesNotMatch(source, /module\.exports/);
 });
 
-test('registers the recorder element in a browser context', () => {
-    const constructors = new Map();
-    class FakeHTMLElement {
-        attachShadow({ mode }) {
-            this.shadowRoot = { mode };
-        }
-    }
-    const context = {
-        HTMLElement: FakeHTMLElement,
-        customElements: {
-            get: (name) => constructors.get(name),
-            define: (name, constructor) => constructors.set(name, constructor)
-        },
-        setInterval,
-        clearInterval
-    };
-    context.globalThis = context;
-    vm.runInNewContext(source, context);
-
-    const api = context.EdVibeActionRecorderDialog;
-    assert.equal(constructors.get(RECORDER_DIALOG_TAG), api.ActionRecorderDialog);
-    const element = new api.ActionRecorderDialog();
-    assert.equal(element.shadowRoot, undefined);
-    assert.doesNotThrow(() => element.connectedCallback());
-});
-
-test('keeps rendering, sensitivity warning, and safe controls in the component', () => {
-    assert.match(source, /class ActionRecorderDialog extends HTMLElementBase/);
-    assert.match(source, /attachShadow\(\{ mode: 'open' \}\)/);
-    assert.match(source, /createElement\?\.\('template'\)/);
-    assert.match(source, /content\.cloneNode\(true\)/);
-    assert.doesNotMatch(source, /shadowRoot\.innerHTML/);
+test('action recorder preserves safe recorder controls and minimize behavior', () => {
     assert.match(source, /Запись может содержать данные учеников/);
     assert.match(source, /Копировать рецепт/);
     assert.match(source, /Экспорт JSON/);
+    assert.match(source, /if \(this\.state\.status === 'recording'\) \{\s*this\.minimized = true;/);
+    assert.match(source, /this\.callbacks\.onClose\?\.\(\)/);
+    assert.match(source, /syncElapsedTimer\(\)/);
+    assert.match(source, /globalThis\.EdVibeActionRecorderDialog = actionRecorderDialogApi;/);
     assert.doesNotMatch(source, />Replay</);
     assert.doesNotMatch(source, />Run</);
-});
-
-test('minimizes rather than closes an active recording', () => {
-    assert.match(
-        source,
-        /if \(this\.state\.status === 'recording'\) \{\s*this\.minimized = true/
-    );
-    assert.match(source, /this\.callbacks\.onClose\?\.\(\)/);
-});
-
-test('fails silently for unavailable DOM and unexpected options', () => {
-    const dialog = new ActionRecorderDialog();
-    assert.doesNotThrow(() => dialog.connectedCallback());
-    assert.doesNotThrow(() => dialog.configure(null));
-    assert.doesNotThrow(() => dialog.setState(null));
 });


### PR DESCRIPTION
## Summary
- migrate recorder status, toolbar, minimize/restore, operations, other frames, notice, and copy fallback views to Lit
- keep the elapsed timer as the only lifecycle side effect while the rendered UI is derived from reactive state
- preserve start/stop/clear/copy/export/close callback contracts and active-recording minimize behavior
- add real-browser coverage for recording, filtering Toolbox traffic, minimize/restore, controls, elapsed state, and fallback copy output

Closes #33