### PR TITLE
Add bounded request-attempt diagnostics to execution history records (schema-compatible)

### DIFF
--- a/src/shared/execution-history-export.js
+++ b/src/shared/execution-history-export.js
@@ -1,14 +1,13 @@
 import * as recordApi from './execution-history-record.js';
 
 function serializeExecutionRecord(record) {
-    recordApi.validateExecutionRecord(record);
-    return `${JSON.stringify(record, null, 2)}\n`;
+    return `${JSON.stringify(recordApi.cloneExecutionRecord(record), null, 2)}\n`;
 }
 
 function serializeExecutionRecords(records) {
     if (!Array.isArray(records)) throw new TypeError('Records must be an array');
-    records.forEach(recordApi.validateExecutionRecord);
-    return `${JSON.stringify(records, null, 2)}\n`;
+    const normalizedRecords = records.map(recordApi.cloneExecutionRecord);
+    return `${JSON.stringify(normalizedRecords, null, 2)}\n`;
 }
 
 function slug(value) {

--- a/src/shared/execution-history-record.js
+++ b/src/shared/execution-history-record.js
@@ -20,6 +20,20 @@ const UNSAFE_FIELD_WORDS = new Set([
     'credentials', 'frame', 'frames', 'image', 'password', 'recording',
     'response', 'session', 'token', 'transport', 'websocket'
 ]);
+const DIAGNOSTIC_LIMITS = Object.freeze({
+    attempts: 20,
+    summaryDepth: 4,
+    summaryEntries: 25,
+    stringLength: 500,
+    serializedSize: 32 * 1024
+});
+const DIAGNOSTIC_FIELDS = new Set(['requestAttempts']);
+const REQUEST_ATTEMPT_FIELDS = new Set([
+    'correlationId', 'operationName', 'controller', 'method', 'projectName', 'requestId',
+    'attemptNumber', 'startedAt', 'completedAt', 'durationMs', 'outcome', 'transportCode',
+    'serverErrorCode', 'serverErrorMessage', 'requestSummary', 'responseSummary'
+]);
+const DIAGNOSTIC_OUTCOMES = new Set(['success', 'failure', 'timeout', 'cancelled', 'retry']);
 
 function validationError(message, path = '') {
     const error = new TypeError(path ? `${message} (${path})` : message);
@@ -73,6 +87,104 @@ function isUnsafeFieldName(key) {
         .split(/[^a-z0-9]+/)
         .filter(Boolean);
     return words.includes('raw') || words.some((word) => UNSAFE_FIELD_WORDS.has(word));
+}
+
+function assertAllowedFields(value, allowedFields, path) {
+    for (const key of Object.keys(value)) {
+        if (!allowedFields.has(key)) throw validationError('Unexpected field is not allowed', `${path}.${key}`);
+    }
+}
+
+function truncateString(value, maxLength = DIAGNOSTIC_LIMITS.stringLength) {
+    const string = String(value);
+    return string.length <= maxLength ? string : `${string.slice(0, maxLength - 1)}…`;
+}
+
+function sanitizeDiagnosticSummary(value, path, depth = 0, seen = new WeakSet()) {
+    if (value === null || typeof value === 'boolean') return value;
+    if (typeof value === 'string') return truncateString(value);
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) throw validationError('Expected a finite number', path);
+        return value;
+    }
+    if (value === undefined) return null;
+    if (typeof value !== 'object') throw validationError('Unsupported diagnostic value', path);
+    if (depth >= DIAGNOSTIC_LIMITS.summaryDepth) return '[TRUNCATED]';
+    if (seen.has(value)) throw validationError('Circular values are not supported', path);
+    seen.add(value);
+    try {
+        if (Array.isArray(value)) {
+            return value.slice(0, DIAGNOSTIC_LIMITS.summaryEntries)
+                .map((entry, index) => sanitizeDiagnosticSummary(entry, `${path}[${index}]`, depth + 1, seen));
+        }
+        assertPlainObject(value, path);
+        const output = {};
+        for (const [key, entry] of Object.entries(value).slice(0, DIAGNOSTIC_LIMITS.summaryEntries)) {
+            const safeKey = truncateString(key, 120);
+            output[safeKey] = isUnsafeFieldName(key)
+                ? '[REDACTED]'
+                : sanitizeDiagnosticSummary(entry, `${path}.${key}`, depth + 1, seen);
+        }
+        return output;
+    } finally {
+        seen.delete(value);
+    }
+}
+
+function normalizeDiagnosticInteger(value, path, { minimum = 0 } = {}) {
+    const number = Number(value);
+    if (!Number.isSafeInteger(number) || number < minimum) throw validationError('Expected a safe integer', path);
+    return number;
+}
+
+function normalizeRequestAttempt(value, index, resultIndex) {
+    const path = `results[${resultIndex}].diagnostics.requestAttempts[${index}]`;
+    assertPlainObject(value, path);
+    assertAllowedFields(value, REQUEST_ATTEMPT_FIELDS, path);
+    const startedAt = normalizeIsoTimestamp(value.startedAt, `${path}.startedAt`);
+    const completedAt = value.completedAt == null ? null : normalizeIsoTimestamp(value.completedAt, `${path}.completedAt`);
+    if (completedAt && new Date(completedAt) < new Date(startedAt)) {
+        throw validationError('Completion timestamp cannot precede start timestamp', `${path}.completedAt`);
+    }
+    const outcome = normalizeNonEmptyString(value.outcome, `${path}.outcome`, 40);
+    if (!DIAGNOSTIC_OUTCOMES.has(outcome)) throw validationError('Unsupported diagnostic outcome', `${path}.outcome`);
+    const attempt = {
+        correlationId: normalizeNonEmptyString(value.correlationId, `${path}.correlationId`, 160),
+        operationName: normalizeNonEmptyString(value.operationName, `${path}.operationName`, 160),
+        controller: normalizeOptionalString(value.controller, `${path}.controller`, 160),
+        method: normalizeNonEmptyString(value.method, `${path}.method`, 20).toUpperCase(),
+        projectName: normalizeOptionalString(value.projectName, `${path}.projectName`, 240),
+        requestId: normalizeOptionalString(value.requestId, `${path}.requestId`, 160),
+        attemptNumber: normalizeDiagnosticInteger(value.attemptNumber, `${path}.attemptNumber`, { minimum: 1 }),
+        startedAt,
+        completedAt,
+        durationMs: value.durationMs == null ? null : normalizeDiagnosticInteger(value.durationMs, `${path}.durationMs`),
+        outcome,
+        transportCode: normalizeOptionalString(value.transportCode, `${path}.transportCode`, 120),
+        serverErrorCode: normalizeOptionalString(value.serverErrorCode, `${path}.serverErrorCode`, 120),
+        serverErrorMessage: value.serverErrorMessage == null ? null : truncateString(value.serverErrorMessage),
+        requestSummary: sanitizeDiagnosticSummary(value.requestSummary ?? null, `${path}.requestSummary`),
+        responseSummary: sanitizeDiagnosticSummary(value.responseSummary ?? null, `${path}.responseSummary`)
+    };
+    return Object.freeze(attempt);
+}
+
+function normalizeDiagnostics(value, resultIndex) {
+    const path = `results[${resultIndex}].diagnostics`;
+    assertPlainObject(value, path);
+    assertAllowedFields(value, DIAGNOSTIC_FIELDS, path);
+    if (!Array.isArray(value.requestAttempts)) throw validationError('Expected an array', `${path}.requestAttempts`);
+    if (value.requestAttempts.length > DIAGNOSTIC_LIMITS.attempts) {
+        throw validationError(`Collection exceeds ${DIAGNOSTIC_LIMITS.attempts} entries`, `${path}.requestAttempts`);
+    }
+    const diagnostics = Object.freeze({
+        requestAttempts: Object.freeze(value.requestAttempts.map((attempt, index) =>
+            normalizeRequestAttempt(attempt, index, resultIndex)))
+    });
+    if (JSON.stringify(diagnostics).length > DIAGNOSTIC_LIMITS.serializedSize) {
+        throw validationError('Diagnostics exceed serialized-size limit', path);
+    }
+    return diagnostics;
 }
 
 function sanitizeJsonValue(value, path = 'value', seen = new WeakSet()) {
@@ -132,7 +244,7 @@ function normalizeResult(value, index) {
     assertPlainObject(value, `results[${index}]`);
     const attempts = value.attempts === undefined ? 1 : normalizeCount(value.attempts, `results[${index}].attempts`);
     const data = value.data === undefined ? {} : sanitizeJsonValue(value.data, `results[${index}].data`);
-    return Object.freeze({
+    const result = {
         order: index,
         itemId: normalizeOptionalString(value.itemId, `results[${index}].itemId`, 160),
         label: normalizeNonEmptyString(value.label ?? value.itemId ?? `Item ${index + 1}`, `results[${index}].label`, 500),
@@ -141,7 +253,18 @@ function normalizeResult(value, index) {
         message: normalizeNonEmptyString(value.message, `results[${index}].message`, 1000),
         attempts,
         data: Object.freeze(data)
-    });
+    };
+    if (value.diagnostics !== undefined) result.diagnostics = normalizeDiagnostics(value.diagnostics, index);
+    return Object.freeze(result);
+}
+
+function withoutDiagnostics(record) {
+    return {
+        ...record,
+        results: Array.isArray(record.results)
+            ? record.results.map(({ diagnostics: _diagnostics, ...result }) => result)
+            : record.results
+    };
 }
 
 function fallbackExecutionId(now, operationType) {
@@ -151,6 +274,7 @@ function fallbackExecutionId(now, operationType) {
 
 function buildExecutionRecord(input, options = {}) {
     assertPlainObject(input, 'record');
+    sanitizeJsonValue(withoutDiagnostics(input), 'record');
     const now = options.now instanceof Date ? options.now : new Date(options.now || Date.now());
     const operationType = normalizeNonEmptyString(input.operationType, 'operationType', 120);
     const cryptoApi = options.cryptoApi;
@@ -198,19 +322,24 @@ function validateExecutionRecord(record) {
     normalizeCounts(record.counts || {});
     if (!Array.isArray(record.results)) throw validationError('Expected an array', 'results');
     record.results.forEach((result, index) => normalizeResult(result, index));
-    sanitizeJsonValue(record, 'record');
+    sanitizeJsonValue(withoutDiagnostics(record), 'record');
     return true;
 }
 
 function cloneExecutionRecord(record) {
     validateExecutionRecord(record);
-    return JSON.parse(JSON.stringify(record));
+    const clone = JSON.parse(JSON.stringify(record));
+    clone.pageContext = normalizePageContext(clone.pageContext);
+    clone.counts = normalizeCounts(clone.counts);
+    clone.results = clone.results.map(normalizeResult);
+    return JSON.parse(JSON.stringify(clone));
 }
 
 export {
     EXECUTION_RECORD_SCHEMA_VERSION,
     TERMINAL_STATUSES,
     COUNT_KEYS,
+    DIAGNOSTIC_LIMITS,
     buildExecutionRecord,
     validateExecutionRecord,
     cloneExecutionRecord,

--- a/src/shared/execution-history-record.test.js
+++ b/src/shared/execution-history-record.test.js
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    EXECUTION_RECORD_SCHEMA_VERSION,
+    buildExecutionRecord,
+    cloneExecutionRecord,
+    validateExecutionRecord
+} from './execution-history-record.js';
+import { serializeExecutionRecord } from './execution-history-export.js';
+import { createExecutionHistoryRepository } from './execution-history-repository.js';
+
+function recordInput(overrides = {}) {
+    return {
+        id: 'execution-1',
+        operationType: 'archive-lessons',
+        startedAt: '2026-08-11T10:00:00.000Z',
+        completedAt: '2026-08-11T10:01:00.000Z',
+        status: 'completed',
+        pageContext: { marathonId: '42', marathonName: 'Summer course' },
+        counts: { requested: 1, eligible: 1, attempted: 1, successful: 1 },
+        results: [{ itemId: '7', label: 'Lesson', status: 'completed', code: 'OK', message: 'Done' }],
+        ...overrides
+    };
+}
+
+function requestAttempt(overrides = {}) {
+    return {
+        correlationId: 'execution-1:7',
+        operationName: 'archiveLesson',
+        controller: 'Lessons',
+        method: 'post',
+        projectName: 'School',
+        requestId: 'request-7',
+        attemptNumber: 1,
+        startedAt: '2026-08-11T10:00:01.000Z',
+        completedAt: '2026-08-11T10:00:01.125Z',
+        durationMs: 125,
+        outcome: 'success',
+        transportCode: 'MESSAGE',
+        serverErrorCode: null,
+        serverErrorMessage: null,
+        requestSummary: { lessonId: 7 },
+        responseSummary: { updated: true },
+        ...overrides
+    };
+}
+
+test('keeps legacy version-1 records viewable, exportable, and cloneable', () => {
+    const legacy = buildExecutionRecord(recordInput());
+    assert.equal(EXECUTION_RECORD_SCHEMA_VERSION, 1);
+    assert.equal(validateExecutionRecord(legacy), true);
+    assert.deepEqual(cloneExecutionRecord(legacy), JSON.parse(JSON.stringify(legacy)));
+    assert.deepEqual(JSON.parse(serializeExecutionRecord(legacy)), legacy);
+    assert.equal(legacy.results[0].diagnostics, undefined);
+});
+
+test('keeps legacy version-1 records listable and removable from IndexedDB repositories', async () => {
+    const legacy = buildExecutionRecord(recordInput());
+    const records = new Map([[legacy.id, JSON.parse(JSON.stringify(legacy))]]);
+    const repository = createExecutionHistoryRepository({
+        indexedDbApi: {
+            createIndexedDb: () => ({
+                repository: () => ({
+                    get: async (id) => records.get(id),
+                    newest: async () => [...records.values()],
+                    delete: async (id) => records.delete(id),
+                    put: async (record) => records.set(record.id, record),
+                    clear: async () => records.clear(),
+                    count: async () => records.size
+                }),
+                close() {}
+            })
+        }
+    });
+    assert.equal((await repository.list()).length, 1);
+    assert.deepEqual(await repository.get(legacy.id), JSON.parse(JSON.stringify(legacy)));
+    await repository.delete(legacy.id);
+    assert.equal(await repository.get(legacy.id), null);
+});
+
+test('normalizes and round-trips bounded request-attempt diagnostics', () => {
+    const input = recordInput({
+        results: [{
+            itemId: '7', label: 'Lesson', status: 'completed', code: 'OK', message: 'Done',
+            diagnostics: { requestAttempts: [requestAttempt()] }
+        }]
+    });
+    const record = buildExecutionRecord(input);
+    const attempt = record.results[0].diagnostics.requestAttempts[0];
+    assert.equal(attempt.method, 'POST');
+    assert.equal(attempt.durationMs, 125);
+    assert.deepEqual(JSON.parse(serializeExecutionRecord(record)), cloneExecutionRecord(record));
+});
+
+test('continues to reject forbidden raw fields and transport objects outside diagnostics', () => {
+    assert.throws(() => buildExecutionRecord(recordInput({
+        results: [{
+            label: 'Lesson', status: 'completed', code: 'OK', message: 'Done',
+            data: { rawResponse: { secret: true } }
+        }]
+    })), /Unsafe field is not allowed/);
+    assert.throws(() => buildExecutionRecord(recordInput({ transport: { socket: true } })), /Unsafe field is not allowed/);
+});
+
+test('redacts unsafe summary fields and truncates bounded diagnostic content', () => {
+    const long = 'x'.repeat(800);
+    const record = buildExecutionRecord(recordInput({
+        results: [{
+            label: 'Lesson', status: 'completed', code: 'OK', message: 'Done',
+            diagnostics: { requestAttempts: [requestAttempt({
+                serverErrorMessage: long,
+                requestSummary: { authorization: 'Bearer secret', nested: { response: { token: 'secret' } } },
+                responseSummary: { message: long, values: Array.from({ length: 40 }, (_, index) => index) }
+            })] }
+        }]
+    }));
+    const attempt = record.results[0].diagnostics.requestAttempts[0];
+    assert.equal(attempt.requestSummary.authorization, '[REDACTED]');
+    assert.equal(attempt.requestSummary.nested.response, '[REDACTED]');
+    assert.equal(attempt.serverErrorMessage.length, 500);
+    assert.equal(attempt.responseSummary.message.length, 500);
+    assert.equal(attempt.responseSummary.values.length, 25);
+    assert.doesNotMatch(JSON.stringify(record), /Bearer secret/);
+});
+
+test('rejects malformed, unknown, oversized, and raw diagnostic fields', () => {
+    const withDiagnostics = (diagnostics) => recordInput({
+        results: [{ label: 'Lesson', status: 'completed', code: 'OK', message: 'Done', diagnostics }]
+    });
+    assert.throws(() => buildExecutionRecord(withDiagnostics({ requestAttempts: {} })), /Expected an array/);
+    assert.throws(() => buildExecutionRecord(withDiagnostics({ requestAttempts: [requestAttempt({ outcome: 'maybe' })] })), /Unsupported diagnostic outcome/);
+    assert.throws(() => buildExecutionRecord(withDiagnostics({ requestAttempts: [requestAttempt({ rawResponse: {} })] })), /Unexpected field/);
+    assert.throws(() => buildExecutionRecord(withDiagnostics({ requestAttempts: Array.from({ length: 21 }, requestAttempt) })), /Collection exceeds/);
+});
+
+test('exports a sanitized clone rather than the caller-owned diagnostic values', () => {
+    const record = buildExecutionRecord(recordInput({
+        results: [{
+            label: 'Lesson', status: 'completed', code: 'OK', message: 'Done',
+            diagnostics: { requestAttempts: [requestAttempt()] }
+        }]
+    }));
+    const storedShape = JSON.parse(JSON.stringify(record));
+    storedShape.results[0].diagnostics.requestAttempts[0].method = 'get';
+    assert.equal(JSON.parse(serializeExecutionRecord(storedShape)).results[0].diagnostics.requestAttempts[0].method, 'GET');
+});


### PR DESCRIPTION
### Motivation

- Provide a dedicated, bounded diagnostics section on execution `results` for normalized request-attempt metadata and sanitized request/response summaries while preserving existing storage safety rules.
- Allow collecting useful per-attempt diagnostics (correlation IDs, controller/method, timing, outcome, transport/server codes) without permitting raw transport objects or unbounded sensitive payloads.

### Description

- Added diagnostic limits and allowlists via `DIAGNOSTIC_LIMITS`, `DIAGNOSTIC_FIELDS`, `REQUEST_ATTEMPT_FIELDS`, and `DIAGNOSTIC_OUTCOMES` and implemented `sanitizeDiagnosticSummary`, `normalizeRequestAttempt`, and `normalizeDiagnostics` to enforce them in `src/shared/execution-history-record.js`.
- Extended `normalizeResult` to accept an optional `diagnostics` object on individual results and added `withoutDiagnostics`/`assertAllowedFields` helpers so top-level sanitization continues to reject raw/unsafe fields while validating the dedicated diagnostic shape separately.
- Updated cloning/export so `cloneExecutionRecord` and `serializeExecutionRecord` produce a normalized, sanitized clone (avoiding serialization of caller-owned values) and kept the existing generic `sanitizeJsonValue` rejection of unsafe field names (words like `raw`, `transport`, `response`, `token`, etc.).
- Kept schema compatibility by leaving `EXECUTION_RECORD_SCHEMA_VERSION` at `1` and making diagnostics optional, ensuring older version-1 IndexedDB records remain listable, viewable, exportable, and removable; added comprehensive tests in `src/shared/execution-history-record.test.js` to cover legacy records and the new diagnostics behavior.

### Testing

- Ran the new unit tests with `node --import ./scripts/test-css-loader.mjs --test src/shared/execution-history-record.test.js` and they passed.
- Ran the repository linter with `npm run lint` and `npx eslint` on modified files and it passed with no errors.
- Ran the full test CI with `npm run test:ci` and it passed in the validation run.
- Performed a production build with `npm run build` and the production bundle check with `npm run check:build-output`, both of which succeeded.

Files changed: `src/shared/execution-history-record.js`, `src/shared/execution-history-export.js`, and new tests `src/shared/execution-history-record.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b823cf7748330b23e8d4c8b87ae41)