### PR TITLE
Migrate batch user onboarding dialog to Lit

### DIFF
--- a/scripts/run-component-tests.mjs
+++ b/scripts/run-component-tests.mjs
@@ -139,9 +139,9 @@ try {
     const timeoutPromise = new Promise((_, rejectTimeout) => {
         setTimeout(
             () => rejectTimeout(new Error(
-                `Component tests timed out after 15 seconds.\n${browserProcess.getStderr()}`
+                `Component tests timed out after 30 seconds.\n${browserProcess.getStderr()}`
             )),
-            15_000
+            30_000
         );
     });
 

--- a/src/component-tests/batch-user-onboarding-dialog-tests.js
+++ b/src/component-tests/batch-user-onboarding-dialog-tests.js
@@ -1,0 +1,152 @@
+import '../components/batch-user-onboarding-dialog.js';
+import {cleanup, click, elementUpdated, equal, fixture, shadowQuery} from './component-test-harness.js';
+
+function discoveredRow(email, overrides = {}) {
+    return {
+        email,
+        normalizedEmail: email.toLowerCase(),
+        user: {name: 'User'},
+        resolution: 'in_marathon',
+        membership: 'in_marathon',
+        actionable: true,
+        moderatorStateSafe: true,
+        currentModerators: [],
+        message: '',
+        ...overrides
+    };
+}
+
+export async function runBatchUserOnboardingDialogTests() {
+    const calls = {preflight: null, executed: null, copied: '', history: null, closed: 0};
+    const dialog = await fixture('<edvibe-toolbox-batch-user-onboarding-dialog></edvibe-toolbox-batch-user-onboarding-dialog>');
+    dialog.configure({
+        stylesheetUrl: '/src/components/batch-user-onboarding-dialog.css',
+        moderators: [{id: 7, name: 'Curator', email: 'curator@example.com'}],
+        parseEmailInput: (value) => ({
+            entries: value.trim() ? value.split(/\s+/).filter((entry) => entry.includes('@')) : [],
+            malformed: value.includes('bad') ? ['bad'] : []
+        }),
+        onDiscover: async () => [
+            discoveredRow('existing@example.com'),
+            discoveredRow('new@example.com', {
+                user: null,
+                resolution: 'resolvable_not_in_marathon',
+                membership: 'not_in_marathon'
+            })
+        ],
+        onPreflight: async (request) => {
+            calls.preflight = request;
+            return {
+                counts: {requested: 2, additions: 1, assignments: 1, noOps: 0, rejectedOperations: 0},
+                rows: [
+                    {
+                        email: 'existing@example.com',
+                        resolution: 'in_marathon',
+                        selectedOperations: [],
+                        message: 'No changes'
+                    },
+                    {
+                        email: 'new@example.com',
+                        resolution: 'resolvable_not_in_marathon',
+                        selectedOperations: ['add', 'assign'],
+                        add: {status: 'planned', code: 'ADD'},
+                        assign: {status: 'planned', code: 'ASSIGN'}
+                    }
+                ]
+            };
+        },
+        onExecute: async (plan, onProgress) => {
+            calls.executed = plan;
+            onProgress({completed: 1, total: 2, successes: 1, failures: 0, current: {email: 'new@example.com', operation: 'add'}});
+            onProgress({completed: 2, total: 2, successes: 2, failures: 0, current: {email: 'new@example.com', operation: 'assign'}});
+            return {
+                report: 'onboarding report',
+                history: {stored: true, record: {id: 'onboarding-history-1'}}
+            };
+        },
+        onCopy: (report) => { calls.copied = report; },
+        onOpenHistory: (id) => { calls.history = id; },
+        onClose: () => { calls.closed += 1; }
+    });
+    dialog.showConfigure();
+    await elementUpdated(dialog);
+
+    const emails = shadowQuery(dialog, '.emails');
+    emails.value = 'existing@example.com new@example.com bad';
+    emails.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+    equal(shadowQuery(dialog, '.valid-count').textContent, 'Уникальных email: 2');
+    equal(shadowQuery(dialog, '.invalid-count').textContent, 'Некорректных: 1');
+
+    await dialog.discover();
+    await elementUpdated(dialog);
+    equal(dialog.mode, 'review');
+    equal(shadowQuery(dialog, '.rows').querySelectorAll('tr').length, 2);
+    equal([...shadowQuery(dialog, '.rows').querySelectorAll('input')].every((input) => input.checked === false), true);
+
+    const newRow = [...shadowQuery(dialog, '.rows').querySelectorAll('tr')]
+        .find((row) => row.dataset.email === 'new@example.com');
+    let add = newRow.querySelector('.add-selected');
+    let assign = newRow.querySelector('.assign-selected');
+    equal(assign.disabled, true, 'Assignment is unavailable until a new user is selected for addition.');
+
+    add.checked = true;
+    add.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+    assign = [...shadowQuery(dialog, '.rows').querySelectorAll('tr')]
+        .find((row) => row.dataset.email === 'new@example.com')
+        .querySelector('.assign-selected');
+    equal(assign.disabled, false);
+    assign.checked = true;
+    assign.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+    equal(dialog.rows.find((row) => row.normalizedEmail === 'new@example.com').assignSelected, true);
+
+    add = [...shadowQuery(dialog, '.rows').querySelectorAll('tr')]
+        .find((row) => row.dataset.email === 'new@example.com')
+        .querySelector('.add-selected');
+    add.checked = false;
+    add.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+    const resetRow = dialog.rows.find((row) => row.normalizedEmail === 'new@example.com');
+    equal(resetRow.addSelected, false);
+    equal(resetRow.assignSelected, false, 'Removing add must also remove the dependent assignment.');
+
+    dialog.setRowSelection('new@example.com', 'addSelected', true);
+    dialog.setRowSelection('new@example.com', 'assignSelected', true);
+    dialog.targetModeratorId = '7';
+    await dialog.preparePlan();
+    await elementUpdated(dialog);
+    equal(dialog.mode, 'preflight');
+    equal(calls.preflight.targetModeratorId, '7');
+    equal(calls.preflight.rows.find((row) => row.normalizedEmail === 'new@example.com').assignSelected, true);
+    equal(shadowQuery(dialog, '.preflight').textContent.includes('Неизменяемый план'), true);
+    equal(shadowQuery(dialog, '.preflight').textContent.includes('Назначений: 1'), true);
+
+    dialog.returnToReview();
+    equal(dialog.mode, 'review');
+    await dialog.preparePlan();
+    await dialog.execute();
+    await elementUpdated(dialog);
+    equal(dialog.mode, 'complete');
+    equal(calls.executed, dialog.plan);
+    equal(shadowQuery(dialog, '.report').value, 'onboarding report');
+    equal(shadowQuery(dialog, '.history').hidden, false);
+    equal(shadowQuery(dialog, '.status').textContent.includes('Результат сохранён в истории'), true);
+
+    click(shadowQuery(dialog, '.copy'));
+    click(shadowQuery(dialog, '.history'));
+    equal(calls.copied, 'onboarding report');
+    equal(calls.history, 'onboarding-history-1');
+
+    click(shadowQuery(dialog, '.restart'));
+    await elementUpdated(dialog);
+    equal(dialog.mode, 'configure');
+    equal(dialog.emailInput, '');
+    equal(dialog.targetModeratorId, '');
+    equal(dialog.rows.length, 0);
+
+    dialog.close();
+    equal(calls.closed, 1);
+    await cleanup();
+}

--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -33,7 +33,8 @@ async function run() {
         ['./batch-lesson-access-dialog-tests.js', 'runBatchLessonAccessDialogTests'],
         ['./batch-section-creation-dialog-tests.js', 'runBatchSectionCreationDialogTests'],
         ['./batch-section-deletion-dialog-tests.js', 'runBatchSectionDeletionDialogTests'],
-        ['./batch-user-management-dialog-tests.js', 'runBatchUserManagementDialogTests']
+        ['./batch-user-management-dialog-tests.js', 'runBatchUserManagementDialogTests'],
+        ['./batch-user-onboarding-dialog-tests.js', 'runBatchUserOnboardingDialogTests']
     ]) {
         const module = await import(modulePath);
         await module[exportName]();

--- a/src/components/batch-user-onboarding-dialog.js
+++ b/src/components/batch-user-onboarding-dialog.js
@@ -1,531 +1,322 @@
-(function initializeBatchUserOnboardingDialog(root, factory) {
-    const api = factory(root);
-    if (typeof module === 'object' && module.exports) {
-        module.exports = api;
-    } else {
-        root.EdVibeBatchUserOnboardingDialog = api;
+import { LitElement, html, nothing } from 'lit';
+
+const BATCH_USER_ONBOARDING_DIALOG_TAG = 'edvibe-toolbox-batch-user-onboarding-dialog';
+
+class BatchUserOnboardingDialog extends LitElement {
+    static properties = {
+        options: {state: true},
+        rows: {state: true},
+        plan: {state: true},
+        mode: {state: true},
+        executionId: {state: true},
+        emailInput: {state: true},
+        targetModeratorId: {state: true},
+        emailCounts: {state: true},
+        errors: {state: true},
+        report: {state: true},
+        statusMessage: {state: true},
+        progress: {state: true}
+    };
+
+    constructor() {
+        super();
+        this.options = null;
+        this.rows = [];
+        this.plan = null;
+        this.mode = 'loading';
+        this.executionId = null;
+        this.emailInput = '';
+        this.targetModeratorId = '';
+        this.emailCounts = {valid: 0, invalid: 0};
+        this.errors = [];
+        this.report = '';
+        this.statusMessage = '';
+        this.progress = {visible: false, completed: 0, total: 1};
+        this.handleKeydownBound = (event) => {
+            if (event.key === 'Escape') this.close();
+        };
     }
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(root) {
-    'use strict';
 
-    const BATCH_USER_ONBOARDING_DIALOG_TAG = 'edvibe-toolbox-batch-user-onboarding-dialog';
-    const HTMLElementBase = root.HTMLElement || class {};
-    const template = root.document?.createElement?.('template') || null;
+    connectedCallback() {
+        super.connectedCallback();
+        this.ownerDocument?.addEventListener('keydown', this.handleKeydownBound);
+    }
 
-    if (template) {
-        template.innerHTML = `
-            <link class="stylesheet" rel="stylesheet">
-            <div class="overlay">
+    disconnectedCallback() {
+        this.ownerDocument?.removeEventListener('keydown', this.handleKeydownBound);
+        super.disconnectedCallback();
+    }
+
+    configure(options = {}) {
+        this.options = options && typeof options === 'object' ? options : {};
+        return this;
+    }
+
+    showLoading(message = 'Загрузка…') {
+        this.mode = 'loading';
+        this.showStatus(message);
+        return this;
+    }
+
+    showConfigure() {
+        this.mode = 'configure';
+        this.plan = null;
+        this.executionId = null;
+        this.clearErrors();
+        this.report = '';
+        this.progress = {visible: false, completed: 0, total: 1};
+        this.showStatus('Введите email пользователей и проверьте список.');
+        this.updateEmailCounts();
+        return this;
+    }
+
+    updateEmailCounts() {
+        if (!this.options?.parseEmailInput) return;
+        const parsed = this.options.parseEmailInput(this.emailInput);
+        this.emailCounts = {
+            valid: parsed.entries?.length || 0,
+            invalid: parsed.malformed?.length || 0
+        };
+    }
+
+    async discover() {
+        if (!this.options?.onDiscover || this.mode === 'executing') return;
+        this.clearErrors();
+        this.mode = 'loading';
+        this.showStatus('Проверяем пользователей…');
+        try {
+            const discovered = await this.options.onDiscover({emailInput: this.emailInput});
+            this.rows = discovered.map((row) => ({...row, addSelected: false, assignSelected: false}));
+            this.plan = null;
+            this.mode = 'review';
+            this.showStatus('Проверьте найденные состояния и выберите операции.');
+        } catch (error) {
+            this.showError(error);
+            this.mode = 'configure';
+        }
+    }
+
+    canAssign(row) {
+        if (!row.actionable || !row.moderatorStateSafe) return false;
+        if (row.membership === 'in_marathon') return true;
+        return row.membership === 'not_in_marathon' && Boolean(row.addSelected);
+    }
+
+    setRowSelection(normalizedEmail, field, checked) {
+        if (this.mode !== 'review') return;
+        this.rows = this.rows.map((row) => {
+            if (row.normalizedEmail !== normalizedEmail) return row;
+            const next = {...row, [field]: Boolean(checked)};
+            if (field === 'addSelected' && !checked && row.membership === 'not_in_marathon') {
+                next.assignSelected = false;
+            }
+            return next;
+        });
+        this.plan = null;
+    }
+
+    selectAll(field) {
+        if (this.mode !== 'review') return;
+        this.rows = this.rows.map((row) => {
+            if (field === 'addSelected' && row.actionable) return {...row, addSelected: true};
+            if (field === 'assignSelected' && this.canAssign(row)) return {...row, assignSelected: true};
+            return row;
+        });
+        this.plan = null;
+    }
+
+    async preparePlan() {
+        if (!this.options?.onPreflight || this.mode !== 'review') return;
+        this.clearErrors();
+        try {
+            this.plan = await this.options.onPreflight({
+                rows: this.rows.map((row) => ({
+                    normalizedEmail: row.normalizedEmail,
+                    addSelected: Boolean(row.addSelected),
+                    assignSelected: Boolean(row.assignSelected)
+                })),
+                targetModeratorId: this.targetModeratorId
+            });
+            this.mode = 'preflight';
+            this.showStatus('План зафиксирован. Проверьте его и подтвердите выполнение.');
+        } catch (error) {
+            this.showError(error);
+        }
+    }
+
+    returnToReview() {
+        if (this.mode !== 'preflight') return;
+        this.plan = null;
+        this.mode = 'review';
+        this.showStatus('Измените выбор и подготовьте новый план.');
+    }
+
+    async execute() {
+        if (!this.plan || !this.options?.onExecute || this.mode !== 'preflight') return;
+        this.mode = 'executing';
+        this.showStatus('Выполняем подтверждённый план…');
+        this.progress = {visible: true, completed: 0, total: 1};
+        try {
+            const result = await this.options.onExecute(this.plan, (progress) => this.showProgress(progress));
+            this.report = result.report || '';
+            this.executionId = result.history?.stored ? result.history.record?.id || null : null;
+            this.mode = result.fatalError ? 'partial-complete' : 'complete';
+            const historyMessage = result.history?.stored
+                ? ' Результат сохранён в истории.'
+                : result.history?.persistenceError
+                    ? ' Видимый отчёт сохранён, но историю записать не удалось.'
+                    : '';
+            this.showStatus(`${result.fatalError
+                ? 'Операция прервана, частичные результаты сохранены.'
+                : 'Обработка завершена.'}${historyMessage}`);
+        } catch (error) {
+            this.mode = 'partial-complete';
+            this.showError(error);
+        } finally {
+            this.progress = {...this.progress, visible: false};
+        }
+    }
+
+    showProgress(progress = {}) {
+        const completed = Math.max(0, Number(progress.completed) || 0);
+        const total = Math.max(0, Number(progress.total) || 0);
+        this.progress = {visible: true, completed: Math.min(completed, Math.max(total, 1)), total: Math.max(total, 1)};
+        const current = progress.current?.operation
+            ? ` Сейчас: ${progress.current.email ? `${progress.current.email}, ` : ''}${progress.current.operation}.`
+            : '';
+        this.showStatus(`Готово операций: ${completed}/${total}. Успешных/no-op: ${progress.successes || 0}. Проблем: ${progress.failures || 0}.${current}`);
+    }
+
+    restart() {
+        if (this.mode === 'executing') return;
+        this.rows = [];
+        this.plan = null;
+        this.executionId = null;
+        this.emailInput = '';
+        this.targetModeratorId = '';
+        this.report = '';
+        this.mode = 'configure';
+        this.updateEmailCounts();
+        this.showStatus('Введите следующую группу пользователей.');
+    }
+
+    close() {
+        if (this.mode === 'executing' || this.mode === 'loading') return;
+        this.options?.onClose?.();
+    }
+
+    clearErrors() {
+        this.errors = [];
+    }
+
+    showError(error) {
+        const message = error?.message || String(error || 'Неизвестная ошибка.');
+        this.errors = [message];
+        this.showStatus(message);
+    }
+
+    showStatus(message) {
+        this.statusMessage = String(message || '');
+    }
+
+    membershipLabel(row) {
+        return {
+            in_marathon: 'В марафоне',
+            resolvable_not_in_marathon: 'Можно добавить по email',
+            ambiguous: 'Неоднозначно',
+            invalid: 'Некорректный email'
+        }[row.resolution] || row.resolution;
+    }
+
+    curatorLabel(row) {
+        if (!row.moderatorStateSafe && row.membership === 'in_marathon') return 'Нельзя безопасно прочитать';
+        return row.currentModerators?.length
+            ? row.currentModerators.map((moderator) => moderator.name || moderator.email || `#${moderator.id}`).join(', ')
+            : 'Нет';
+    }
+
+    renderRow(row) {
+        return html`
+            <tr data-email=${row.normalizedEmail}>
+                <td><strong>${row.user?.name || row.email}</strong><small>${row.user?.name ? row.email : ''}</small></td>
+                <td>${this.membershipLabel(row)}</td>
+                <td class=${!row.moderatorStateSafe && row.membership === 'in_marathon' ? 'is-error' : ''}>${this.curatorLabel(row)}</td>
+                <td><input class="add-selected" type="checkbox" .checked=${Boolean(row.addSelected)}
+                    ?disabled=${this.mode !== 'review' || !row.actionable}
+                    aria-label=${`Добавить ${row.email}`}
+                    @change=${(event) => this.setRowSelection(row.normalizedEmail, 'addSelected', event.currentTarget.checked)}></td>
+                <td><input class="assign-selected" type="checkbox" .checked=${Boolean(row.assignSelected)}
+                    ?disabled=${this.mode !== 'review' || !this.canAssign(row)}
+                    aria-label=${`Назначить куратора ${row.email}`}
+                    @change=${(event) => this.setRowSelection(row.normalizedEmail, 'assignSelected', event.currentTarget.checked)}></td>
+                <td class="row-status">${row.message || 'Готово к выбору.'}</td>
+            </tr>`;
+    }
+
+    renderPreflight() {
+        if (!this.plan) return nothing;
+        return html`
+            <section class="preflight" ?hidden=${!['preflight', 'executing'].includes(this.mode)}>
+                <h3>Неизменяемый план</h3>
+                <p>Строк: ${this.plan.counts.requested}. Добавлений: ${this.plan.counts.additions}. Назначений: ${this.plan.counts.assignments}. Предсказанных no-op: ${this.plan.counts.noOps}. Отклонённых операций: ${this.plan.counts.rejectedOperations}.</p>
+                <ul>${this.plan.rows.map((row) => {
+                    const pieces = [];
+                    if (row.add) pieces.push(`add: ${row.add.status} (${row.add.code})`);
+                    if (row.assign) pieces.push(`assign: ${row.assign.status} (${row.assign.code})`);
+                    if (pieces.length === 0) pieces.push(row.message || row.resolution);
+                    return html`<li>${row.email}: ${pieces.join('; ')}</li>`;
+                })}</ul>
+            </section>`;
+    }
+
+    render() {
+        const reviewVisible = ['review', 'preflight', 'executing', 'complete', 'partial-complete'].includes(this.mode) && this.rows.length > 0;
+        const completed = ['complete', 'partial-complete'].includes(this.mode);
+        return html`
+            <link class="stylesheet" rel="stylesheet" href=${String(this.options?.stylesheetUrl || '')}>
+            <div class="overlay" @click=${(event) => { if (event.target === event.currentTarget) this.close(); }}>
                 <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="batch-user-onboarding-title">
-                    <header class="header">
-                        <div>
-                            <p class="eyebrow">Edvibe Toolbox</p>
-                            <h2 id="batch-user-onboarding-title">Добавить пользователей и назначить куратора</h2>
-                            <p class="description">Проверьте весь список, подготовьте неизменяемый план и только потом подтвердите запись.</p>
-                        </div>
-                        <button class="icon close" type="button" aria-label="Закрыть">×</button>
-                    </header>
+                    <header class="header"><div><p class="eyebrow">Edvibe Toolbox</p><h2 id="batch-user-onboarding-title">Добавить пользователей и назначить куратора</h2><p class="description">Проверьте весь список, подготовьте неизменяемый план и только потом подтвердите запись.</p></div>
+                        <button class="icon close" type="button" aria-label="Закрыть" ?disabled=${['loading', 'executing'].includes(this.mode)} @click=${() => this.close()}>×</button></header>
                     <main class="body">
                         <section class="configure">
-                            <label class="field">
-                                <span>Email пользователей</span>
-                                <textarea class="emails" rows="5" placeholder="user@example.com"></textarea>
-                            </label>
-                            <div class="email-state" aria-live="polite">
-                                <span class="valid-count">Уникальных email: 0</span>
-                                <span class="invalid-count">Некорректных: 0</span>
-                            </div>
-                            <label class="field curator-field">
-                                <span>Целевой куратор</span>
-                                <select class="curator"><option value="">Не выбран</option></select>
-                                <small>Нужен только для строк с операцией назначения.</small>
-                            </label>
+                            <label class="field"><span>Email пользователей</span><textarea class="emails" rows="5" placeholder="user@example.com"
+                                .value=${this.emailInput} ?disabled=${this.mode !== 'configure'}
+                                @input=${(event) => { this.emailInput = event.currentTarget.value; this.updateEmailCounts(); }}></textarea></label>
+                            <div class="email-state" aria-live="polite"><span class="valid-count">Уникальных email: ${this.emailCounts.valid}</span><span class="invalid-count">Некорректных: ${this.emailCounts.invalid}</span></div>
+                            <label class="field curator-field"><span>Целевой куратор</span>
+                                <select class="curator" .value=${this.targetModeratorId} ?disabled=${!['configure', 'review'].includes(this.mode)}
+                                    @change=${(event) => { this.targetModeratorId = event.currentTarget.value; this.plan = null; }}>
+                                    <option value="">Не выбран</option>
+                                    ${(this.options?.moderators || []).map((moderator) => html`<option value=${String(moderator.id)}>${moderator.name ? `${moderator.name}${moderator.email ? ` · ${moderator.email}` : ''}` : moderator.email || `Moderator #${moderator.id}`}</option>`)}
+                                </select><small>Нужен только для строк с операцией назначения.</small></label>
                         </section>
-
-                        <section class="errors" aria-live="polite" hidden></section>
-
-                        <section class="review" hidden>
-                            <div class="review-toolbar">
-                                <strong class="review-count"></strong>
-                                <span>Все операции по умолчанию выключены.</span>
-                            </div>
-                            <div class="table-wrap">
-                                <table>
-                                    <thead>
-                                        <tr>
-                                            <th>Пользователь</th>
-                                            <th>Статус</th>
-                                            <th>Текущие кураторы</th>
-                                            <th>Добавить<button class="select-all-add" type="button">Выбрать все</button></th>
-                                            <th>Назначить<button class="select-all-assign" type="button">Выбрать все</button></th>
-                                            <th>Проверка / результат</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody class="rows"></tbody>
-                                </table>
-                            </div>
+                        <section class="errors" aria-live="polite" ?hidden=${this.errors.length === 0}>${this.errors.map((error) => html`<p>${error}</p>`)}</section>
+                        <section class="review" ?hidden=${!reviewVisible}><div class="review-toolbar"><strong class="review-count">${this.rows.length} строк</strong><span>Все операции по умолчанию выключены.</span></div>
+                            <div class="table-wrap"><table><thead><tr><th>Пользователь</th><th>Статус</th><th>Текущие кураторы</th><th>Добавить<button class="select-all-add" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('addSelected')}>Выбрать все</button></th><th>Назначить<button class="select-all-assign" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('assignSelected')}>Выбрать все</button></th><th>Проверка / результат</th></tr></thead><tbody class="rows">${this.rows.map((row) => this.renderRow(row))}</tbody></table></div>
                         </section>
-
-                        <section class="preflight" hidden></section>
-
-                        <section class="result" hidden>
-                            <label class="field"><span>Отчёт</span><textarea class="report" rows="12" readonly></textarea></label>
-                            <div class="result-actions">
-                                <button class="copy secondary" type="button">Скопировать отчёт</button>
-                                <button class="history secondary" type="button" hidden>Открыть в истории</button>
-                            </div>
-                        </section>
+                        ${this.renderPreflight()}
+                        <section class="result" ?hidden=${!completed}><label class="field"><span>Отчёт</span><textarea class="report" rows="12" readonly .value=${this.report}></textarea></label>
+                            <div class="result-actions"><button class="copy secondary" type="button" @click=${() => this.options?.onCopy?.(this.report)}>Скопировать отчёт</button><button class="history secondary" type="button" ?hidden=${!this.executionId} @click=${() => this.executionId && this.options?.onOpenHistory?.(this.executionId)}>Открыть в истории</button></div></section>
                     </main>
-
-                    <div class="live-region">
-                        <p class="status" role="status" aria-live="polite"></p>
-                        <progress class="progress" max="1" value="0" hidden></progress>
-                    </div>
-
+                    <div class="live-region"><p class="status" role="status" aria-live="polite">${this.statusMessage}</p><progress class="progress" max=${this.progress.total} value=${this.progress.completed} ?hidden=${!this.progress.visible}></progress></div>
                     <footer class="footer">
-                        <button class="restart secondary" type="button" hidden>Запустить другую группу</button>
-                        <button class="edit secondary" type="button" hidden>Изменить выбор</button>
-                        <button class="discover primary" type="button">Проверить пользователей</button>
-                        <button class="prepare primary" type="button" hidden>Подготовить план</button>
-                        <button class="execute primary" type="button" hidden>Подтвердить и выполнить</button>
+                        <button class="restart secondary" type="button" ?hidden=${!completed} @click=${this.restart}>Запустить другую группу</button>
+                        <button class="edit secondary" type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.returnToReview}>Изменить выбор</button>
+                        <button class="discover primary" type="button" ?hidden=${this.mode !== 'configure'} @click=${this.discover}>Проверить пользователей</button>
+                        <button class="prepare primary" type="button" ?hidden=${this.mode !== 'review'} @click=${this.preparePlan}>Подготовить план</button>
+                        <button class="execute primary" type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.execute}>Подтвердить и выполнить</button>
                     </footer>
                 </section>
             </div>`;
     }
+}
 
-    class BatchUserOnboardingDialog extends HTMLElementBase {
-        constructor() {
-            super();
-            this.options = null;
-            this.rows = [];
-            this.plan = null;
-            this.mode = 'loading';
-            this.executionId = null;
-            this.connection = null;
-            this.elements = null;
-            if (typeof this.attachShadow !== 'function' || !template) {
-                return;
-            }
-            this.attachShadow({ mode: 'open' }).append(template.content.cloneNode(true));
-            this.cacheElements();
-        }
+if (!customElements.get(BATCH_USER_ONBOARDING_DIALOG_TAG)) {
+    customElements.define(BATCH_USER_ONBOARDING_DIALOG_TAG, BatchUserOnboardingDialog);
+}
 
-        connectedCallback() {
-            this.connectListeners();
-            this.renderState();
-        }
+const batchUserOnboardingDialogApi = Object.freeze({BATCH_USER_ONBOARDING_DIALOG_TAG, BatchUserOnboardingDialog});
+globalThis.EdVibeBatchUserOnboardingDialog = batchUserOnboardingDialogApi;
 
-        disconnectedCallback() {
-            this.connection?.abort();
-            this.connection = null;
-        }
-
-        configure(options = {}) {
-            this.options = options;
-            this.elements?.stylesheet?.setAttribute('href', String(options.stylesheetUrl || ''));
-            this.renderModerators();
-            this.renderState();
-            return this;
-        }
-
-        cacheElements() {
-            const find = (selector) => this.shadowRoot.querySelector(selector);
-            this.elements = {
-                stylesheet: find('.stylesheet'),
-                overlay: find('.overlay'),
-                close: find('.close'),
-                emails: find('.emails'),
-                validCount: find('.valid-count'),
-                invalidCount: find('.invalid-count'),
-                curator: find('.curator'),
-                errors: find('.errors'),
-                review: find('.review'),
-                reviewCount: find('.review-count'),
-                rows: find('.rows'),
-                selectAllAdd: find('.select-all-add'),
-                selectAllAssign: find('.select-all-assign'),
-                preflight: find('.preflight'),
-                result: find('.result'),
-                report: find('.report'),
-                copy: find('.copy'),
-                history: find('.history'),
-                status: find('.status'),
-                progress: find('.progress'),
-                restart: find('.restart'),
-                edit: find('.edit'),
-                discover: find('.discover'),
-                prepare: find('.prepare'),
-                execute: find('.execute')
-            };
-        }
-
-        connectListeners() {
-            if (!this.elements || this.connection) {
-                return;
-            }
-            this.connection = new AbortController();
-            const signal = this.connection.signal;
-            this.elements.emails.addEventListener('input', () => this.updateEmailCounts(), { signal });
-            this.elements.discover.addEventListener('click', () => this.discover(), { signal });
-            this.elements.prepare.addEventListener('click', () => this.preparePlan(), { signal });
-            this.elements.execute.addEventListener('click', () => this.execute(), { signal });
-            this.elements.edit.addEventListener('click', () => this.returnToReview(), { signal });
-            this.elements.restart.addEventListener('click', () => this.restart(), { signal });
-            this.elements.selectAllAdd.addEventListener('click', () => this.selectAll('addSelected'), { signal });
-            this.elements.selectAllAssign.addEventListener('click', () => this.selectAll('assignSelected'), { signal });
-            this.elements.rows.addEventListener('change', (event) => this.handleRowSelection(event), { signal });
-            this.elements.copy.addEventListener('click', () => this.options?.onCopy?.(this.elements.report.value), { signal });
-            this.elements.history.addEventListener('click', () => {
-                if (this.executionId) this.options?.onOpenHistory?.(this.executionId);
-            }, { signal });
-            this.elements.close.addEventListener('click', () => this.close(), { signal });
-            this.elements.overlay.addEventListener('click', (event) => {
-                if (event.target === this.elements.overlay) this.close();
-            }, { signal });
-            this.ownerDocument?.addEventListener('keydown', (event) => {
-                if (event.key === 'Escape') this.close();
-            }, { signal });
-        }
-
-        showLoading(message = 'Загрузка…') {
-            this.mode = 'loading';
-            this.showStatus(message);
-            this.renderState();
-            return this;
-        }
-
-        showConfigure() {
-            this.mode = 'configure';
-            this.plan = null;
-            this.executionId = null;
-            this.clearErrors();
-            this.showStatus('Введите email пользователей и проверьте список.');
-            this.updateEmailCounts();
-            this.renderState();
-            return this;
-        }
-
-        renderModerators() {
-            if (!this.elements || !this.options) return;
-            const selected = this.elements.curator.value;
-            this.elements.curator.replaceChildren();
-            const empty = this.ownerDocument.createElement('option');
-            empty.value = '';
-            empty.textContent = 'Не выбран';
-            this.elements.curator.append(empty);
-            for (const moderator of this.options.moderators || []) {
-                const option = this.ownerDocument.createElement('option');
-                option.value = String(moderator.id);
-                option.textContent = moderator.name
-                    ? `${moderator.name}${moderator.email ? ` · ${moderator.email}` : ''}`
-                    : moderator.email || `Moderator #${moderator.id}`;
-                this.elements.curator.append(option);
-            }
-            if ([...this.elements.curator.options].some((option) => option.value === selected)) {
-                this.elements.curator.value = selected;
-            }
-        }
-
-        updateEmailCounts() {
-            if (!this.options?.parseEmailInput) return;
-            const parsed = this.options.parseEmailInput(this.elements.emails.value);
-            this.elements.validCount.textContent = `Уникальных email: ${parsed.entries.length}`;
-            this.elements.invalidCount.textContent = `Некорректных: ${parsed.malformed.length}`;
-        }
-
-        async discover() {
-            if (!this.options?.onDiscover || this.mode === 'executing') return;
-            this.clearErrors();
-            this.setBusy(true, 'Проверяем пользователей…');
-            try {
-                this.rows = (await this.options.onDiscover({ emailInput: this.elements.emails.value }))
-                    .map((row) => ({ ...row, addSelected: false, assignSelected: false }));
-                this.plan = null;
-                this.mode = 'review';
-                this.renderRows();
-                this.showStatus('Проверьте найденные состояния и выберите операции.');
-            } catch (error) {
-                this.showError(error);
-                this.mode = 'configure';
-            } finally {
-                this.setBusy(false);
-                this.renderState();
-            }
-        }
-
-        renderRows() {
-            const documentApi = this.ownerDocument;
-            this.elements.rows.replaceChildren();
-            this.elements.reviewCount.textContent = `${this.rows.length} строк`;
-            for (const row of this.rows) {
-                const tr = documentApi.createElement('tr');
-                tr.dataset.email = row.normalizedEmail;
-
-                const identity = documentApi.createElement('td');
-                const name = documentApi.createElement('strong');
-                name.textContent = row.user?.name || row.email;
-                const email = documentApi.createElement('small');
-                email.textContent = row.user?.name ? row.email : '';
-                identity.append(name, email);
-
-                const membership = documentApi.createElement('td');
-                membership.textContent = {
-                    in_marathon: 'В марафоне',
-                    resolvable_not_in_marathon: 'Можно добавить по email',
-                    ambiguous: 'Неоднозначно',
-                    invalid: 'Некорректный email'
-                }[row.resolution] || row.resolution;
-
-                const curators = documentApi.createElement('td');
-                if (!row.moderatorStateSafe && row.membership === 'in_marathon') {
-                    curators.textContent = 'Нельзя безопасно прочитать';
-                    curators.classList.add('is-error');
-                } else {
-                    curators.textContent = row.currentModerators?.length
-                        ? row.currentModerators.map((moderator) => moderator.name || moderator.email || `#${moderator.id}`).join(', ')
-                        : 'Нет';
-                }
-
-                const addCell = documentApi.createElement('td');
-                addCell.append(this.createCheckbox(row, 'addSelected', row.actionable));
-
-                const assignCell = documentApi.createElement('td');
-                assignCell.append(this.createCheckbox(row, 'assignSelected', this.canAssign(row)));
-
-                const status = documentApi.createElement('td');
-                status.className = 'row-status';
-                status.textContent = row.message || 'Готово к выбору.';
-
-                tr.append(identity, membership, curators, addCell, assignCell, status);
-                this.elements.rows.append(tr);
-            }
-        }
-
-        createCheckbox(row, field, enabled) {
-            const input = this.ownerDocument.createElement('input');
-            input.type = 'checkbox';
-            input.dataset.field = field;
-            input.dataset.email = row.normalizedEmail;
-            input.checked = Boolean(row[field]);
-            input.disabled = !enabled;
-            input.setAttribute('aria-label', `${field === 'addSelected' ? 'Добавить' : 'Назначить куратора'} ${row.email}`);
-            return input;
-        }
-
-        canAssign(row) {
-            if (!row.actionable || !row.moderatorStateSafe) return false;
-            if (row.membership === 'in_marathon') return true;
-            return row.membership === 'not_in_marathon' && Boolean(row.addSelected);
-        }
-
-        handleRowSelection(event) {
-            const input = event.target;
-            if (!(input instanceof root.HTMLInputElement) || input.type !== 'checkbox') return;
-            const row = this.rows.find((item) => item.normalizedEmail === input.dataset.email);
-            if (!row) return;
-            row[input.dataset.field] = input.checked;
-            if (input.dataset.field === 'addSelected' && !input.checked && row.membership === 'not_in_marathon') {
-                row.assignSelected = false;
-            }
-            this.plan = null;
-            this.renderRows();
-            this.renderState();
-        }
-
-        selectAll(field) {
-            if (this.mode !== 'review') return;
-            for (const row of this.rows) {
-                if (field === 'addSelected' && row.actionable) {
-                    row.addSelected = true;
-                }
-                if (field === 'assignSelected' && this.canAssign(row)) {
-                    row.assignSelected = true;
-                }
-            }
-            this.plan = null;
-            this.renderRows();
-            this.renderState();
-        }
-
-        async preparePlan() {
-            if (!this.options?.onPreflight || this.mode !== 'review') return;
-            this.clearErrors();
-            try {
-                this.plan = await this.options.onPreflight({
-                    rows: this.rows.map((row) => ({
-                        normalizedEmail: row.normalizedEmail,
-                        addSelected: Boolean(row.addSelected),
-                        assignSelected: Boolean(row.assignSelected)
-                    })),
-                    targetModeratorId: this.elements.curator.value
-                });
-                this.mode = 'preflight';
-                this.renderPreflight();
-                this.showStatus('План зафиксирован. Проверьте его и подтвердите выполнение.');
-            } catch (error) {
-                this.showError(error);
-            }
-            this.renderState();
-        }
-
-        renderPreflight() {
-            const documentApi = this.ownerDocument;
-            this.elements.preflight.replaceChildren();
-            const heading = documentApi.createElement('h3');
-            heading.textContent = 'Неизменяемый план';
-            const summary = documentApi.createElement('p');
-            summary.textContent = `Строк: ${this.plan.counts.requested}. Добавлений: ${this.plan.counts.additions}. `
-                + `Назначений: ${this.plan.counts.assignments}. Предсказанных no-op: ${this.plan.counts.noOps}. `
-                + `Отклонённых операций: ${this.plan.counts.rejectedOperations}.`;
-            const list = documentApi.createElement('ul');
-            for (const row of this.plan.rows) {
-                if (row.selectedOperations.length === 0 && !['invalid', 'ambiguous'].includes(row.resolution)) continue;
-                const item = documentApi.createElement('li');
-                const pieces = [];
-                if (row.add) pieces.push(`add: ${row.add.status} (${row.add.code})`);
-                if (row.assign) pieces.push(`assign: ${row.assign.status} (${row.assign.code})`);
-                if (pieces.length === 0) pieces.push(row.message || row.resolution);
-                item.textContent = `${row.email}: ${pieces.join('; ')}`;
-                list.append(item);
-            }
-            this.elements.preflight.append(heading, summary, list);
-        }
-
-        returnToReview() {
-            if (this.mode !== 'preflight') return;
-            this.plan = null;
-            this.mode = 'review';
-            this.elements.preflight.replaceChildren();
-            this.showStatus('Измените выбор и подготовьте новый план.');
-            this.renderState();
-        }
-
-        async execute() {
-            if (!this.plan || !this.options?.onExecute || this.mode !== 'preflight') return;
-            this.mode = 'executing';
-            this.setBusy(true, 'Выполняем подтверждённый план…');
-            this.elements.progress.hidden = false;
-            try {
-                const result = await this.options.onExecute(this.plan, (progress) => this.showProgress(progress));
-                this.elements.report.value = result.report || '';
-                this.executionId = result.history?.stored ? result.history.record?.id || null : null;
-                this.elements.history.hidden = !this.executionId;
-                this.mode = result.fatalError ? 'partial-complete' : 'complete';
-                const historyMessage = result.history?.stored
-                    ? ' Результат сохранён в истории.'
-                    : result.history?.persistenceError
-                        ? ' Видимый отчёт сохранён, но историю записать не удалось.'
-                        : '';
-                this.showStatus(
-                    `${result.fatalError ? 'Операция прервана, частичные результаты сохранены.' : 'Обработка завершена.'}${historyMessage}`
-                );
-            } catch (error) {
-                this.mode = 'partial-complete';
-                this.showError(error);
-            } finally {
-                this.setBusy(false);
-                this.renderState();
-            }
-        }
-
-        showProgress(progress = {}) {
-            const completed = Math.max(0, Number(progress.completed) || 0);
-            const total = Math.max(0, Number(progress.total) || 0);
-            this.elements.progress.max = Math.max(total, 1);
-            this.elements.progress.value = Math.min(completed, Math.max(total, 1));
-            this.elements.progress.hidden = false;
-            const current = progress.current?.operation
-                ? ` Сейчас: ${progress.current.email ? `${progress.current.email}, ` : ''}${progress.current.operation}.`
-                : '';
-            this.showStatus(`Готово операций: ${completed}/${total}. Успешных/no-op: ${progress.successes || 0}. Проблем: ${progress.failures || 0}.${current}`);
-        }
-
-        restart() {
-            if (this.mode === 'executing') return;
-            this.rows = [];
-            this.plan = null;
-            this.executionId = null;
-            this.elements.emails.value = '';
-            this.elements.curator.value = '';
-            this.elements.rows.replaceChildren();
-            this.elements.preflight.replaceChildren();
-            this.elements.report.value = '';
-            this.elements.history.hidden = true;
-            this.mode = 'configure';
-            this.updateEmailCounts();
-            this.showStatus('Введите следующую группу пользователей.');
-            this.renderState();
-        }
-
-        close() {
-            if (this.mode === 'executing' || this.mode === 'loading') return;
-            this.options?.onClose?.();
-        }
-
-        setBusy(busy, message = '') {
-            if (message) this.showStatus(message);
-            if (!this.elements) return;
-            for (const element of this.shadowRoot.querySelectorAll('button, textarea, select, input')) {
-                element.disabled = Boolean(busy);
-            }
-            if (!busy) this.renderState();
-        }
-
-        renderState() {
-            if (!this.elements) return;
-            const reviewVisible = ['review', 'preflight', 'executing', 'complete', 'partial-complete'].includes(this.mode) && this.rows.length > 0;
-            this.elements.review.hidden = !reviewVisible;
-            this.elements.preflight.hidden = !['preflight', 'executing'].includes(this.mode);
-            this.elements.result.hidden = !['complete', 'partial-complete'].includes(this.mode);
-            this.elements.discover.hidden = this.mode !== 'configure';
-            this.elements.prepare.hidden = this.mode !== 'review';
-            this.elements.execute.hidden = this.mode !== 'preflight';
-            this.elements.edit.hidden = this.mode !== 'preflight';
-            this.elements.restart.hidden = !['complete', 'partial-complete'].includes(this.mode);
-            this.elements.close.disabled = ['loading', 'executing'].includes(this.mode);
-            this.elements.emails.disabled = this.mode !== 'configure';
-            this.elements.curator.disabled = !['configure', 'review'].includes(this.mode);
-            this.elements.selectAllAdd.disabled = this.mode !== 'review';
-            this.elements.selectAllAssign.disabled = this.mode !== 'review';
-            for (const input of this.elements.rows.querySelectorAll('input[type="checkbox"]')) {
-                const row = this.rows.find((item) => item.normalizedEmail === input.dataset.email);
-                const enabled = input.dataset.field === 'addSelected'
-                    ? row?.actionable
-                    : row ? this.canAssign(row) : false;
-                input.disabled = this.mode !== 'review' || !enabled;
-            }
-            if (this.mode !== 'executing') {
-                this.elements.progress.hidden = true;
-            }
-        }
-
-        showStatus(message) {
-            if (this.elements) this.elements.status.textContent = String(message || '');
-        }
-
-        clearErrors() {
-            if (!this.elements) return;
-            this.elements.errors.replaceChildren();
-            this.elements.errors.hidden = true;
-        }
-
-        showError(error) {
-            if (!this.elements) return;
-            this.clearErrors();
-            const entry = this.ownerDocument.createElement('p');
-            entry.textContent = error?.message || String(error || 'Неизвестная ошибка.');
-            this.elements.errors.append(entry);
-            this.elements.errors.hidden = false;
-            this.showStatus(entry.textContent);
-        }
-    }
-
-    if (root.customElements && root.HTMLElement && !root.customElements.get(BATCH_USER_ONBOARDING_DIALOG_TAG)) {
-        root.customElements.define(BATCH_USER_ONBOARDING_DIALOG_TAG, BatchUserOnboardingDialog);
-    }
-
-    return Object.freeze({
-        BATCH_USER_ONBOARDING_DIALOG_TAG,
-        BatchUserOnboardingDialog
-    });
-});
+export {BATCH_USER_ONBOARDING_DIALOG_TAG, BatchUserOnboardingDialog};

--- a/src/components/batch-user-onboarding-dialog.test.js
+++ b/src/components/batch-user-onboarding-dialog.test.js
@@ -3,33 +3,36 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const dialogApi = require('./batch-user-onboarding-dialog');
-
 const source = fs.readFileSync(path.join(__dirname, 'batch-user-onboarding-dialog.js'), 'utf8');
 
-test('exports a guarded Web Component for the onboarding workflow', () => {
-    assert.equal(
-        dialogApi.BATCH_USER_ONBOARDING_DIALOG_TAG,
-        'edvibe-toolbox-batch-user-onboarding-dialog'
-    );
+test('batch user onboarding dialog is a guarded Lit component', () => {
+    assert.match(source, /import \{ LitElement, html, nothing \} from 'lit';/);
+    assert.match(source, /class BatchUserOnboardingDialog extends LitElement/);
     assert.match(source, /customElements\.get\(BATCH_USER_ONBOARDING_DIALOG_TAG\)/);
-    assert.match(source, /attachShadow\(\{ mode: 'open' \}\)/);
-    assert.match(source, /disconnectedCallback\(\)/);
-    assert.match(source, /AbortController/);
+    assert.match(source, /customElements\.define\(BATCH_USER_ONBOARDING_DIALOG_TAG, BatchUserOnboardingDialog\)/);
+    assert.doesNotMatch(source, /createElement\?\.\('template'\)/);
+    assert.doesNotMatch(source, /replaceChildren\(/);
+    assert.doesNotMatch(source, /module\.exports/);
 });
 
-test('keeps confirmation separate from review and starts all mutations unchecked', () => {
+test('onboarding keeps discovery, immutable preflight, and execution as separate states', () => {
+    assert.match(source, /async discover\(\)/);
+    assert.match(source, /addSelected: false, assignSelected: false/);
+    assert.match(source, /async preparePlan\(\)/);
+    assert.match(source, /this\.mode = 'preflight'/);
+    assert.match(source, /async execute\(\)/);
+    assert.match(source, /this\.mode = 'executing'/);
     assert.match(source, /Подготовить план/);
     assert.match(source, /Подтвердить и выполнить/);
-    assert.match(source, /addSelected: false, assignSelected: false/);
-    assert.match(source, /this\.mode = 'preflight'/);
-    assert.match(source, /this\.mode = 'executing'/);
 });
 
-test('provides independent bulk controls, curator selection, reports, and history entry point', () => {
+test('onboarding preserves dependent operation selection, moderator, report, and history controls', () => {
+    assert.match(source, /if \(field === 'addSelected' && !checked && row\.membership === 'not_in_marathon'\)/);
+    assert.match(source, /next\.assignSelected = false;/);
     assert.match(source, /select-all-add/);
     assert.match(source, /select-all-assign/);
     assert.match(source, /class="curator"/);
     assert.match(source, /Скопировать отчёт/);
     assert.match(source, /Открыть в истории/);
+    assert.match(source, /globalThis\.EdVibeBatchUserOnboardingDialog = batchUserOnboardingDialogApi;/);
 });


### PR DESCRIPTION
## Summary
- migrate onboarding discovery, review, moderator selection, immutable preflight, execution, reporting, and restart states to Lit
- preserve the dependency between adding a new user and assigning a curator, including clearing assignment when addition is deselected
- keep service callbacks for discovery, preflight, execution, copy, history navigation, and close outside rendering
- replace imperative row/preflight DOM construction with reactive Lit templates and add real-browser workflow coverage

Closes #37