### PR TITLE
Add shared history diagnostic helpers and attach to history builders

### DIFF
--- a/src/features/batch-lesson-access-history-record.js
+++ b/src/features/batch-lesson-access-history-record.js
@@ -5,10 +5,11 @@ import {
     lessonKey,
     attemptKey
 } from './batch-lesson-access-history-model.js';
+import { historyDiagnostics } from '../shared/history-diagnostics.js';
 
 const REJECTED_WRITE_CODES = new Set(['SERVER_REJECTED', 'INVALID_RESPONSE']);
 
-function resultFromMatrix(item, outcome, attempts, code, message) {
+function resultFromMatrix(item, outcome, attempts, code, message, diagnosticSource = null) {
     const status = {
         opened: 'success',
         already_open: 'noop',
@@ -23,6 +24,7 @@ function resultFromMatrix(item, outcome, attempts, code, message) {
         code,
         message,
         attempts,
+        ...(historyDiagnostics(diagnosticSource) ? { diagnostics: historyDiagnostics(diagnosticSource) } : {}),
         data: freezeObject({
             submittedEmail: item.submittedInput,
             resolvedEmail: item.resolvedEmail,
@@ -70,7 +72,8 @@ function buildMatrixResults(plan, summary = {}, writeAttempts = new Map()) {
                 outcome,
                 Number.isInteger(failure.attempts) ? failure.attempts : 1,
                 failure.code || 'LESSON_ACCESS_WRITE_FAILED',
-                failure.message || 'The lesson access change failed.'
+                failure.message || 'The lesson access change failed.',
+                failure
             );
         }
         return resultFromMatrix(
@@ -109,6 +112,7 @@ function operationFailureResults(failures) {
         code: failure.code,
         message: failure.message,
         attempts: failure.attempts,
+        ...(historyDiagnostics(failure) ? { diagnostics: historyDiagnostics(failure) } : {}),
         data: freezeObject({ stage: failure.kind === 'input' ? 'input_validation' : 'preflight' })
     }));
 }
@@ -121,6 +125,7 @@ function discoveryFailureResults(failures) {
         code: failure.code,
         message: failure.message,
         attempts: failure.attempts,
+        ...(historyDiagnostics(failure) ? { diagnostics: historyDiagnostics(failure) } : {}),
         data: freezeObject({
             submittedEmail: failure.submittedEmail,
             resolvedEmail: failure.resolvedEmail,

--- a/src/features/batch-lesson-access-history-record.test.js
+++ b/src/features/batch-lesson-access-history-record.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildExecutionHistoryInput } from './batch-lesson-access-history-record.js';
+function attempt(correlationId, requestId, transportCode = 'SERVER_REJECTED') {
+    return { correlationId, operationName: 'write', controller: 'C', method: 'POST', projectName: 'P', requestId, attemptNumber: 1, startedAt: '2026-01-01T00:00:00.000Z', completedAt: null, durationMs: null, outcome: 'failure', transportCode, serverErrorCode: 'DENIED', serverErrorMessage: null, requestSummary: null, responseSummary: null };
+}
+test('correlates server rejection and transport failure diagnostics across result rows', () => {
+    const matrix = [1, 2].map((id) => ({ submittedInput: 'a@b.test', resolvedEmail: 'a@b.test', pupilId: 1, marathonPupilId: 2, marathonLessonId: id, lessonNumber: id, lessonName: `L${id}`, preflightAccessState: 'closed', plannedOutcome: 'open' }));
+    const failures = [['SERVER_REJECTED', 'reject-1', 1], ['REQUEST_TIMEOUT', 'timeout-2', 2]].map(([code, id, lesson]) => ({ email: 'a@b.test', marathonLessonId: lesson, code, message: code, attempts: 1, diagnostics: { requestAttempts: [attempt(`write:${lesson}`, id, code)] } }));
+    const record = buildExecutionHistoryInput({ plan: { matrix, identities: [], selectedLessons: [], discoveryFailures: [], operationFailures: [] }, summary: { failures }, startedAt: '2026-01-01T00:00:00.000Z', completedAt: '2026-01-01T00:00:01.000Z' });
+    assert.deepEqual(record.results.map((result) => result.diagnostics.requestAttempts[0].requestId), ['reject-1', 'timeout-2']);
+});

--- a/src/features/batch-section-creation-history-record.js
+++ b/src/features/batch-section-creation-history-record.js
@@ -1,4 +1,5 @@
 import * as modelApi from './batch-section-creation-history-model.js';
+import { historyDiagnostics } from '../shared/history-diagnostics.js';
 
 const TERMINAL_STATUSES = new Set(modelApi.TERMINAL_STATUSES);
 
@@ -94,6 +95,7 @@ function serializeResult(result, definitionSummary, terminalStatus) {
         code,
         message,
         attempts,
+        ...(historyDiagnostics(result) ? { diagnostics: historyDiagnostics(result) } : {}),
         data: Object.freeze({
             lesson,
             section: definitionSummary,

--- a/src/features/batch-section-creation-history-record.test.js
+++ b/src/features/batch-section-creation-history-record.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { serializeResult } from './batch-section-creation-history-record.js';
+function attempt(correlationId, requestId, transportCode = 'SERVER_REJECTED') {
+    return { correlationId, operationName: 'write', controller: 'C', method: 'POST', projectName: 'P', requestId, attemptNumber: 1, startedAt: '2026-01-01T00:00:00.000Z', completedAt: null, durationMs: null, outcome: 'failure', transportCode, serverErrorCode: 'DENIED', serverErrorMessage: null, requestSummary: null, responseSummary: null };
+}
+test('preserves server rejection and transport failure diagnostics for recipe requests', () => {
+    for (const [code, id] of [['SERVER_REJECTED', 'reject-1'], ['REQUEST_TIMEOUT', 'timeout-2']]) {
+        const result = serializeResult({ lessonId: 1, lessonName: 'L', status: 'failed', code, diagnostics: { requestAttempts: [attempt('lesson:1', id, code)] } }, Object.freeze({}), null);
+        assert.equal(result.diagnostics.requestAttempts[0].requestId, id);
+        assert.equal(result.diagnostics.requestAttempts[0].correlationId, 'lesson:1');
+    }
+});

--- a/src/features/batch-section-deletion-history.js
+++ b/src/features/batch-section-deletion-history.js
@@ -1,4 +1,5 @@
 import * as coreApi from './batch-section-deletion.js';
+import { historyDiagnostics } from '../shared/history-diagnostics.js';
 
 const OPERATION_TYPE = 'batch-section-deletion';
 const TERMINAL_STATUSES = new Set([
@@ -156,6 +157,7 @@ function serializeResult(entry, plan, terminalStatus) {
         code,
         message,
         attempts: entry.attempts,
+        ...(historyDiagnostics(entry) ? { diagnostics: historyDiagnostics(entry) } : {}),
         data: Object.freeze({
             lesson,
             section: Object.freeze({

--- a/src/features/batch-section-deletion-history.test.js
+++ b/src/features/batch-section-deletion-history.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { serializeResult } from './batch-section-deletion-history.js';
+import { buildExecutionHistoryInput as buildLegacyHistory } from './batch-section-deletion.js';
+function attempt(correlationId, requestId, transportCode = 'SERVER_REJECTED') {
+    return { correlationId, operationName: 'write', controller: 'C', method: 'POST', projectName: 'P', requestId, attemptNumber: 1, startedAt: '2026-01-01T00:00:00.000Z', completedAt: null, durationMs: null, outcome: 'failure', transportCode, serverErrorCode: 'DENIED', serverErrorMessage: null, requestSummary: null, responseSummary: null };
+}
+test('preserves server rejection and transport failure diagnostics for deletion requests', () => {
+    for (const [code, id] of [['SERVER_REJECTED', 'reject-1'], ['REQUEST_TIMEOUT', 'timeout-2']]) {
+        const result = serializeResult({ lessonId: 1, number: 1, name: 'L', status: 'failed', code, attempts: 1, diagnostics: { requestAttempts: [attempt('lesson:1', id, code)] } }, { sectionName: 'S' }, null);
+        assert.equal(result.diagnostics.requestAttempts[0].requestId, id);
+    }
+});
+
+test('the legacy builder converts a transport error and correlates it to its lesson', () => {
+    const error = Object.assign(new Error('timeout'), { code: 'REQUEST_TIMEOUT', diagnostics: {
+        request: { controller: 'C', method: 'POST', requestId: 'legacy-timeout', startedAt: 1 }
+    } });
+    const entry = { lessonId: 9, number: 1, name: 'L', status: 'failed', code: error.code,
+        message: error.message, diagnosticObservations: [error] };
+    const record = buildLegacyHistory({ marathonId: '1', startedAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-01-01T00:00:01.000Z', result: { plan: { selectedCount: 1,
+            eligible: [entry], sectionName: 'S' }, results: [entry], fatalError: null } });
+    assert.equal(record.results[0].diagnostics.requestAttempts[0].requestId, 'legacy-timeout');
+    assert.equal(record.results[0].diagnostics.requestAttempts[0].correlationId, 'delete-section:9');
+});

--- a/src/features/batch-section-deletion.js
+++ b/src/features/batch-section-deletion.js
@@ -1,5 +1,6 @@
 import { createFeatureError as featureError, parseMarathonId } from '../shared/batch-workflow-primitives.js';
 import { getLessonById, loadAllMarathonLessons } from '../shared/edvibe-marathon-api.js';
+import { historyDiagnostics } from '../shared/history-diagnostics.js';
 
 const DIALOG_TAG = 'edvibe-toolbox-batch-section-deletion-dialog';
 const EXPECTED_WRITE_CODES = new Set(['SERVER_REJECTED', 'INVALID_RESPONSE', 'REQUEST_TIMEOUT', 'SEND_FAILED', 'WS_UNAVAILABLE']);
@@ -126,7 +127,13 @@ async function executePlan({ plan, sendRequest, wait, requestDelayMs = 300, onPr
             results.push({ ...entry, status: 'deleted', code: 'DELETED', message: 'Section deleted.' });
         } catch (error) {
             const code = error.code || 'DELETE_FAILED';
-            results.push({ ...entry, status: 'failed', code, message: error.message || 'Deletion failed.' });
+            results.push({
+                ...entry,
+                status: 'failed',
+                code,
+                message: error.message || 'Deletion failed.',
+                diagnosticObservations: [error]
+            });
             if (!EXPECTED_WRITE_CODES.has(code)) fatalError = error;
         }
         onProgress?.({ current: index + 1, total: plan.eligible.length, entry, results: [...results] });
@@ -185,6 +192,13 @@ function buildExecutionHistoryInput({ marathonId, startedAt, completedAt, result
             code: entry.code,
             message: entry.message,
             attempts: entry.status === 'not_attempted' || entry.status === 'rejected' ? 0 : 1,
+            ...(historyDiagnostics(entry, {
+                correlationId: `delete-section:${entry.lessonId}`,
+                operationName: 'delete_section'
+            }) ? { diagnostics: historyDiagnostics(entry, {
+                    correlationId: `delete-section:${entry.lessonId}`,
+                    operationName: 'delete_section'
+                }) } : {}),
             data: Object.freeze({
                 lessonId: entry.lessonId,
                 marathonLessonId: entry.marathonLessonId,

--- a/src/features/batch-user-management-history.js
+++ b/src/features/batch-user-management-history.js
@@ -1,3 +1,5 @@
+import { diagnosticsFromAttempts, historyDiagnostics } from '../shared/history-diagnostics.js';
+
 const OPERATION_TYPE = 'batch_user_management';
 const OPERATION_NAMES = Object.freeze({
     unassign: 'unassign_curator',
@@ -49,7 +51,8 @@ function serializeOperation(name, result) {
         message: result.message || null,
         dependency: dependencyBlocked
             ? Object.freeze({ blockedBy: OPERATION_NAMES.unassign })
-            : null
+            : null,
+        ...(historyDiagnostics(result) ? { diagnostics: historyDiagnostics(result) } : {})
     });
 }
 
@@ -101,6 +104,8 @@ function serializeRow(row, index) {
         ? serializeOperation(name, row?.unassign)
         : serializeOperation(name, row?.delete));
     const status = inferItemStatus(row, operations);
+    const diagnostics = diagnosticsFromAttempts(operations.flatMap((operation) =>
+        historyDiagnostics(operation)?.requestAttempts || []));
     return Object.freeze({
         itemId: row?.normalizedEmail || row?.email || `input-${index + 1}`,
         label: row?.email || row?.normalizedEmail || `Input ${index + 1}`,
@@ -108,6 +113,7 @@ function serializeRow(row, index) {
         code: resultCode(row, status),
         message: resultMessage(row, status, operations),
         attempts: operations.reduce((sum, operation) => sum + operation.attemptCount, 0),
+        ...(diagnostics ? { diagnostics } : {}),
         data: Object.freeze({
             submittedInput: row?.email || null,
             normalizedEmail: row?.normalizedEmail || null,

--- a/src/features/batch-user-management-history.test.js
+++ b/src/features/batch-user-management-history.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { serializeRow } from './batch-user-management-history.js';
+function attempt(correlationId, requestId, transportCode = 'SERVER_REJECTED') {
+    return { correlationId, operationName: 'write', controller: 'C', method: 'POST', projectName: 'P', requestId, attemptNumber: 1, startedAt: '2026-01-01T00:00:00.000Z', completedAt: null, durationMs: null, outcome: 'failure', transportCode, serverErrorCode: 'DENIED', serverErrorMessage: null, requestSummary: null, responseSummary: null };
+}
+test('preserves correlated server rejection and transport failure diagnostics', () => {
+    const operation = (code, id) => ({ status: 'failed', code, attempts: 1, diagnostics: { requestAttempts: [attempt('user:a', id, code)] } });
+    const row = serializeRow({ email: 'a@b.test', normalizedEmail: 'a@b.test', status: 'matched', unassignSelected: true, deleteSelected: true, unassign: operation('SERVER_REJECTED', 'reject-1'), delete: operation('REQUEST_TIMEOUT', 'timeout-2') }, 0);
+    assert.deepEqual(row.diagnostics.requestAttempts.map(({ requestId }) => requestId), ['reject-1', 'timeout-2']);
+    assert.equal(row.diagnostics.requestAttempts[0].correlationId, 'user:a');
+});

--- a/src/shared/history-diagnostics.js
+++ b/src/shared/history-diagnostics.js
@@ -1,0 +1,78 @@
+const DEFAULT_STARTED_AT = '1970-01-01T00:00:00.000Z';
+
+function isoTimestamp(value, fallback = DEFAULT_STARTED_AT) {
+    if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) return new Date(value).toISOString();
+    if (Number.isFinite(value)) return new Date(value).toISOString();
+    return fallback;
+}
+
+function diagnosticSource(observation) {
+    return observation?.diagnostics || observation || {};
+}
+
+function requestAttemptFromObservation(observation, {
+    correlationId,
+    operationName,
+    attemptNumber = 1,
+    outcome
+} = {}) {
+    const source = diagnosticSource(observation);
+    const request = source.request || {};
+    const response = source.response || {};
+    const startedAt = isoTimestamp(request.startedAt);
+    const durationMs = Number.isSafeInteger(response.elapsedMs) && response.elapsedMs >= 0
+        ? response.elapsedMs : null;
+    const completedAt = response.completedAt == null && durationMs == null
+        ? null
+        : isoTimestamp(response.completedAt ?? (Date.parse(startedAt) + durationMs), startedAt);
+    const failed = observation instanceof Error || response.success === false;
+    return Object.freeze({
+        correlationId: String(correlationId || request.requestId || observation?.requestId || operationName),
+        operationName: String(operationName),
+        controller: observation?.controller || request.controller || null,
+        method: String(observation?.method || request.method || 'UNKNOWN'),
+        projectName: observation?.projectName || request.projectName || null,
+        requestId: observation?.requestId || request.requestId || response.requestId || null,
+        attemptNumber,
+        startedAt,
+        completedAt,
+        durationMs,
+        outcome: outcome || (failed ? 'failure' : 'success'),
+        transportCode: failed ? observation?.code || null : null,
+        serverErrorCode: observation?.serverErrorCode || response.errorCode || null,
+        serverErrorMessage: response.serverMessage || null,
+        requestSummary: request.value ?? observation?.requestValue ?? null,
+        responseSummary: response.value ?? null
+    });
+}
+
+function diagnosticsFromAttempts(attempts) {
+    const values = (Array.isArray(attempts) ? attempts : []).filter(Boolean);
+    return values.length === 0 ? undefined : Object.freeze({ requestAttempts: Object.freeze(values) });
+}
+
+function diagnosticsFromObservations(observations, options = {}) {
+    return diagnosticsFromAttempts((Array.isArray(observations) ? observations : [observations])
+        .filter(Boolean)
+        .map((observation, index) => requestAttemptFromObservation(observation, {
+            ...options,
+            attemptNumber: options.attemptNumber ?? index + 1
+        })));
+}
+
+function historyDiagnostics(value, options = {}) {
+    if (!value) return undefined;
+    if (Array.isArray(value.requestAttempts)) return diagnosticsFromAttempts(value.requestAttempts);
+    if (value.diagnostics && Array.isArray(value.diagnostics.requestAttempts)) {
+        return diagnosticsFromAttempts(value.diagnostics.requestAttempts);
+    }
+    const observations = value.observations || value.attemptsDiagnostics || value.diagnosticObservations;
+    return observations ? diagnosticsFromObservations(observations, options) : undefined;
+}
+
+export {
+    requestAttemptFromObservation,
+    diagnosticsFromAttempts,
+    diagnosticsFromObservations,
+    historyDiagnostics
+};

--- a/src/shared/history-diagnostics.test.js
+++ b/src/shared/history-diagnostics.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { requestAttemptFromObservation, diagnosticsFromObservations } from './history-diagnostics.js';
+
+function error(code, requestId, response = {}) {
+    return Object.assign(new Error(code), { code, requestId, diagnostics: {
+        request: { controller: 'Controller', method: 'Post', projectName: 'Project', requestId, startedAt: 100, value: { Id: 7 } },
+        response
+    } });
+}
+
+test('converts server rejection and transport failure observations to the validated diagnostic contract', () => {
+    const diagnostics = diagnosticsFromObservations([
+        error('SERVER_REJECTED', 'server-1', { requestId: 'server-1', success: false, errorCode: 'DENIED', serverMessage: 'No', elapsedMs: 5 }),
+        error('REQUEST_TIMEOUT', 'transport-2')
+    ], { correlationId: 'shared-page-1', operationName: 'load_page' });
+    assert.deepEqual(diagnostics.requestAttempts.map(({ requestId, outcome }) => [requestId, outcome]), [
+        ['server-1', 'failure'], ['transport-2', 'failure']
+    ]);
+    assert.equal(diagnostics.requestAttempts[0].correlationId, 'shared-page-1');
+    assert.equal(diagnostics.requestAttempts[1].attemptNumber, 2);
+    assert.equal(requestAttemptFromObservation(error('REQUEST_TIMEOUT', 'x'), {
+        correlationId: 'retry', operationName: 'write'
+    }).transportCode, 'REQUEST_TIMEOUT');
+});


### PR DESCRIPTION
### Motivation

- Centralize conversion of transport observations and errors into the validated `requestAttempts` diagnostic shape so feature history builders stop reimplementing ad hoc serialization. 
- Preserve each workflow’s existing status, counts, per-item messages, partial-result behavior, retry semantics, and cancellation behavior while surfacing bounded diagnostics on relevant result rows. 
- Ensure legacy builders that produced older history shapes continue to correlate transport observations to the correct request/row. 

### Description

- Add a shared helper module `src/shared/history-diagnostics.js` that exposes `requestAttemptFromObservation`, `diagnosticsFromAttempts`, `diagnosticsFromObservations`, and `historyDiagnostics` for normalizing observations or existing bounded diagnostics to the execution-history contract. 
- Wire the shared helpers into history builders so diagnostics are attached without changing operation status or attempt-count semantics in `src/features/batch-user-management-history.js`, `src/features/batch-lesson-access-history-record.js`, `src/features/batch-section-creation-history-record.js`, and `src/features/batch-section-deletion-history.js`. 
- Update the runtime legacy builder `src/features/batch-section-deletion.js` to preserve transport errors (as `diagnosticObservations`) and correlate them into the older history shape when producing its record. 
- Add focused unit tests beside affected modules to validate server rejections and transport failures are converted and correlated correctly in `src/shared/history-diagnostics.test.js` and new feature tests under `src/features/*history*.test.js` that cover multi-row correlation and legacy-builder behavior. 

### Testing

- Ran linting with `npm run lint` and it passed. 
- Ran the full Node test suite with `npm test` and all new and existing tests passed, including the added focused tests for server rejections and transport failures. 
- Built the production bundles with `npm run build` and validated bundle regression budgets with `npm run check:build-output`, both of which succeeded. 
- Performed a repository-level check (`git diff --check` and local status) and found no outstanding whitespace or verification errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bd27daf5483309f35fd62f21c7e4f)