### PR TITLE
Isolate batch section image upload behind an explicit boundary

### DIFF
--- a/src/component-tests/batch-section-image-upload-tests.js
+++ b/src/component-tests/batch-section-image-upload-tests.js
@@ -1,0 +1,67 @@
+import {
+    BatchSectionImageUploadController,
+    createPlaceholderUrl,
+    createRegistry,
+    formatFileSize,
+    parseClientId
+} from '../components/batch-section-image-upload.js';
+import {equal} from './component-test-harness.js';
+
+export async function runBatchSectionImageUploadTests() {
+    const revoked = [];
+    let previewIndex = 0;
+    const registry = createRegistry();
+    const controller = new BatchSectionImageUploadController({
+        registry,
+        cryptoApi: {randomUUID: () => 'client-1'},
+        urlApi: {
+            createObjectURL: () => `blob:preview-${++previewIndex}`,
+            revokeObjectURL: (url) => revoked.push(url)
+        }
+    });
+
+    const imageBlock = controller.createBlock({id: 'image-1', type: 'image', alt: ''});
+    equal(imageBlock.clientId, 'client-1');
+    equal(imageBlock.url, createPlaceholderUrl('client-1'));
+    equal(parseClientId(imageBlock.url), 'client-1');
+    equal(formatFileSize(2048), '2.0 КБ');
+    equal(controller.canSubmit([imageBlock]), false);
+
+    const firstFile = new File(['first'], 'first.png', {type: 'image/png'});
+    const selected = controller.selectFile(imageBlock, firstFile);
+    equal(selected.fileName, 'first.png');
+    equal(selected.fileType, 'image/png');
+    equal(selected.previewUrl, 'blob:preview-1');
+    equal(registry.get('client-1'), firstFile);
+    equal(registry.size(), 1);
+    equal(controller.canSubmit([selected]), true);
+
+    const secondFile = new File(['second'], 'second.jpg', {type: 'image/jpeg'});
+    const replaced = controller.selectFile(selected, secondFile);
+    equal(replaced.fileName, 'second.jpg');
+    equal(replaced.previewUrl, 'blob:preview-2');
+    equal(registry.get('client-1'), secondFile);
+    equal(JSON.stringify(revoked), JSON.stringify(['blob:preview-1']));
+
+    const cleared = controller.clearFile(replaced);
+    equal(cleared.fileName, '');
+    equal(cleared.previewUrl, '');
+    equal(cleared.url, createPlaceholderUrl('client-1'));
+    equal(registry.size(), 0);
+    equal(JSON.stringify(revoked), JSON.stringify(['blob:preview-1', 'blob:preview-2']));
+
+    const invalid = controller.selectFile(cleared, new File(['text'], 'notes.txt', {type: 'text/plain'}));
+    equal(invalid.fileError, 'Выберите файл изображения.');
+    equal(registry.size(), 0);
+    equal(controller.canSubmit([invalid]), false);
+
+    const first = controller.selectFile(controller.createBlock({id: 'first', type: 'image'}), firstFile);
+    const second = controller.selectFile(controller.createBlock({id: 'second', type: 'image'}), secondFile);
+    const released = controller.releaseAll([first, {id: 'text', type: 'text', text: 'Hello'}, second]);
+    equal(registry.size(), 0);
+    equal(released[0].previewUrl, '');
+    equal(released[1].text, 'Hello');
+    equal(released[2].previewUrl, '');
+    equal(revoked.includes(first.previewUrl), true);
+    equal(revoked.includes(second.previewUrl), true);
+}

--- a/src/component-tests/browser-tests.js
+++ b/src/component-tests/browser-tests.js
@@ -34,7 +34,8 @@ async function run() {
         ['./batch-section-creation-dialog-tests.js', 'runBatchSectionCreationDialogTests'],
         ['./batch-section-deletion-dialog-tests.js', 'runBatchSectionDeletionDialogTests'],
         ['./batch-user-management-dialog-tests.js', 'runBatchUserManagementDialogTests'],
-        ['./batch-user-onboarding-dialog-tests.js', 'runBatchUserOnboardingDialogTests']
+        ['./batch-user-onboarding-dialog-tests.js', 'runBatchUserOnboardingDialogTests'],
+        ['./batch-section-image-upload-tests.js', 'runBatchSectionImageUploadTests']
     ]) {
         const module = await import(modulePath);
         await module[exportName]();

--- a/src/components/batch-section-image-upload.js
+++ b/src/components/batch-section-image-upload.js
@@ -1,79 +1,133 @@
-(function initializeBatchSectionImageUploadComponent(root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define([], () => factory(root));
-    } else if (typeof module === 'object' && module.exports) {
-        module.exports = factory(null);
-    } else {
-        root.EdVibeBatchSectionImageUploadComponent = factory(root);
+const IMAGE_PLACEHOLDER_PREFIX = 'https://media-files-y.edvibe.com/local-upload/';
+
+function createClientId(cryptoApi = globalThis.crypto) {
+    return cryptoApi?.randomUUID?.()
+        || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function createPlaceholderUrl(clientId) {
+    return `${IMAGE_PLACEHOLDER_PREFIX}${encodeURIComponent(String(clientId || ''))}`;
+}
+
+function parseClientId(value) {
+    const text = String(value || '');
+    if (!text.startsWith(IMAGE_PLACEHOLDER_PREFIX)) return '';
+    try {
+        return decodeURIComponent(text.slice(IMAGE_PLACEHOLDER_PREFIX.length));
+    } catch (_) {
+        return '';
     }
-})(typeof globalThis !== 'undefined' ? globalThis : window, function createModule(root) {
-    'use strict';
+}
 
-    const IMAGE_PLACEHOLDER_PREFIX = 'https://media-files-y.edvibe.com/local-upload/';
-    const ENHANCED_MARKER = Symbol('edvibeBatchSectionImageUploadEnhanced');
+function formatFileSize(value) {
+    const bytes = Math.max(0, Number(value) || 0);
+    if (bytes < 1024) return `${bytes} Б`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} КБ`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+}
 
-    function createClientId(cryptoApi = globalThis.crypto) {
-        return cryptoApi?.randomUUID?.()
-            || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-    }
-
-    function createPlaceholderUrl(clientId) {
-        return `${IMAGE_PLACEHOLDER_PREFIX}${encodeURIComponent(String(clientId || ''))}`;
-    }
-
-    function parseClientId(value) {
-        const text = String(value || '');
-        if (!text.startsWith(IMAGE_PLACEHOLDER_PREFIX)) {
-            return '';
+function createRegistry() {
+    const files = new Map();
+    return Object.freeze({
+        register(clientId, file) {
+            if (clientId && file) files.set(String(clientId), file);
+        },
+        get(clientId) {
+            return files.get(String(clientId || '')) || null;
+        },
+        remove(clientId) {
+            files.delete(String(clientId || ''));
+        },
+        clear() {
+            files.clear();
+        },
+        size() {
+            return files.size;
         }
-        try {
-            return decodeURIComponent(text.slice(IMAGE_PLACEHOLDER_PREFIX.length));
-        } catch (_) {
-            return '';
-        }
+    });
+}
+
+function enhanceImageBlock(block, cryptoApi = globalThis.crypto) {
+    const clientId = block?.clientId || parseClientId(block?.url) || createClientId(cryptoApi);
+    return {
+        ...block,
+        clientId,
+        url: createPlaceholderUrl(clientId),
+        alt: String(block?.alt || ''),
+        fileName: String(block?.fileName || ''),
+        fileSize: Math.max(0, Number(block?.fileSize) || 0),
+        fileType: String(block?.fileType || ''),
+        previewUrl: String(block?.previewUrl || ''),
+        fileError: String(block?.fileError || '')
+    };
+}
+
+function resolveEnhancementStylesheet(stylesheetUrl) {
+    try {
+        return new URL('./batch-section-image-upload.css', stylesheetUrl).href;
+    } catch (_) {
+        return '';
+    }
+}
+
+class BatchSectionImageUploadController {
+    constructor({
+        registry = createRegistry(),
+        urlApi = globalThis.URL,
+        cryptoApi = globalThis.crypto
+    } = {}) {
+        this.registry = registry;
+        this.urlApi = urlApi;
+        this.cryptoApi = cryptoApi;
     }
 
-    function formatFileSize(value) {
-        const bytes = Math.max(0, Number(value) || 0);
-        if (bytes < 1024) {
-            return `${bytes} Б`;
-        }
-        if (bytes < 1024 * 1024) {
-            return `${(bytes / 1024).toFixed(1)} КБ`;
-        }
-        return `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+    createBlock(block = {}) {
+        return enhanceImageBlock(block, this.cryptoApi);
     }
 
-    function createRegistry() {
-        const files = new Map();
-        return Object.freeze({
-            register(clientId, file) {
-                if (clientId && file) {
-                    files.set(String(clientId), file);
-                }
-            },
-            get(clientId) {
-                return files.get(String(clientId || '')) || null;
-            },
-            remove(clientId) {
-                files.delete(String(clientId || ''));
-            },
-            clear() {
-                files.clear();
-            },
-            size() {
-                return files.size;
-            }
-        });
+    hasSelectedFile(block) {
+        if (!block || block.type !== 'image') return true;
+        return Boolean(this.registry.get(block.clientId || parseClientId(block.url)));
     }
 
-    function enhanceImageBlock(block, cryptoApi = globalThis.crypto) {
-        const clientId = createClientId(cryptoApi);
+    canSubmit(blocks = []) {
+        return !blocks.some((block) => block.type === 'image' && !this.hasSelectedFile(block));
+    }
+
+    selectFile(block, file) {
+        const released = this.releaseBlock(block);
+        if (!file) return released;
+        if (!String(file.type || '').startsWith('image/')) {
+            return {...released, fileError: 'Выберите файл изображения.'};
+        }
+
+        const clientId = released.clientId || createClientId(this.cryptoApi);
+        const previewUrl = this.urlApi?.createObjectURL?.(file) || '';
+        this.registry.register(clientId, file);
         return {
-            ...block,
+            ...released,
             clientId,
             url: createPlaceholderUrl(clientId),
-            alt: String(block?.alt || ''),
+            fileName: String(file.name || ''),
+            fileSize: Math.max(0, Number(file.size) || 0),
+            fileType: String(file.type || ''),
+            previewUrl,
+            fileError: ''
+        };
+    }
+
+    clearFile(block) {
+        return this.releaseBlock(block);
+    }
+
+    releaseBlock(block) {
+        if (!block || block.type !== 'image') return block;
+        const clientId = block.clientId || parseClientId(block.url);
+        if (clientId) this.registry.remove(clientId);
+        if (block.previewUrl) this.urlApi?.revokeObjectURL?.(block.previewUrl);
+        const next = enhanceImageBlock({...block, clientId}, this.cryptoApi);
+        return {
+            ...next,
             fileName: '',
             fileSize: 0,
             fileType: '',
@@ -82,243 +136,41 @@
         };
     }
 
-    function resolveEnhancementStylesheet(stylesheetUrl) {
-        try {
-            return new URL('./batch-section-image-upload.css', stylesheetUrl).href;
-        } catch (_) {
-            return '';
-        }
+    releaseAll(blocks = []) {
+        return blocks.map((block) => this.releaseBlock(block));
     }
+}
 
-    function enhanceDialog({ rootObject, dialogApi, registry }) {
-        const Dialog = dialogApi?.BatchSectionCreationDialog;
-        if (!Dialog?.prototype || Dialog.prototype[ENHANCED_MARKER]) {
-            return false;
-        }
-
-        const prototype = Dialog.prototype;
-        Object.defineProperty(prototype, ENHANCED_MARKER, { value: true });
-
-        const originalConfigure = prototype.configure;
-        const originalCreateBlock = prototype.createBlock;
-        const originalRenderBlocks = prototype.renderBlocks;
-        const originalRenderPreview = prototype.renderPreview;
-        const originalOnInput = prototype.onInput;
-        const originalOnBlockClick = prototype.onBlockClick;
-        const originalOnRestart = prototype.onRestart;
-        const originalClose = prototype.close;
-        const originalRenderState = prototype.renderState;
-
-        function releaseBlock(block) {
-            if (!block || block.type !== 'image') {
-                return;
-            }
-            registry.remove(block.clientId || parseClientId(block.url));
-            if (block.previewUrl) {
-                rootObject.URL?.revokeObjectURL?.(block.previewUrl);
-            }
-            block.fileName = '';
-            block.fileSize = 0;
-            block.fileType = '';
-            block.previewUrl = '';
-            block.fileError = '';
-        }
-
-        function releaseAll(dialog) {
-            for (const block of dialog.blocks || []) {
-                releaseBlock(block);
-            }
-        }
-
-        prototype.configure = function configure(options = {}) {
-            const result = originalConfigure.call(this, options);
-            const href = resolveEnhancementStylesheet(options.stylesheetUrl || this.stylesheetUrl);
-            if (href && this.shadowRoot && !this.shadowRoot.querySelector('.edvibe-batch-section-image-upload-stylesheet')) {
-                const link = (this.ownerDocument || rootObject.document).createElement('link');
-                link.className = 'edvibe-batch-section-image-upload-stylesheet';
-                link.rel = 'stylesheet';
-                link.href = href;
-                this.shadowRoot.prepend(link);
-            }
-            return result;
-        };
-
-        prototype.createBlock = function createBlock(type) {
-            const block = originalCreateBlock.call(this, type);
-            return type === 'image'
-                ? enhanceImageBlock(block, rootObject.crypto)
-                : block;
-        };
-
-        prototype.renderBlocks = function renderBlocks() {
-            originalRenderBlocks.call(this);
-            const document = this.ownerDocument || rootObject.document;
-
-            for (const block of this.blocks || []) {
-                if (block.type !== 'image') {
-                    continue;
-                }
-                const article = this.elements.blocks.querySelector(`[data-block-id="${block.id}"]`);
-                const urlInput = article?.querySelector('[data-block-field="url"]');
-                const field = urlInput?.closest?.('label');
-                if (!article || !field) {
-                    continue;
-                }
-
-                const title = document.createElement('span');
-                title.textContent = 'Файл изображения';
-                const input = document.createElement('input');
-                input.type = 'file';
-                input.accept = 'image/*';
-                input.dataset.blockField = 'file';
-                input.className = 'edvibe-batch-section-file-input';
-                field.replaceChildren(title, input);
-
-                const details = document.createElement('div');
-                details.className = 'edvibe-batch-section-file-details';
-                const text = document.createElement('span');
-                text.textContent = block.fileName
-                    ? `${block.fileName} · ${formatFileSize(block.fileSize)}`
-                    : 'Файл ещё не выбран';
-                details.appendChild(text);
-
-                if (block.fileName) {
-                    const clear = document.createElement('button');
-                    clear.type = 'button';
-                    clear.dataset.blockAction = 'clear-file';
-                    clear.textContent = 'Убрать файл';
-                    details.appendChild(clear);
-                }
-                field.after(details);
-
-                if (block.fileError) {
-                    const error = document.createElement('p');
-                    error.className = 'edvibe-batch-section-file-error';
-                    error.textContent = block.fileError;
-                    details.after(error);
-                }
-
-                if (block.previewUrl) {
-                    const preview = document.createElement('img');
-                    preview.className = 'edvibe-batch-section-image-preview';
-                    preview.src = block.previewUrl;
-                    preview.alt = block.alt || block.fileName || 'Предпросмотр баннера';
-                    (article.querySelector('.edvibe-batch-section-file-error') || details).after(preview);
-                }
-            }
-        };
-
-        prototype.renderPreview = function renderPreview() {
-            originalRenderPreview.call(this);
-            const items = this.elements.previewBlocks.querySelectorAll('li');
-            (this.blocks || []).forEach((block, index) => {
-                if (block.type === 'image' && items[index]) {
-                    items[index].textContent = `${index + 1}. Баннер: ${block.fileName || 'файл не выбран'}`;
-                }
-            });
-        };
-
-        prototype.onInput = function onInput(event) {
-            const field = event.target?.dataset?.blockField;
-            if (field !== 'file') {
-                originalOnInput.call(this, event);
-                if (field === 'alt') {
-                    const article = event.target.closest?.('[data-block-id]');
-                    const preview = article?.querySelector?.('.edvibe-batch-section-image-preview');
-                    if (preview) {
-                        preview.alt = event.target.value || 'Предпросмотр баннера';
-                    }
-                }
-                return;
-            }
-
-            const article = event.target.closest?.('[data-block-id]');
-            const block = this.blocks.find((entry) => entry.id === article?.dataset?.blockId);
-            if (!block) {
-                return;
-            }
-
-            releaseBlock(block);
-            const file = event.target.files?.[0] || null;
-            if (file && !String(file.type || '').startsWith('image/')) {
-                block.fileError = 'Выберите файл изображения.';
-                event.target.value = '';
-            } else if (file) {
-                block.fileName = file.name;
-                block.fileSize = file.size;
-                block.fileType = file.type;
-                block.previewUrl = rootObject.URL?.createObjectURL?.(file) || '';
-                registry.register(block.clientId, file);
-            }
-
-            this.renderBlocks();
-            this.renderPreview();
-            this.renderState();
-        };
-
-        prototype.onBlockClick = function onBlockClick(event) {
-            const action = event.target?.dataset?.blockAction;
-            const article = event.target?.closest?.('[data-block-id]');
-            const block = this.blocks.find((entry) => entry.id === article?.dataset?.blockId);
-
-            if (action === 'clear-file' && block?.type === 'image') {
-                releaseBlock(block);
-                this.renderBlocks();
-                this.renderPreview();
-                this.renderState();
-                return;
-            }
-            if (action === 'remove' && block?.type === 'image') {
-                releaseBlock(block);
-            }
-            originalOnBlockClick.call(this, event);
-        };
-
-        prototype.onRestart = function onRestart() {
-            releaseAll(this);
-            originalOnRestart.call(this);
-        };
-
-        prototype.close = function close() {
-            releaseAll(this);
-            originalClose.call(this);
-        };
-
-        prototype.renderState = function renderState() {
-            originalRenderState.call(this);
-            const configurable = ['configure', 'validation-error'].includes(this.mode);
-            const missingImage = (this.blocks || []).some((block) =>
-                block.type === 'image' && !registry.get(block.clientId || parseClientId(block.url))
-            );
-            if (configurable && missingImage) {
-                this.elements.preflight.disabled = true;
-            }
-        };
-
-        return true;
-    }
-
-    let registry = null;
-    if (root?.document && root.EdVibeBatchSectionCreationDialog) {
-        registry = createRegistry();
-        root.EdVibeBatchSectionImageRegistry = registry;
-        enhanceDialog({
-            rootObject: root,
-            dialogApi: root.EdVibeBatchSectionCreationDialog,
-            registry
-        });
-    }
-
-    return {
-        IMAGE_PLACEHOLDER_PREFIX,
-        createClientId,
-        createPlaceholderUrl,
-        parseClientId,
-        formatFileSize,
-        createRegistry,
-        enhanceImageBlock,
-        resolveEnhancementStylesheet,
-        enhanceDialog,
-        registry
-    };
+const registry = createRegistry();
+const controller = new BatchSectionImageUploadController({registry});
+const batchSectionImageUploadComponentApi = Object.freeze({
+    IMAGE_PLACEHOLDER_PREFIX,
+    createClientId,
+    createPlaceholderUrl,
+    parseClientId,
+    formatFileSize,
+    createRegistry,
+    enhanceImageBlock,
+    resolveEnhancementStylesheet,
+    BatchSectionImageUploadController,
+    createController: (options = {}) => new BatchSectionImageUploadController(options),
+    registry,
+    controller
 });
+
+globalThis.EdVibeBatchSectionImageRegistry = registry;
+globalThis.EdVibeBatchSectionImageUploadComponent = batchSectionImageUploadComponentApi;
+
+export {
+    IMAGE_PLACEHOLDER_PREFIX,
+    createClientId,
+    createPlaceholderUrl,
+    parseClientId,
+    formatFileSize,
+    createRegistry,
+    enhanceImageBlock,
+    resolveEnhancementStylesheet,
+    BatchSectionImageUploadController,
+    registry,
+    controller
+};

--- a/src/components/batch-section-image-upload.test.js
+++ b/src/components/batch-section-image-upload.test.js
@@ -1,46 +1,34 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
-const {
-    createPlaceholderUrl,
-    parseClientId,
-    formatFileSize,
-    createRegistry,
-    enhanceImageBlock,
-    resolveEnhancementStylesheet
-} = require('./batch-section-image-upload.js');
+const source = fs.readFileSync(path.resolve(__dirname, 'batch-section-image-upload.js'), 'utf8');
 
-test('image blocks receive stable upload placeholders without storing the file in the URL', () => {
-    const block = enhanceImageBlock(
-        { id: 'block-1', type: 'image', url: '', alt: '' },
-        { randomUUID: () => 'client-image-1' }
-    );
-
-    assert.equal(block.clientId, 'client-image-1');
-    assert.equal(block.url, createPlaceholderUrl('client-image-1'));
-    assert.equal(parseClientId(block.url), 'client-image-1');
-    assert.equal(block.fileName, '');
+test('section image upload exposes an explicit integration controller', () => {
+    assert.match(source, /class BatchSectionImageUploadController/);
+    assert.match(source, /selectFile\(block, file\)/);
+    assert.match(source, /clearFile\(block\)/);
+    assert.match(source, /releaseBlock\(block\)/);
+    assert.match(source, /releaseAll\(blocks = \[\]\)/);
+    assert.match(source, /canSubmit\(blocks = \[\]\)/);
+    assert.match(source, /globalThis\.EdVibeBatchSectionImageRegistry = registry;/);
 });
 
-test('image registry keeps selected files only in memory', () => {
-    const registry = createRegistry();
-    const file = { name: 'banner.png', type: 'image/png', size: 2048 };
-
-    registry.register('client-image-1', file);
-    assert.equal(registry.get('client-image-1'), file);
-    assert.equal(registry.size(), 1);
-
-    registry.remove('client-image-1');
-    assert.equal(registry.get('client-image-1'), null);
-    assert.equal(registry.size(), 0);
+test('section image upload no longer patches dialog prototypes or DOM rendering hooks', () => {
+    assert.doesNotMatch(source, /BatchSectionCreationDialog\.prototype/);
+    assert.doesNotMatch(source, /\.prototype\[/);
+    assert.doesNotMatch(source, /enhanceDialog/);
+    assert.doesNotMatch(source, /createElement\(/);
+    assert.doesNotMatch(source, /replaceChildren\(/);
+    assert.doesNotMatch(source, /querySelector\(/);
 });
 
-test('file metadata and enhancement stylesheet are formatted for the dialog', () => {
-    assert.equal(formatFileSize(512), '512 Б');
-    assert.equal(formatFileSize(2048), '2.0 КБ');
-    assert.equal(formatFileSize(2 * 1024 * 1024), '2.0 МБ');
-    assert.equal(
-        resolveEnhancementStylesheet('chrome-extension://toolbox/src/components/batch-section-creation-dialog.css'),
-        'chrome-extension://toolbox/src/components/batch-section-image-upload.css'
-    );
+test('section image upload keeps placeholder and file metadata helpers for feature compatibility', () => {
+    assert.match(source, /IMAGE_PLACEHOLDER_PREFIX/);
+    assert.match(source, /createPlaceholderUrl\(clientId\)/);
+    assert.match(source, /parseClientId\(value\)/);
+    assert.match(source, /formatFileSize\(value\)/);
+    assert.match(source, /createRegistry\(\)/);
+    assert.match(source, /enhanceImageBlock\(block/);
 });


### PR DESCRIPTION
## Summary
- replace the dialog prototype monkey patch with an explicit image-upload controller and registry boundary
- keep placeholder URLs and the shared file registry compatible with the existing upload adapter
- make file ownership, replacement, validation, object-URL cleanup, and submit readiness explicit
- add browser coverage for selection, replacement, invalid files, cleanup, and registry lifecycle

This intentionally does not add image controls to the Lit dialog yet; #39 consumes this boundary declaratively.

Closes #38