### PR TITLE
Migrate batch section deletion dialog to Lit

### DIFF
--- a/src/component-tests/batch-section-deletion-dialog-tests.js
+++ b/src/component-tests/batch-section-deletion-dialog-tests.js
@@ -1,0 +1,79 @@
+import '../components/batch-section-deletion-dialog.js';
+import {
+    cleanup,
+    click,
+    elementUpdated,
+    equal,
+    fixture,
+    shadowQuery
+} from './component-test-harness.js';
+
+export async function runBatchSectionDeletionDialogTests() {
+    const calls = {inspect: 0, execute: 0, copied: '', history: null, closed: 0};
+    const plan = {
+        selectedCount: 2,
+        eligible: [{lessonId: 10, number: 1, name: 'Welcome', sectionId: 100}],
+        rejected: [{lessonId: 11, number: 2, name: 'Practice <safe>', code: 'NOT_FOUND', message: 'Missing <safe>'}]
+    };
+    const dialog = await fixture('<edvibe-toolbox-batch-section-deletion-dialog></edvibe-toolbox-batch-section-deletion-dialog>');
+    dialog.configure({
+        stylesheetUrl: '/src/components/batch-section-deletion-dialog.css',
+        lessons: [
+            {lessonId: 10, number: 1, name: 'Welcome'},
+            {lessonId: 11, number: 2, name: 'Practice <safe>'}
+        ],
+        onInspect: async ({sectionName, selectedLessonIds, onProgress}) => {
+            calls.inspect += 1;
+            equal(sectionName, 'Announcement');
+            equal(JSON.stringify(selectedLessonIds), JSON.stringify([10, 11]));
+            onProgress({current: 1, total: 2});
+            return plan;
+        },
+        onExecute: async (receivedPlan, onProgress) => {
+            calls.execute += 1;
+            equal(receivedPlan, plan);
+            onProgress({current: 1, total: 1});
+            return {
+                report: 'deletion report',
+                history: {stored: true, record: {id: 'history-1'}}
+            };
+        },
+        onCopy: (report) => { calls.copied = report; },
+        onOpenHistory: (id) => { calls.history = id; },
+        onClose: () => { calls.closed += 1; }
+    });
+    await elementUpdated(dialog);
+
+    equal(shadowQuery(dialog, '.lessons').querySelectorAll('input').length, 2);
+    click(shadowQuery(dialog, '.select-all'));
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.selection').textContent, '2 selected');
+
+    const name = shadowQuery(dialog, '.section-name');
+    name.value = 'Announcement';
+    name.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
+    await dialog.inspect();
+    await elementUpdated(dialog);
+    equal(calls.inspect, 1);
+    equal(shadowQuery(dialog, '.preflight').textContent.includes('Eligible'), true);
+    equal(shadowQuery(dialog, '.preflight').textContent.includes('Practice <safe>'), true);
+    equal(shadowQuery(dialog, '.execute').hidden, false);
+    equal(shadowQuery(dialog, '.inspect').textContent, 'Run preflight again');
+
+    await dialog.execute();
+    await elementUpdated(dialog);
+    equal(calls.execute, 1);
+    equal(shadowQuery(dialog, '.result').hidden, false);
+    equal(shadowQuery(dialog, '.result textarea').value, 'deletion report');
+    equal(shadowQuery(dialog, '.history').hidden, false);
+    equal(shadowQuery(dialog, '.status').textContent.includes('Saved to execution history'), true);
+
+    click(shadowQuery(dialog, '.copy'));
+    click(shadowQuery(dialog, '.history'));
+    equal(calls.copied, 'deletion report');
+    equal(calls.history, 'history-1');
+
+    click(shadowQuery(dialog, 'button.close'));
+    equal(calls.closed, 1);
+    await cleanup();
+}

--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -1,20 +1,9 @@
 async function runHarnessSmokeTest(harness) {
-    const {
-        assert,
-        cleanup,
-        click,
-        elementUpdated,
-        equal,
-        fixture,
-        keydown,
-        shadowQuery
-    } = harness;
-
+    const {assert, cleanup, click, elementUpdated, equal, fixture, keydown, shadowQuery} = harness;
     const element = await fixture('<browser-fixture-element label="Initial"></browser-fixture-element>');
     assert(element instanceof HTMLElement, 'Fixture should mount a real custom element.');
     assert(element.shadowRoot instanceof ShadowRoot, 'Fixture should expose a real ShadowRoot.');
     equal(shadowQuery(element, 'button').textContent, 'Initial');
-
     let clicks = 0;
     let lastKey = null;
     const button = shadowQuery(element, 'button');
@@ -24,11 +13,9 @@ async function runHarnessSmokeTest(harness) {
     keydown(button, 'Enter');
     equal(clicks, 1, 'Mouse interaction helper should dispatch a browser click event.');
     equal(lastKey, 'Enter', 'Keyboard interaction helper should dispatch a browser keyboard event.');
-
     element.setAttribute('label', 'Updated');
     await elementUpdated(element);
     equal(shadowQuery(element, 'button').textContent, 'Updated');
-
     await cleanup();
     equal(element.isConnected, false, 'cleanup() should remove mounted fixtures.');
 }
@@ -37,29 +24,26 @@ async function run() {
     const harness = await import('./component-test-harness.js');
     await import('./browser-fixture-element.js');
     await runHarnessSmokeTest(harness);
-
-    const { runPopupToolListTests } = await import('./popup-tool-list-tests.js');
-    await runPopupToolListTests();
-    const { runExportProgressDialogTests } = await import('./export-progress-dialog-tests.js');
-    await runExportProgressDialogTests();
-    const { runResetLessonsDialogTests } = await import('./reset-lessons-dialog-tests.js');
-    await runResetLessonsDialogTests();
-    const { runExecutionHistoryDialogTests } = await import('./execution-history-dialog-tests.js');
-    await runExecutionHistoryDialogTests();
-    const { runActionRecorderDialogTests } = await import('./action-recorder-dialog-tests.js');
-    await runActionRecorderDialogTests();
-    const { runBatchLessonAccessDialogTests } = await import('./batch-lesson-access-dialog-tests.js');
-    await runBatchLessonAccessDialogTests();
-    const { runBatchSectionCreationDialogTests } = await import('./batch-section-creation-dialog-tests.js');
-    await runBatchSectionCreationDialogTests();
+    for (const [modulePath, exportName] of [
+        ['./popup-tool-list-tests.js', 'runPopupToolListTests'],
+        ['./export-progress-dialog-tests.js', 'runExportProgressDialogTests'],
+        ['./reset-lessons-dialog-tests.js', 'runResetLessonsDialogTests'],
+        ['./execution-history-dialog-tests.js', 'runExecutionHistoryDialogTests'],
+        ['./action-recorder-dialog-tests.js', 'runActionRecorderDialogTests'],
+        ['./batch-lesson-access-dialog-tests.js', 'runBatchLessonAccessDialogTests'],
+        ['./batch-section-creation-dialog-tests.js', 'runBatchSectionCreationDialogTests'],
+        ['./batch-section-deletion-dialog-tests.js', 'runBatchSectionDeletionDialogTests']
+    ]) {
+        const module = await import(modulePath);
+        await module[exportName]();
+    }
 }
 
 async function report(status, message) {
     document.documentElement.dataset.testStatus = status;
     document.querySelector('#test-result').textContent = message;
     await fetch('/__component-test-result', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
+        method: 'POST', headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({status, message})
     });
 }
@@ -70,9 +54,6 @@ try {
 } catch (error) {
     const message = error?.stack || String(error);
     console.error(error);
-    try {
-        await report('failed', message);
-    } catch (reportError) {
-        console.error('Unable to report component test failure:', reportError);
-    }
+    try { await report('failed', message); }
+    catch (reportError) { console.error('Unable to report component test failure:', reportError); }
 }

--- a/src/components/batch-section-deletion-dialog.js
+++ b/src/components/batch-section-deletion-dialog.js
@@ -1,155 +1,231 @@
-(function initializeDialog(root, factory) {
-    const api = factory();
-    if (typeof module === 'object' && module.exports) module.exports = api;
-    else root.EdVibeBatchSectionDeletionDialog = api;
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule() {
-    'use strict';
-    const BATCH_SECTION_DELETION_DIALOG_TAG = 'edvibe-toolbox-batch-section-deletion-dialog';
+import { LitElement, html, nothing } from 'lit';
 
-    if (typeof customElements !== 'undefined' && !customElements.get(BATCH_SECTION_DELETION_DIALOG_TAG)) {
-        customElements.define(BATCH_SECTION_DELETION_DIALOG_TAG, class extends HTMLElement {
-            constructor() {
-                super();
-                this.attachShadow({ mode: 'open' });
-                this.plan = null;
-                this.options = null;
-                this.executionId = null;
-            }
+const BATCH_SECTION_DELETION_DIALOG_TAG = 'edvibe-toolbox-batch-section-deletion-dialog';
 
-            configure(options) {
-                this.options = options;
-                this.render();
-            }
+class BatchSectionDeletionDialog extends LitElement {
+    static properties = {
+        options: {state: true},
+        sectionName: {state: true},
+        selectedLessonIds: {state: true},
+        plan: {state: true},
+        executionId: {state: true},
+        busy: {state: true},
+        statusMessage: {state: true},
+        statusVisible: {state: true},
+        resultReport: {state: true},
+        resultVisible: {state: true}
+    };
 
-            render() {
-                const root = this.shadowRoot;
-                root.innerHTML = '';
-                const link = document.createElement('link');
-                link.rel = 'stylesheet';
-                link.href = this.options.stylesheetUrl;
-                root.append(link);
-
-                const overlay = document.createElement('div');
-                overlay.className = 'overlay';
-                overlay.innerHTML = `
-                    <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="title">
-                        <header><div><h2 id="title">Delete section from lessons</h2><p>Every lesson is inspected before any deletion.</p></div><button class="icon close" aria-label="Close">×</button></header>
-                        <main>
-                            <label>Exact section name<input class="section-name" type="text" autocomplete="off" placeholder="Ogłoszenie"></label>
-                            <div class="toolbar"><button class="select-all">Select all</button><button class="clear">Clear</button><span class="selection"></span></div>
-                            <div class="lessons"></div>
-                            <div class="status" hidden></div>
-                            <section class="preflight" hidden></section>
-                            <section class="result" hidden><textarea readonly></textarea><div class="result-actions"><button class="copy">Copy report</button><button class="history" hidden>Open in history</button></div></section>
-                        </main>
-                        <footer><button class="secondary close">Cancel</button><button class="inspect">Inspect selected lessons</button><button class="danger execute" hidden>Confirm deletion</button></footer>
-                    </section>`;
-                root.append(overlay);
-
-                const lessons = root.querySelector('.lessons');
-                for (const lesson of this.options.lessons) {
-                    const label = document.createElement('label');
-                    label.className = 'lesson';
-                    label.innerHTML = `<input type="checkbox" value="${lesson.lessonId}"><span>#${lesson.number} ${this.escape(lesson.name)}</span>`;
-                    lessons.append(label);
-                }
-                const update = () => root.querySelector('.selection').textContent = `${this.selectedIds().length} selected`;
-                lessons.addEventListener('change', update);
-                root.querySelector('.select-all').addEventListener('click', () => { root.querySelectorAll('.lesson input').forEach((item) => item.checked = true); update(); });
-                root.querySelector('.clear').addEventListener('click', () => { root.querySelectorAll('.lesson input').forEach((item) => item.checked = false); update(); });
-                root.querySelectorAll('.close').forEach((button) => button.addEventListener('click', () => this.options.onClose()));
-                root.querySelector('.inspect').addEventListener('click', () => this.inspect());
-                root.querySelector('.execute').addEventListener('click', () => this.execute());
-                root.querySelector('.copy').addEventListener('click', () => this.options.onCopy(root.querySelector('textarea').value));
-                root.querySelector('.history').addEventListener('click', () => {
-                    if (this.executionId) this.options.onOpenHistory?.(this.executionId);
-                });
-                update();
-            }
-
-            selectedIds() {
-                return [...this.shadowRoot.querySelectorAll('.lesson input:checked')].map((item) => Number(item.value));
-            }
-
-            setBusy(message) {
-                const status = this.shadowRoot.querySelector('.status');
-                status.hidden = false;
-                status.textContent = message;
-                this.shadowRoot.querySelectorAll('button, input').forEach((element) => element.disabled = true);
-            }
-
-            clearBusy() {
-                this.shadowRoot.querySelector('.status').hidden = true;
-                this.shadowRoot.querySelectorAll('button, input').forEach((element) => element.disabled = false);
-            }
-
-            async inspect() {
-                const sectionName = this.shadowRoot.querySelector('.section-name').value;
-                const selectedLessonIds = this.selectedIds();
-                if (!sectionName.trim() || selectedLessonIds.length === 0) {
-                    this.showStatus('Enter a section name and select at least one lesson.');
-                    return;
-                }
-                this.setBusy('Inspecting lessons…');
-                try {
-                    this.plan = await this.options.onInspect({ sectionName, selectedLessonIds, onProgress: ({ current, total }) => this.showStatus(`Inspecting ${current}/${total}…`) });
-                    this.renderPlan();
-                } catch (error) {
-                    this.showStatus(error.message || 'Inspection failed.');
-                } finally {
-                    this.clearBusy();
-                }
-            }
-
-            renderPlan() {
-                const section = this.shadowRoot.querySelector('.preflight');
-                const eligible = this.plan.eligible.map((item) => `<li>#${item.number} ${this.escape(item.name)} → section ${item.sectionId}</li>`).join('');
-                const rejected = this.plan.rejected.map((item) => `<li>#${item.number} ${this.escape(item.name)}: ${item.code} — ${this.escape(item.message)}</li>`).join('');
-                section.innerHTML = `<h3>Preflight</h3><dl><div><dt>Selected</dt><dd>${this.plan.selectedCount}</dd></div><div><dt>Eligible</dt><dd>${this.plan.eligible.length}</dd></div><div><dt>Rejected</dt><dd>${this.plan.rejected.length}</dd></div></dl><h4>Will delete</h4><ul>${eligible || '<li>None</li>'}</ul><h4>Will not modify</h4><ul>${rejected || '<li>None</li>'}</ul>`;
-                section.hidden = false;
-                this.shadowRoot.querySelector('.execute').hidden = this.plan.eligible.length === 0;
-                this.shadowRoot.querySelector('.inspect').textContent = 'Run preflight again';
-            }
-
-            async execute() {
-                if (!this.plan || this.plan.eligible.length === 0) return;
-                this.setBusy('Deleting sections…');
-                try {
-                    const result = await this.options.onExecute(this.plan, ({ current, total }) => this.showStatus(`Deleting ${current}/${total}…`));
-                    const area = this.shadowRoot.querySelector('.result');
-                    area.hidden = false;
-                    area.querySelector('textarea').value = result.report;
-                    this.executionId = result.history?.stored ? result.history.record?.id || null : null;
-                    area.querySelector('.history').hidden = !this.executionId;
-                    this.shadowRoot.querySelector('.execute').hidden = true;
-                    this.shadowRoot.querySelector('.inspect').hidden = true;
-                    const outcome = result.fatalError
-                        ? 'Stopped after an operation-wide error. Partial results retained.'
-                        : 'Deletion finished.';
-                    const history = result.history?.stored
-                        ? ' Saved to execution history.'
-                        : result.history?.persistenceError
-                            ? ' The visible report is intact, but history could not be saved.'
-                            : '';
-                    this.showStatus(`${outcome}${history}`);
-                } catch (error) {
-                    this.showStatus(error.message || 'Deletion failed.');
-                } finally {
-                    this.clearBusy();
-                }
-            }
-
-            showStatus(message) {
-                const status = this.shadowRoot.querySelector('.status');
-                status.hidden = false;
-                status.textContent = message;
-            }
-
-            escape(value) {
-                return String(value || '').replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]));
-            }
-        });
+    constructor() {
+        super();
+        this.options = null;
+        this.sectionName = '';
+        this.selectedLessonIds = new Set();
+        this.plan = null;
+        this.executionId = null;
+        this.busy = false;
+        this.statusMessage = '';
+        this.statusVisible = false;
+        this.resultReport = '';
+        this.resultVisible = false;
     }
 
-    return Object.freeze({ BATCH_SECTION_DELETION_DIALOG_TAG });
+    configure(options = {}) {
+        this.options = options && typeof options === 'object' ? options : {};
+        this.selectedLessonIds = new Set();
+        this.plan = null;
+        this.executionId = null;
+        this.resultReport = '';
+        this.resultVisible = false;
+        return this;
+    }
+
+    selectedIds() {
+        return [...this.selectedLessonIds];
+    }
+
+    setLessonSelected(lessonId, selected) {
+        if (this.busy) return;
+        const next = new Set(this.selectedLessonIds);
+        if (selected) next.add(Number(lessonId));
+        else next.delete(Number(lessonId));
+        this.selectedLessonIds = next;
+    }
+
+    selectAll() {
+        if (this.busy) return;
+        this.selectedLessonIds = new Set(
+            (this.options?.lessons || []).map((lesson) => Number(lesson.lessonId))
+        );
+    }
+
+    clearSelection() {
+        if (this.busy) return;
+        this.selectedLessonIds = new Set();
+    }
+
+    setBusy(message) {
+        this.busy = true;
+        this.showStatus(message);
+    }
+
+    clearBusy() {
+        this.busy = false;
+    }
+
+    async inspect() {
+        const selectedLessonIds = this.selectedIds();
+        if (!this.sectionName.trim() || selectedLessonIds.length === 0) {
+            this.showStatus('Enter a section name and select at least one lesson.');
+            return;
+        }
+        this.setBusy('Inspecting lessons…');
+        try {
+            this.plan = await this.options.onInspect({
+                sectionName: this.sectionName,
+                selectedLessonIds,
+                onProgress: ({current, total}) => this.showStatus(`Inspecting ${current}/${total}…`)
+            });
+        } catch (error) {
+            this.showStatus(error.message || 'Inspection failed.');
+        } finally {
+            this.clearBusy();
+        }
+    }
+
+    async execute() {
+        if (!this.plan || this.plan.eligible.length === 0) return;
+        this.setBusy('Deleting sections…');
+        try {
+            const result = await this.options.onExecute(
+                this.plan,
+                ({current, total}) => this.showStatus(`Deleting ${current}/${total}…`)
+            );
+            this.resultReport = String(result.report || '');
+            this.resultVisible = true;
+            this.executionId = result.history?.stored ? result.history.record?.id || null : null;
+            const outcome = result.fatalError
+                ? 'Stopped after an operation-wide error. Partial results retained.'
+                : 'Deletion finished.';
+            const history = result.history?.stored
+                ? ' Saved to execution history.'
+                : result.history?.persistenceError
+                    ? ' The visible report is intact, but history could not be saved.'
+                    : '';
+            this.showStatus(`${outcome}${history}`);
+        } catch (error) {
+            this.showStatus(error.message || 'Deletion failed.');
+        } finally {
+            this.clearBusy();
+        }
+    }
+
+    showStatus(message) {
+        this.statusMessage = String(message || '');
+        this.statusVisible = true;
+    }
+
+    close() {
+        if (!this.busy) this.options?.onClose?.();
+    }
+
+    openHistory() {
+        if (this.executionId) this.options?.onOpenHistory?.(this.executionId);
+    }
+
+    renderPlanGroup(title, items, formatter) {
+        return html`
+            <h4>${title}</h4>
+            <ul>${items.length
+                ? items.map((item) => html`<li>${formatter(item)}</li>`)
+                : html`<li>None</li>`}</ul>
+        `;
+    }
+
+    renderPlan() {
+        if (!this.plan) return nothing;
+        return html`
+            <section class="preflight">
+                <h3>Preflight</h3>
+                <dl>
+                    <div><dt>Selected</dt><dd>${this.plan.selectedCount}</dd></div>
+                    <div><dt>Eligible</dt><dd>${this.plan.eligible.length}</dd></div>
+                    <div><dt>Rejected</dt><dd>${this.plan.rejected.length}</dd></div>
+                </dl>
+                ${this.renderPlanGroup('Will delete', this.plan.eligible,
+                    (item) => `#${item.number} ${item.name} → section ${item.sectionId}`)}
+                ${this.renderPlanGroup('Will not modify', this.plan.rejected,
+                    (item) => `#${item.number} ${item.name}: ${item.code} — ${item.message}`)}
+            </section>
+        `;
+    }
+
+    render() {
+        const lessons = this.options?.lessons || [];
+        const canExecute = Boolean(this.plan?.eligible?.length) && !this.resultVisible;
+        return html`
+            <link rel="stylesheet" href=${String(this.options?.stylesheetUrl || '')}>
+            <div class="overlay">
+                <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="title">
+                    <header>
+                        <div><h2 id="title">Delete section from lessons</h2><p>Every lesson is inspected before any deletion.</p></div>
+                        <button class="icon close" type="button" aria-label="Close" ?disabled=${this.busy}
+                            @click=${() => this.close()}>×</button>
+                    </header>
+                    <main>
+                        <label>Exact section name<input class="section-name" type="text" autocomplete="off"
+                            placeholder="Ogłoszenie" .value=${this.sectionName} ?disabled=${this.busy}
+                            @input=${(event) => { this.sectionName = event.currentTarget.value; }}></label>
+                        <div class="toolbar">
+                            <button class="select-all" type="button" ?disabled=${this.busy} @click=${this.selectAll}>Select all</button>
+                            <button class="clear" type="button" ?disabled=${this.busy} @click=${this.clearSelection}>Clear</button>
+                            <span class="selection">${this.selectedLessonIds.size} selected</span>
+                        </div>
+                        <div class="lessons">
+                            ${lessons.map((lesson) => html`
+                                <label class="lesson">
+                                    <input type="checkbox" .value=${String(lesson.lessonId)}
+                                        .checked=${this.selectedLessonIds.has(Number(lesson.lessonId))}
+                                        ?disabled=${this.busy}
+                                        @change=${(event) => this.setLessonSelected(lesson.lessonId, event.currentTarget.checked)}>
+                                    <span>#${lesson.number} ${lesson.name}</span>
+                                </label>
+                            `)}
+                        </div>
+                        <div class="status" ?hidden=${!this.statusVisible}>${this.statusMessage}</div>
+                        ${this.renderPlan()}
+                        <section class="result" ?hidden=${!this.resultVisible}>
+                            <textarea readonly .value=${this.resultReport}></textarea>
+                            <div class="result-actions">
+                                <button class="copy" type="button" ?disabled=${this.busy}
+                                    @click=${() => this.options?.onCopy?.(this.resultReport)}>Copy report</button>
+                                <button class="history" type="button" ?hidden=${!this.executionId}
+                                    ?disabled=${this.busy} @click=${this.openHistory}>Open in history</button>
+                            </div>
+                        </section>
+                    </main>
+                    <footer>
+                        <button class="secondary close" type="button" ?disabled=${this.busy}
+                            @click=${() => this.close()}>Cancel</button>
+                        <button class="inspect" type="button" ?hidden=${this.resultVisible} ?disabled=${this.busy}
+                            @click=${this.inspect}>${this.plan ? 'Run preflight again' : 'Inspect selected lessons'}</button>
+                        <button class="danger execute" type="button" ?hidden=${!canExecute} ?disabled=${this.busy}
+                            @click=${this.execute}>Confirm deletion</button>
+                    </footer>
+                </section>
+            </div>
+        `;
+    }
+}
+
+if (!customElements.get(BATCH_SECTION_DELETION_DIALOG_TAG)) {
+    customElements.define(BATCH_SECTION_DELETION_DIALOG_TAG, BatchSectionDeletionDialog);
+}
+
+const batchSectionDeletionDialogApi = Object.freeze({
+    BATCH_SECTION_DELETION_DIALOG_TAG,
+    BatchSectionDeletionDialog
 });
+globalThis.EdVibeBatchSectionDeletionDialog = batchSectionDeletionDialogApi;
+
+export {BATCH_SECTION_DELETION_DIALOG_TAG, BatchSectionDeletionDialog};

--- a/src/components/batch-section-deletion-dialog.test.js
+++ b/src/components/batch-section-deletion-dialog.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(path.join(__dirname, 'batch-section-deletion-dialog.js'), 'utf8');
+
+test('batch section deletion dialog uses Lit and keeps async feature callbacks', () => {
+    assert.match(source, /import \{ LitElement, html, nothing \} from 'lit';/);
+    assert.match(source, /class BatchSectionDeletionDialog extends LitElement/);
+    assert.match(source, /this\.options\.onInspect/);
+    assert.match(source, /this\.options\.onExecute/);
+    assert.match(source, /onOpenHistory/);
+    assert.match(source, /onCopy/);
+    assert.match(source, /onClose/);
+    assert.doesNotMatch(source, /innerHTML\s*=/);
+    assert.doesNotMatch(source, /module\.exports/);
+});
+
+test('batch section deletion preserves preflight and result states', () => {
+    assert.match(source, /renderPlan\(\)/);
+    assert.match(source, /Will delete/);
+    assert.match(source, /Will not modify/);
+    assert.match(source, /Confirm deletion/);
+    assert.match(source, /Open in history/);
+    assert.match(source, /globalThis\.EdVibeBatchSectionDeletionDialog = batchSectionDeletionDialogApi;/);
+});


### PR DESCRIPTION
## Summary
- migrate lesson selection, exact-name preflight, confirmation, async execution, report, and history-link rendering to Lit
- preserve the feature callback contract for inspect, execute, copy, history navigation, and close
- keep busy-state guards and progress/status updates while async operations run
- add real-browser coverage for selection, preflight, deletion, reporting, copying, and history navigation

Closes #33