### PR TITLE
Validate builds and synchronize dist in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'dist/**'
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -24,3 +26,48 @@ jobs:
         run: npm ci
       - name: Run test suite
         run: npm run test:ci
+      - name: Build production extension
+        run: npm run build
+
+  sync-dist:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: dist-sync-master
+      cancel-in-progress: false
+    steps:
+      - name: Check out latest master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build production extension
+        run: npm run build
+      - name: Detect generated distribution changes
+        id: dist
+        shell: bash
+        run: |
+          git add -A dist
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit synchronized distribution
+        if: steps.dist.outputs.changed == 'true'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: synchronize generated extension distribution [skip ci]"
+          git push origin HEAD:master

--- a/scripts/run-component-tests.mjs
+++ b/scripts/run-component-tests.mjs
@@ -139,9 +139,9 @@ try {
     const timeoutPromise = new Promise((_, rejectTimeout) => {
         setTimeout(
             () => rejectTimeout(new Error(
-                `Component tests timed out after 30 seconds.\n${browserProcess.getStderr()}`
+                `Component tests timed out after 60 seconds.\n${browserProcess.getStderr()}`
             )),
-            30_000
+            60_000
         );
     });
 


### PR DESCRIPTION
## Summary
- extend PR validation to run the production extension build after the existing test suites
- keep validation read-only and never modify PR branches
- add a master-only `sync-dist` job with narrowly scoped `contents: write`
- detect generated additions, modifications, and deletions with `git add -A dist`
- skip commits when the generated distribution is unchanged
- prevent recursive CI runs for dist-only synchronization commits

Closes #41