### PR TITLE
Integrate section image UI into the Lit dialog

### DIFF
--- a/src/component-tests/batch-section-creation-dialog-tests.js
+++ b/src/component-tests/batch-section-creation-dialog-tests.js
@@ -35,7 +35,7 @@ export async function runBatchSectionCreationDialogTests() {
     const imageBlock = dialog.blocks[0];
     equal(imageBlock.type, 'image');
     equal(dialog.canPreflight(), false, 'Image blocks require a selected file.');
-    equal(shadowQuery(dialog, '.edvibe-batch-section-image-preview') === null, true);
+    equal(dialog.shadowRoot.querySelector('.edvibe-batch-section-image-preview'), null);
 
     const imageInput = shadowQuery(dialog, '.edvibe-batch-section-file-input');
     const file = new File(['image-data'], 'banner.png', {type: 'image/png'});

--- a/src/component-tests/batch-section-creation-dialog-tests.js
+++ b/src/component-tests/batch-section-creation-dialog-tests.js
@@ -1,4 +1,5 @@
 import '../components/batch-section-creation-dialog.js';
+import {registry as imageRegistry} from '../components/batch-section-image-upload.js';
 import {
     cleanup,
     click,
@@ -9,6 +10,7 @@ import {
 } from './component-test-harness.js';
 
 export async function runBatchSectionCreationDialogTests() {
+    imageRegistry.clear();
     const lessons = [
         {lessonId: 10, number: 1, name: 'Welcome'},
         {lessonId: 11, number: 2, name: 'Practice'}
@@ -25,8 +27,32 @@ export async function runBatchSectionCreationDialogTests() {
     const name = shadowQuery(dialog, '.edvibe-batch-section-name');
     name.value = 'Summer section';
     name.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
+    click(shadowQuery(dialog, '[data-add-block="image"]'));
     click(shadowQuery(dialog, '[data-add-block="text"]'));
     await elementUpdated(dialog);
+
+    equal(dialog.blocks.length, 2);
+    const imageBlock = dialog.blocks[0];
+    equal(imageBlock.type, 'image');
+    equal(dialog.canPreflight(), false, 'Image blocks require a selected file.');
+    equal(shadowQuery(dialog, '.edvibe-batch-section-image-preview') === null, true);
+
+    const imageInput = shadowQuery(dialog, '.edvibe-batch-section-file-input');
+    const file = new File(['image-data'], 'banner.png', {type: 'image/png'});
+    Object.defineProperty(imageInput, 'files', {configurable: true, value: [file]});
+    imageInput.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+
+    const selectedImage = dialog.blocks.find((block) => block.type === 'image');
+    equal(selectedImage.fileName, 'banner.png');
+    equal(selectedImage.url.includes('/local-upload/'), true);
+    equal(imageRegistry.get(selectedImage.clientId), file);
+    equal(shadowQuery(dialog, '.edvibe-batch-section-file-details').textContent.includes('banner.png'), true);
+    equal(shadowQuery(dialog, '.edvibe-batch-section-image-preview').src.startsWith('blob:'), true);
+
+    const altInput = shadowQuery(dialog, '[data-block-field="alt"]');
+    altInput.value = 'Campaign banner';
+    altInput.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
     const blockText = shadowQuery(dialog, '[data-block-field="text"]');
     blockText.value = 'Hello';
     blockText.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
@@ -34,18 +60,25 @@ export async function runBatchSectionCreationDialogTests() {
     await elementUpdated(dialog);
 
     equal(dialog.sectionName, 'Summer section');
-    equal(dialog.blocks.length, 1);
-    equal(dialog.blocks[0].text, 'Hello');
+    equal(dialog.blocks.find((block) => block.type === 'image').alt, 'Campaign banner');
+    equal(dialog.blocks.find((block) => block.type === 'text').text, 'Hello');
     equal(dialog.selectedLessonIds.size, 2);
     equal(shadowQuery(dialog, '.edvibe-batch-section-preview-name').textContent, 'Summer section');
-    equal(shadowQuery(dialog, '.edvibe-batch-section-preview-blocks').textContent.includes('Текст: Hello'), true);
+    equal(shadowQuery(dialog, '.edvibe-batch-section-preview-blocks').textContent.includes('Баннер: banner.png'), true);
     equal(shadowQuery(dialog, '.edvibe-batch-section-preflight').disabled, false);
+
+    const imageArticle = [...dialog.shadowRoot.querySelectorAll('.edvibe-batch-section-block')]
+        .find((element) => element.dataset.blockId === selectedImage.id);
+    click(imageArticle.querySelector('[data-block-action="down"]'));
+    await elementUpdated(dialog);
+    equal(dialog.blocks[1].type, 'image', 'Image block should reorder through the normal Lit block model.');
 
     let preflight = null;
     dialog.addEventListener('edvibe-batch-section-preflight', (event) => { preflight = event.detail; });
     click(shadowQuery(dialog, '.edvibe-batch-section-preflight'));
     equal(preflight.definition.name, 'Summer section');
-    equal(preflight.definition.blocks.length, 1);
+    equal(preflight.definition.blocks.length, 2);
+    equal(preflight.definition.blocks.find((block) => block.type === 'image').fileName, 'banner.png');
     equal(JSON.stringify(preflight.selectedLessonIds), JSON.stringify([10, 11]));
 
     dialog.showValidationErrors([{code: 'SECTION_NAME_COLLISION', message: 'Already exists'}]);
@@ -56,7 +89,7 @@ export async function runBatchSectionCreationDialogTests() {
         selectedLessonIds: [10, 11],
         eligible: [{number: 1, name: 'Welcome'}],
         rejected: [{number: 2, name: 'Practice', code: 'SECTION_NAME_COLLISION', message: 'Already exists'}],
-        definition: {name: 'Summer section', blocks: [{type: 'text', text: 'Hello'}]}
+        definition: {name: 'Summer section', blocks: preflight.definition.blocks}
     };
     dialog.showConfirmation(plan);
     await elementUpdated(dialog);
@@ -91,16 +124,29 @@ export async function runBatchSectionCreationDialogTests() {
     dialog.addEventListener('edvibe-batch-section-restart', () => { restarted += 1; });
     click(shadowQuery(dialog, '.edvibe-batch-section-copy'));
     click(shadowQuery(dialog, '.edvibe-batch-section-restart'));
+    await elementUpdated(dialog);
     equal(copied, 1);
     equal(restarted, 1);
     equal(dialog.sectionName, '');
     equal(dialog.blocks.length, 0);
     equal(dialog.selectedLessonIds.size, 0);
+    equal(imageRegistry.size(), 0, 'Restart should release selected image files.');
+
+    dialog.showConfigure({lessons, recipeReady: true});
+    click(shadowQuery(dialog, '[data-add-block="image"]'));
+    await elementUpdated(dialog);
+    const secondInput = shadowQuery(dialog, '.edvibe-batch-section-file-input');
+    const secondFile = new File(['second'], 'second.png', {type: 'image/png'});
+    Object.defineProperty(secondInput, 'files', {configurable: true, value: [secondFile]});
+    secondInput.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+    await elementUpdated(dialog);
+    equal(imageRegistry.size(), 1);
 
     let closed = 0;
     dialog.addEventListener('edvibe-dialog-close', () => { closed += 1; });
     dialog.close();
     equal(closed, 1);
     equal(dialog.isConnected, false);
+    equal(imageRegistry.size(), 0, 'Closing should release selected image files.');
     await cleanup();
 }

--- a/src/components/batch-section-creation-dialog.js
+++ b/src/components/batch-section-creation-dialog.js
@@ -1,4 +1,9 @@
 import { LitElement, html, nothing } from 'lit';
+import {
+    controller as defaultImageController,
+    formatFileSize,
+    resolveEnhancementStylesheet
+} from './batch-section-image-upload.js';
 
 const BATCH_SECTION_DIALOG_TAG = 'edvibe-toolbox-batch-section-creation-dialog';
 const BATCH_SECTION_OVERLAY_ID = 'edvibe-toolbox-batch-section-creation-overlay';
@@ -6,6 +11,7 @@ const BATCH_SECTION_OVERLAY_ID = 'edvibe-toolbox-batch-section-creation-overlay'
 class BatchSectionCreationDialog extends LitElement {
     static properties = {
         stylesheetUrl: {state: true},
+        imageStylesheetUrl: {state: true},
         lessons: {state: true},
         selectedLessonIds: {state: true},
         blocks: {state: true},
@@ -25,6 +31,8 @@ class BatchSectionCreationDialog extends LitElement {
     constructor() {
         super();
         this.stylesheetUrl = '';
+        this.imageStylesheetUrl = '';
+        this.imageController = defaultImageController;
         this.lessons = [];
         this.selectedLessonIds = new Set();
         this.blocks = [];
@@ -50,6 +58,7 @@ class BatchSectionCreationDialog extends LitElement {
     }
 
     disconnectedCallback() {
+        this.releaseImageFiles();
         this.ownerDocument?.removeEventListener('keydown', this.onKeydownBound);
         super.disconnectedCallback();
     }
@@ -58,6 +67,10 @@ class BatchSectionCreationDialog extends LitElement {
         options = options && typeof options === 'object' ? options : {};
         if (options.stylesheetUrl !== undefined) {
             this.stylesheetUrl = String(options.stylesheetUrl || '');
+            this.imageStylesheetUrl = resolveEnhancementStylesheet(this.stylesheetUrl);
+        }
+        if (options.imageController) {
+            this.imageController = options.imageController;
         }
         return this;
     }
@@ -156,7 +169,9 @@ class BatchSectionCreationDialog extends LitElement {
 
     createBlock(type) {
         const block = {id: `block-${this.nextBlockId++}`, type};
-        if (type === 'image') return {...block, url: '', alt: ''};
+        if (type === 'image') {
+            return this.imageController.createBlock({...block, url: '', alt: ''});
+        }
         if (type === 'text') return {...block, text: ''};
         return {...block, label: '', url: ''};
     }
@@ -176,6 +191,25 @@ class BatchSectionCreationDialog extends LitElement {
         this.blocks = this.blocks.map((block) => block.id === blockId
             ? {...block, [field]: value}
             : block);
+    }
+
+    replaceBlock(blockId, replacement) {
+        this.blocks = this.blocks.map((block) => block.id === blockId ? replacement : block);
+    }
+
+    onImageFileChange(block, event) {
+        const file = event.currentTarget.files?.[0] || null;
+        this.replaceBlock(block.id, this.imageController.selectFile(block, file));
+        event.currentTarget.value = '';
+    }
+
+    onClearImage(block) {
+        this.replaceBlock(block.id, this.imageController.clearFile(block));
+    }
+
+    releaseImageFiles() {
+        if (!this.imageController || this.blocks.length === 0) return;
+        this.blocks = this.imageController.releaseAll(this.blocks);
     }
 
     onLessonChange(event) {
@@ -203,8 +237,10 @@ class BatchSectionCreationDialog extends LitElement {
         const index = this.blocks.findIndex((block) => block.id === blockId);
         if (index < 0) return;
         const next = [...this.blocks];
-        if (action === 'remove') next.splice(index, 1);
-        else if (action === 'up' && index > 0) {
+        if (action === 'remove') {
+            const [removed] = next.splice(index, 1);
+            if (removed?.type === 'image') this.imageController.releaseBlock(removed);
+        } else if (action === 'up' && index > 0) {
             const [block] = next.splice(index, 1);
             next.splice(index - 1, 0, block);
         } else if (action === 'down' && index < next.length - 1) {
@@ -214,7 +250,16 @@ class BatchSectionCreationDialog extends LitElement {
         this.blocks = next;
     }
 
+    canPreflight() {
+        return ['configure', 'validation-error'].includes(this.mode)
+            && this.selectedLessonIds.size > 0
+            && this.sectionName.trim().length > 0
+            && this.blocks.length > 0
+            && this.imageController.canSubmit(this.blocks);
+    }
+
     onPreflight() {
+        if (!this.canPreflight()) return;
         this.dispatchEvent(new CustomEvent('edvibe-batch-section-preflight', {
             bubbles: true,
             composed: true,
@@ -240,6 +285,7 @@ class BatchSectionCreationDialog extends LitElement {
     }
 
     onRestart() {
+        this.releaseImageFiles();
         this.sectionName = '';
         this.blocks = [];
         this.selectedLessonIds = new Set();
@@ -250,6 +296,7 @@ class BatchSectionCreationDialog extends LitElement {
     }
 
     close() {
+        this.releaseImageFiles();
         this.dispatchEvent(new CustomEvent('edvibe-dialog-close', {
             bubbles: true,
             composed: true
@@ -306,6 +353,30 @@ class BatchSectionCreationDialog extends LitElement {
         `;
     }
 
+    renderImageFields(block, configurable) {
+        return html`
+            <label class="edvibe-batch-section-field">
+                <span>Файл изображения</span>
+                <input class="edvibe-batch-section-file-input" type="file" accept="image/*"
+                    ?disabled=${!configurable}
+                    @change=${(event) => this.onImageFileChange(block, event)}>
+            </label>
+            ${block.fileName ? html`
+                <div class="edvibe-batch-section-file-details">
+                    <span>${block.fileName} · ${formatFileSize(block.fileSize)}</span>
+                    <button type="button" ?disabled=${!configurable}
+                        @click=${() => this.onClearImage(block)}>Убрать файл</button>
+                </div>
+            ` : nothing}
+            ${block.fileError ? html`<p class="edvibe-batch-section-file-error">${block.fileError}</p>` : nothing}
+            ${block.previewUrl ? html`
+                <img class="edvibe-batch-section-image-preview" src=${block.previewUrl}
+                    alt=${block.alt || 'Предпросмотр изображения'}>
+            ` : nothing}
+            ${this.renderBlockField(block, 'Альтернативный текст', 'alt', false, configurable)}
+        `;
+    }
+
     renderBlock(block, index, configurable) {
         return html`
             <article class="edvibe-batch-section-block" data-block-id=${block.id}>
@@ -321,21 +392,19 @@ class BatchSectionCreationDialog extends LitElement {
                             @click=${() => this.onBlockAction(block.id, 'remove')}>Удалить</button>
                     </div>
                 </header>
-                ${block.type === 'image' ? html`
-                    ${this.renderBlockField(block, 'URL изображения', 'url', false, configurable)}
-                    ${this.renderBlockField(block, 'Альтернативный текст', 'alt', false, configurable)}
-                ` : block.type === 'text' ? html`
-                    ${this.renderBlockField(block, 'Текст или HTML', 'text', true, configurable)}
-                ` : html`
-                    ${this.renderBlockField(block, 'Подпись кнопки', 'label', false, configurable)}
-                    ${this.renderBlockField(block, 'URL', 'url', false, configurable)}
-                `}
+                ${block.type === 'image' ? this.renderImageFields(block, configurable)
+                    : block.type === 'text' ? html`
+                        ${this.renderBlockField(block, 'Текст или HTML', 'text', true, configurable)}
+                    ` : html`
+                        ${this.renderBlockField(block, 'Подпись кнопки', 'label', false, configurable)}
+                        ${this.renderBlockField(block, 'URL', 'url', false, configurable)}
+                    `}
             </article>
         `;
     }
 
     previewDetail(block) {
-        if (block.type === 'image') return block.url || 'URL не указан';
+        if (block.type === 'image') return block.fileName || 'Файл не выбран';
         if (block.type === 'text') return block.text || 'Текст не указан';
         return `${block.label || 'Без подписи'} → ${block.url || 'URL не указан'}`;
     }
@@ -420,15 +489,13 @@ class BatchSectionCreationDialog extends LitElement {
     render() {
         const configurable = ['configure', 'validation-error'].includes(this.mode);
         const busy = this.isBusy();
-        const canPreflight = configurable
-            && this.selectedLessonIds.size > 0
-            && this.sectionName.trim().length > 0
-            && this.blocks.length > 0;
-        const statusClass = 'edvibe-batch-section-status';
+        const canPreflight = this.canPreflight();
 
         return html`
             <link class="edvibe-batch-section-stylesheet" rel="stylesheet"
                 href=${this.stylesheetUrl || nothing}>
+            <link class="edvibe-batch-section-image-stylesheet" rel="stylesheet"
+                href=${this.imageStylesheetUrl || nothing}>
             <div class="edvibe-batch-section-overlay" @click=${this.onBackdrop}>
                 <section class="edvibe-batch-section-card" role="dialog" aria-modal="true"
                     aria-labelledby="edvibe-batch-section-title">
@@ -490,7 +557,7 @@ class BatchSectionCreationDialog extends LitElement {
                     </div>
                     <div class="edvibe-batch-section-live-region">
                         <span class="edvibe-batch-section-spinner" role="img" aria-label="Выполняется операция" ?hidden=${!busy}></span>
-                        <p class=${statusClass} data-state=${this.statusState} role="status" aria-live="polite">${this.statusMessage}</p>
+                        <p class="edvibe-batch-section-status" data-state=${this.statusState} role="status" aria-live="polite">${this.statusMessage}</p>
                         <progress class="edvibe-batch-section-progress" max=${this.progress.total}
                             value=${this.progress.completed} ?hidden=${!this.progress.visible}></progress>
                     </div>

--- a/src/components/batch-section-creation-dialog.test.js
+++ b/src/components/batch-section-creation-dialog.test.js
@@ -6,6 +6,8 @@ const path = require('node:path');
 const source = fs.readFileSync(path.join(__dirname, 'batch-section-creation-dialog.js'), 'utf8');
 const styles = fs.readFileSync(path.join(__dirname, 'batch-section-creation-dialog.css'), 'utf8');
 
+const imageUploadSource = fs.readFileSync(path.join(__dirname, 'batch-section-image-upload.js'), 'utf8');
+
 test('section creation dialog uses Lit for selection, block construction, preview, and reports', () => {
     assert.match(source, /import \{ LitElement, html, nothing \} from 'lit';/);
     assert.match(source, /class BatchSectionCreationDialog extends LitElement/);
@@ -21,8 +23,24 @@ test('section creation dialog uses Lit for selection, block construction, previe
     assert.doesNotMatch(source, /module\.exports/);
 });
 
-test('section creation dialog keeps presentation in its dedicated stylesheet', () => {
+test('image blocks render through the Lit component and explicit upload controller', () => {
+    assert.match(source, /from '\.\/batch-section-image-upload\.js';/);
+    assert.match(source, /this\.imageController = defaultImageController;/);
+    assert.match(source, /return this\.imageController\.createBlock/);
+    assert.match(source, /renderImageFields\(block, configurable\)/);
+    assert.match(source, /class="edvibe-batch-section-file-input" type="file" accept="image\/\*"/);
+    assert.match(source, /class="edvibe-batch-section-image-preview"/);
+    assert.match(source, /this\.imageController\.selectFile\(block, file\)/);
+    assert.match(source, /this\.imageController\.clearFile\(block\)/);
+    assert.match(source, /this\.imageController\.releaseBlock\(removed\)/);
+    assert.match(source, /this\.imageController\.releaseAll\(this\.blocks\)/);
+    assert.match(source, /this\.imageController\.canSubmit\(this\.blocks\)/);
+    assert.doesNotMatch(imageUploadSource, /BatchSectionCreationDialog\.prototype/);
+});
+
+test('section creation dialog keeps presentation in dedicated stylesheets', () => {
     assert.doesNotMatch(source, /cssText|\.style\.|<style/);
+    assert.match(source, /edvibe-batch-section-image-stylesheet/);
     assert.match(styles, /\.edvibe-batch-section-overlay/);
     assert.match(styles, /\.edvibe-batch-section-grid/);
     assert.match(styles, /\.edvibe-batch-section-block/);


### PR DESCRIPTION
## Summary
- render image file selection, metadata, validation, preview, and alt text directly in the Lit block template
- consume the explicit #38 image-upload controller instead of post-render DOM modification
- block preflight until every image block owns a selected file
- release registry entries and object URLs when images are replaced, removed, restarted, closed, or externally disconnected
- expand real-browser coverage across image selection, preview, reordering, preflight payloads, restart, and close cleanup

Closes #39