### PR TITLE
Render sanitized execution diagnostics in execution history dialog

### DIFF
--- a/src/components/execution-history-dialog.js
+++ b/src/components/execution-history-dialog.js
@@ -33,6 +33,17 @@ function createSummary(record) {
     });
 }
 
+const FAILED_OUTCOME_STATUSES = new Set(['failed', 'rejected', 'interrupted']);
+
+function formatDiagnosticSummary(value) {
+    if (value === null || value === undefined) return 'Not available';
+    return JSON.stringify(value, null, 2);
+}
+
+function isExecutionInterruption(result) {
+    return FAILED_OUTCOME_STATUSES.has(result.status) && !result.itemId;
+}
+
 class ExecutionHistoryDialog extends LitElement {
     static styles = [componentFoundationStyles, dialogFoundationStyles, executionHistoryDialogStyles];
 
@@ -303,7 +314,36 @@ class ExecutionHistoryDialog extends LitElement {
                 ${hasData ? html`
                     <details><summary>Item details</summary><pre>${JSON.stringify(result.data, null, 2)}</pre></details>
                 ` : ''}
+                ${FAILED_OUTCOME_STATUSES.has(result.status) ? this.renderDiagnostics(result.diagnostics) : ''}
             </article>
+        `;
+    }
+
+    renderDiagnostics(diagnostics) {
+        if (!diagnostics?.requestAttempts?.length) return '';
+        return html`
+            <details class="diagnostics">
+                <summary>Request diagnostics</summary>
+                <div class="diagnostic-attempts">
+                    ${diagnostics.requestAttempts.map((attempt) => html`
+                        <section class="diagnostic-attempt" aria-label=${`Request attempt ${attempt.attemptNumber}`}>
+                            <dl class="diagnostic-metadata">
+                                <div><dt>Endpoint</dt><dd>${attempt.method} · ${[attempt.projectName, attempt.controller, attempt.operationName].filter(Boolean).join(' / ')}</dd></div>
+                                <div><dt>Request ID</dt><dd>${attempt.requestId || 'Not available'}</dd></div>
+                                <div><dt>Attempt</dt><dd>${attempt.attemptNumber}</dd></div>
+                                <div><dt>Duration</dt><dd>${attempt.durationMs == null ? 'Not available' : `${attempt.durationMs} ms`}</dd></div>
+                                <div><dt>Transport code</dt><dd>${attempt.transportCode || 'Not available'}</dd></div>
+                                <div><dt>Server code</dt><dd>${attempt.serverErrorCode || 'Not available'}</dd></div>
+                            </dl>
+                            <div class="diagnostic-message"><strong>Server message</strong><p>${attempt.serverErrorMessage || 'Not available'}</p></div>
+                            <div class="diagnostic-summaries">
+                                <section aria-label="Request summary"><h5>Request summary</h5><pre>${formatDiagnosticSummary(attempt.requestSummary)}</pre></section>
+                                <section aria-label="Response summary"><h5>Response summary</h5><pre>${formatDiagnosticSummary(attempt.responseSummary)}</pre></section>
+                            </div>
+                        </section>
+                    `)}
+                </div>
+            </details>
         `;
     }
 
@@ -324,6 +364,8 @@ class ExecutionHistoryDialog extends LitElement {
             ['Started', formatExecutionDate(record.startedAt)],
             ['Completed', formatExecutionDate(record.completedAt)]
         ];
+        const interruptions = record.results.filter(isExecutionInterruption);
+        const itemResults = record.results.filter((result) => !isExecutionInterruption(result));
         return html`
             <section class="detail-header">
                 <div>
@@ -344,10 +386,17 @@ class ExecutionHistoryDialog extends LitElement {
                 `)}
             </section>
             <section class="outcomes">
-                <h4>Item outcomes (${record.results.length})</h4>
-                ${record.results.length === 0
+                ${interruptions.length ? html`
+                    <section class="interruptions" aria-labelledby="interruption-heading">
+                        <h4 id="interruption-heading">Execution interruption</h4>
+                        <p class="muted">Failures that stopped the execution before they could be associated with an item.</p>
+                        ${interruptions.map((result) => this.renderOutcome(result))}
+                    </section>
+                ` : ''}
+                <h4>Item outcomes (${itemResults.length})</h4>
+                ${itemResults.length === 0
                     ? html`<p class="muted">No per-item outcomes were recorded.</p>`
-                    : record.results.map((result) => this.renderOutcome(result))}
+                    : itemResults.map((result) => this.renderOutcome(result))}
             </section>
         `;
     }
@@ -415,7 +464,9 @@ const executionHistoryDialogApi = Object.freeze({
     ExecutionHistoryDialog,
     formatExecutionStatus,
     formatExecutionDate,
-    createSummary
+    createSummary,
+    formatDiagnosticSummary,
+    isExecutionInterruption
 });
 globalThis.EdVibeExecutionHistoryDialog = executionHistoryDialogApi;
 
@@ -424,5 +475,7 @@ export {
     ExecutionHistoryDialog,
     formatExecutionStatus,
     formatExecutionDate,
-    createSummary
+    createSummary,
+    formatDiagnosticSummary,
+    isExecutionInterruption
 };

--- a/src/components/execution-history-dialog.styles.js
+++ b/src/components/execution-history-dialog.styles.js
@@ -110,6 +110,21 @@ time { margin-top: 2px; }
 .outcome-card small { display: block; margin-top: 6px; color: var(--history-muted); }
 .outcome-card details { margin-top: 9px; color: var(--history-muted); font-size: 11px; }
 .outcome-card pre { overflow: auto; margin: 7px 0 0; padding: 10px; border-radius: 9px; color: #344054; background: #f5f7fa; font: 11px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre-wrap; }
+.interruptions { margin-bottom: 22px; padding: 14px; border: 1px solid #efcaca; border-radius: 14px; background: #fff8f8; }
+.interruptions > .muted { margin: -4px 0 10px; }
+.diagnostics > summary { cursor: pointer; color: #475467; font-weight: 800; }
+.diagnostic-attempts { display: grid; gap: 10px; margin-top: 9px; }
+.diagnostic-attempt { min-width: 0; padding: 11px; border: 1px solid var(--history-border); border-radius: 10px; background: #fafbfc; }
+.diagnostic-metadata { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; }
+.diagnostic-metadata div { min-width: 0; }
+.diagnostic-metadata dt, .diagnostic-message strong, .diagnostic-summaries h5 { color: var(--history-muted); font-size: 10px; font-weight: 800; text-transform: uppercase; }
+.diagnostic-metadata dd { overflow-wrap: anywhere; margin: 2px 0 0; color: var(--history-text); }
+.diagnostic-message { margin-top: 10px; }
+.diagnostic-message p { overflow-wrap: anywhere; margin-top: 3px; }
+.diagnostic-summaries { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 10px; }
+.diagnostic-summaries section { min-width: 0; }
+.diagnostic-summaries h5 { margin: 0; }
+.diagnostic-summaries pre { max-width: 100%; max-height: 240px; overflow: auto; overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap; }
 .muted { color: var(--history-muted); font-size: 12px; }
 
 .dialog-footer { border-top: 1px solid var(--history-border); }
@@ -126,6 +141,7 @@ time { margin-top: 2px; }
     .workspace { grid-template-columns: 1fr; overflow: auto; }
     .browser-panel { min-height: 450px; border-right: 0; border-bottom: 1px solid var(--history-border); }
     .detail-panel { min-height: 500px; }
+    .diagnostic-metadata, .diagnostic-summaries { grid-template-columns: 1fr; }
     .settings-grid { grid-template-columns: 1fr 1fr; }
 }
 

--- a/src/components/execution-history-dialog.test.js
+++ b/src/components/execution-history-dialog.test.js
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    ExecutionHistoryDialog,
+    formatDiagnosticSummary,
+    isExecutionInterruption
+} from './execution-history-dialog.js';
+
+function attempt(overrides = {}) {
+    return {
+        projectName: 'School', controller: 'Lessons', operationName: 'archiveLesson', method: 'POST',
+        requestId: 'request-7', attemptNumber: 2, durationMs: 125,
+        transportCode: 'MESSAGE', serverErrorCode: 'LESSON_LOCKED',
+        serverErrorMessage: 'Lesson is locked', requestSummary: { lessonId: 7 },
+        responseSummary: { success: false }, ...overrides
+    };
+}
+
+function templateText(value) {
+    if (value == null || value === false) return '';
+    if (Array.isArray(value)) return value.map(templateText).join('');
+    if (typeof value !== 'object' || !value.strings) return String(value);
+    return value.strings.reduce((output, string, index) =>
+        `${output}${string}${templateText(value.values[index])}`, '');
+}
+
+test('renders sanitized diagnostics beneath a failed outcome', () => {
+    const dialog = new ExecutionHistoryDialog();
+    const markup = templateText(dialog.renderOutcome({
+        itemId: '7', label: 'Lesson', status: 'failed', code: 'SERVER_ERROR',
+        message: 'Could not archive', attempts: 2, data: {},
+        diagnostics: { requestAttempts: [attempt()] }
+    }));
+
+    for (const label of ['Endpoint', 'Request ID', 'Attempt', 'Duration', 'Transport code',
+        'Server code', 'Server message', 'Request summary', 'Response summary']) {
+        assert.match(markup, new RegExp(label));
+    }
+    assert.match(markup, /POST · School \/ Lessons \/ archiveLesson/);
+    assert.match(markup, /request-7/);
+});
+
+test('does not add diagnostics to legacy outcomes', () => {
+    const dialog = new ExecutionHistoryDialog();
+    const markup = templateText(dialog.renderOutcome({
+        label: 'Legacy lesson', status: 'failed', code: 'ERROR',
+        message: 'Failed', attempts: 1, data: {}
+    }));
+    assert.doesNotMatch(markup, /Request diagnostics/);
+});
+
+test('renders server errors without response bodies as explicitly unavailable', () => {
+    const dialog = new ExecutionHistoryDialog();
+    const markup = templateText(dialog.renderDiagnostics({
+        requestAttempts: [attempt({ responseSummary: null })]
+    }));
+    assert.match(markup, /Response summary/);
+    assert.match(markup, /Not available/);
+    assert.equal(formatDiagnosticSummary(null), 'Not available');
+});
+
+test('uses an accessible native collapsed details control that supports expanded state', () => {
+    const dialog = new ExecutionHistoryDialog();
+    const markup = templateText(dialog.renderDiagnostics({ requestAttempts: [attempt()] }));
+    assert.match(markup, /<details class="diagnostics">/);
+    assert.match(markup, /<summary>Request diagnostics<\/summary>/);
+    assert.doesNotMatch(markup, /<details[^>]* open/);
+    assert.match(markup, /aria-label=Request attempt 2/);
+});
+
+test('identifies itemless failures as execution-level interruptions', () => {
+    assert.equal(isExecutionInterruption({ status: 'failed', itemId: null }), true);
+    assert.equal(isExecutionInterruption({ status: 'failed', itemId: '7' }), false);
+    assert.equal(isExecutionInterruption({ status: 'completed', itemId: null }), false);
+});

--- a/src/shared/execution-history-export.test.js
+++ b/src/shared/execution-history-export.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildExecutionRecord } from './execution-history-record.js';
+import { createExecutionHistoryService } from './execution-history-service.js';
+
+function input({ id = 'execution-1', diagnostics = true } = {}) {
+    const result = { label: 'Lesson', status: 'failed', code: 'ERROR', message: 'Failed' };
+    if (diagnostics) result.diagnostics = { requestAttempts: [{
+        correlationId: `${id}:1`, operationName: 'archiveLesson', controller: 'Lessons',
+        method: 'POST', requestId: 'request-1', attemptNumber: 1,
+        startedAt: '2026-08-11T10:00:00.000Z', completedAt: '2026-08-11T10:00:00.010Z',
+        durationMs: 10, outcome: 'failure', serverErrorCode: 'ERROR',
+        requestSummary: { lessonId: 1, authorization: 'Bearer secret', note: 'x'.repeat(800) },
+        responseSummary: { token: 'secret-token', values: Array.from({ length: 100 }, (_, index) => index) }
+    }] };
+    return {
+        id, operationType: 'archive-lessons', startedAt: '2026-08-11T10:00:00.000Z',
+        completedAt: '2026-08-11T10:00:01.000Z', status: 'completed_with_failures',
+        pageContext: {}, counts: { requested: 1, eligible: 1, attempted: 1, failed: 1 },
+        results: [result]
+    };
+}
+
+function serviceHarness(records, autoExport = false) {
+    const downloads = [];
+    const service = createExecutionHistoryService({
+        repository: {
+            persist: async (record) => records.push(record),
+            list: async () => records,
+            get: async (id) => records.find((record) => record.id === id) || null,
+            delete: async () => {}, clear: async () => {}, count: async () => records.length,
+            deleteMany: async () => {}
+        },
+        preferenceStore: { get: async () => ({ mode: 'indefinite', autoExport }), set: async () => {} },
+        downloader: { download: (download) => downloads.push(download) },
+        now: () => new Date('2026-08-11T12:00:00.000Z')
+    });
+    return { service, downloads };
+}
+
+function assertSafeDiagnosticExport(json) {
+    const text = json;
+    const record = Array.isArray(JSON.parse(text)) ? JSON.parse(text)[0] : JSON.parse(text);
+    const attempt = record.results[0].diagnostics.requestAttempts[0];
+    assert.equal(attempt.requestSummary.authorization, '[REDACTED]');
+    assert.equal(attempt.responseSummary.token, '[REDACTED]');
+    assert.equal(attempt.requestSummary.note.length, 500);
+    assert.equal(attempt.responseSummary.values.length, 25);
+    assert.doesNotMatch(text, /Bearer secret|secret-token/);
+}
+
+test('individual and filtered exports contain faithful sanitized diagnostics and preserve legacy records', async () => {
+    const diagnosticRecord = buildExecutionRecord(input());
+    const legacyRecord = buildExecutionRecord(input({ id: 'legacy', diagnostics: false }));
+    const { service, downloads } = serviceHarness([diagnosticRecord, legacyRecord]);
+
+    await service.exportRecord(diagnosticRecord.id);
+    await service.exportFiltered({ status: 'completed_with_failures' });
+
+    assertSafeDiagnosticExport(downloads[0].json);
+    assertSafeDiagnosticExport(downloads[1].json);
+    const filtered = JSON.parse(downloads[1].json);
+    assert.equal(filtered[1].id, 'legacy');
+    assert.equal(filtered[1].results[0].diagnostics, undefined);
+});
+
+test('automatic exports contain the same bounded sanitized diagnostics as the persisted record', async () => {
+    const records = [];
+    const { service, downloads } = serviceHarness(records, true);
+    const persisted = await service.persistTerminal(input({ id: 'automatic' }));
+
+    assert.equal(persisted.stored, true);
+    assert.equal(downloads.length, 1);
+    assertSafeDiagnosticExport(downloads[0].json);
+    assert.deepEqual(JSON.parse(downloads[0].json), JSON.parse(JSON.stringify(persisted.record)));
+});


### PR DESCRIPTION
### Motivation

- Surface bounded, redacted diagnostics for failed outcomes so operators can inspect what happened without leaking secrets or unbounded payloads.
- Distinguish execution-level interruptions (failures not tied to a specific item) so those terminal errors are visible in the summary view.

### Description

- Render a collapsed native `<details>` block under failed item outcomes with semantic labels showing `Endpoint`, `Request ID`, `Attempt`, `Duration`, `Transport code`, `Server code`, `Server message`, and formatted `Request summary` / `Response summary`, and display missing summaries as `Not available` (`src/components/execution-history-dialog.js`).
- Add an execution-level interruption section that surfaces itemless failures separately from per-item outcomes (`src/components/execution-history-dialog.js`).
- Update dialog styles to keep long JSON wrapped/scrollable, bound diagnostic summary heights, support narrow layouts, and preserve keyboard/focus and screen-reader usability (`src/components/execution-history-dialog.styles.js`).
- Keep export APIs unchanged but add tests that verify serialized exports include sanitized diagnostics, continue to preserve legacy records without diagnostics, and never include configured secret fields or unbounded payloads (`src/shared/execution-history-export.test.js` and `src/components/execution-history-dialog.test.js`).

### Testing

- Ran linting with `npm run lint` and the command completed successfully.
- Ran unit tests with `npm test` (and a focused test run for diagnostic-related cases) and all new and existing tests passed (no failures).
- Built production bundles with `npm run build` and validated bundle shape with `npm run check:build-output`, both of which passed the repository checks.
- Note: visual verification in Chrome (manual review of collapsed/expanded diagnostics, keyboard navigation, and scrolling behavior) should be performed after loading the rebuilt `dist/` as an unpacked extension; automated Node tests cover rendering and accessibility contracts but cannot fully reproduce real-browser visuals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b887b31a08330aba06a3469782e29)