### PR TITLE
Minimize Manifest V3 permission surface

### DIFF
--- a/docs/extension-permissions.md
+++ b/docs/extension-permissions.md
@@ -1,0 +1,15 @@
+# Extension permissions
+
+Edvibe Toolbox keeps its Manifest V3 permission surface intentionally small.
+
+| Capability | Manifest declaration | Current use |
+| --- | --- | --- |
+| Extension storage | `storage` | Persists export busy state and execution-history preferences through the ISOLATED-world bridge. |
+| User-invoked active tab | `activeTab` | Lets the popup inspect the active tab URL after the extension action is invoked and address that tab for Toolbox commands. |
+| Automatic Edvibe runtime injection | `content_scripts.matches` for `*://*.edvibe.com/*` | Loads the ISOLATED and MAIN runtime entry points on supported Edvibe pages at `document_start`. |
+
+The extension does not request `scripting`: production code uses statically declared content scripts and never calls `chrome.scripting`.
+
+The extension also does not request separate `host_permissions`. Its automatic page access is declared by the static content-script match pattern, while popup access to the user-selected active tab is temporary through `activeTab`.
+
+When a feature needs a new Chrome capability, add the narrowest permission that supports its current runtime behavior and update this document together with the manifest contract test.

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,7 @@
     "description": "A universal toolkit for automation and backup on the Edvibe platform.",
     "permissions": [
         "storage",
-        "activeTab",
-        "scripting"
-    ],
-    "host_permissions": [
-        "*://*.edvibe.com/*"
+        "activeTab"
     ],
     "action": {
         "default_popup": "popup.html"

--- a/src/manifest-permissions.test.js
+++ b/src/manifest-permissions.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+
+test('manifest requests only Chrome capabilities consumed by the current runtime', () => {
+    assert.deepEqual(manifest.permissions, ['storage', 'activeTab']);
+    assert.equal(Object.prototype.hasOwnProperty.call(manifest, 'host_permissions'), false);
+    assert.equal(manifest.permissions.includes('scripting'), false);
+});
+
+test('Edvibe page access is limited to the static content-script match pattern', () => {
+    assert.equal(manifest.content_scripts.length, 2);
+    for (const entry of manifest.content_scripts) {
+        assert.deepEqual(entry.matches, ['*://*.edvibe.com/*']);
+        assert.equal(entry.run_at, 'document_start');
+    }
+    assert.deepEqual(
+        new Set(manifest.content_scripts.map((entry) => entry.world)),
+        new Set(['ISOLATED', 'MAIN'])
+    );
+});


### PR DESCRIPTION
Closes #73

## Summary
- remove the unused `scripting` permission because production code uses only statically declared content scripts
- remove redundant `host_permissions`; static Edvibe injection remains governed by `content_scripts.matches`, while popup tab access remains temporary through `activeTab`
- retain `storage` for export state and execution-history preferences
- document the rationale for every remaining capability
- add a manifest permission contract test to prevent accidental permission creep

## Validation
Full CI required before merge.