### PR TITLE
Introduce reusable Toolbox UI primitives

### DIFF
--- a/docs/design-foundations.md
+++ b/docs/design-foundations.md
@@ -37,6 +37,11 @@ because a new literal appears once. The canonical values preserve the dominant
 MAIN visual language while retaining the popup's existing indigo as a separate
 brand accent.
 
+The executable source of truth is `src/shared/ui-design-tokens.js`. MAIN Lit
+styles consume it through `src/content/main/styles/foundations.js`, while the
+popup applies the same values to its light-DOM root during startup. The table
+below documents that exported contract and must change with it.
+
 | Token | Canonical value | Purpose |
 | --- | --- | --- |
 | `--edvibe-font-family` | `"Segoe UI", Inter, Arial, system-ui, sans-serif` | Controls and in-page UI typography |

--- a/src/content/main/components/dialog-controller.js
+++ b/src/content/main/components/dialog-controller.js
@@ -1,0 +1,53 @@
+export class DialogController {
+    constructor(host, options = {}) {
+        this.host = host;
+        this.options = options;
+        this.previouslyFocused = null;
+        this.initialFocusApplied = false;
+        this.handleKeydown = this.handleKeydown.bind(this);
+        host.addController(this);
+    }
+
+    get document() {
+        return this.host.ownerDocument;
+    }
+
+    hostConnected() {
+        this.previouslyFocused = this.document?.activeElement || null;
+        this.document?.addEventListener('keydown', this.handleKeydown);
+    }
+
+    hostUpdated() {
+        if (this.initialFocusApplied) return;
+        const target = this.resolveInitialFocus();
+        if (!target) return;
+        target.focus();
+        this.initialFocusApplied = true;
+    }
+
+    hostDisconnected() {
+        this.document?.removeEventListener('keydown', this.handleKeydown);
+        if (this.previouslyFocused?.isConnected) this.previouslyFocused.focus();
+        this.previouslyFocused = null;
+        this.initialFocusApplied = false;
+    }
+
+    resolveInitialFocus() {
+        const root = this.host.renderRoot;
+        const configured = typeof this.options.initialFocus === 'function'
+            ? this.options.initialFocus(this.host)
+            : root?.querySelector(this.options.initialFocus || '[autofocus]');
+        return configured || root?.querySelector(
+            'button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+        );
+    }
+
+    handleKeydown(event) {
+        if (event.key !== 'Escape' || event.defaultPrevented) return;
+        if (this.options.canClose && !this.options.canClose(this.host)) return;
+        const close = this.options.onClose;
+        if (typeof close !== 'function') return;
+        event.preventDefault();
+        close(this.host, event);
+    }
+}

--- a/src/content/main/components/dialog-controller.js
+++ b/src/content/main/components/dialog-controller.js
@@ -5,6 +5,7 @@ export class DialogController {
         this.previouslyFocused = null;
         this.initialFocusApplied = false;
         this.handleKeydown = this.handleKeydown.bind(this);
+        this.handleBackdropClick = this.handleBackdropClick.bind(this);
         host.addController(this);
     }
 
@@ -22,7 +23,7 @@ export class DialogController {
         const target = this.resolveInitialFocus();
         if (!target) return;
         target.focus();
-        this.initialFocusApplied = true;
+        this.initialFocusApplied = this.hasFocus(target);
     }
 
     hostDisconnected() {
@@ -37,17 +38,41 @@ export class DialogController {
         const configured = typeof this.options.initialFocus === 'function'
             ? this.options.initialFocus(this.host)
             : root?.querySelector(this.options.initialFocus || '[autofocus]');
-        return configured || root?.querySelector(
+        if (this.isAvailableFocusTarget(configured)) return configured;
+        const candidates = root?.querySelectorAll(
             'button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+        ) || [];
+        return [...candidates].find((candidate) => this.isAvailableFocusTarget(candidate)) || null;
+    }
+
+    isAvailableFocusTarget(target) {
+        return Boolean(
+            typeof target?.focus === 'function'
+            && !target.closest?.('[hidden], [inert]')
         );
     }
 
-    handleKeydown(event) {
-        if (event.key !== 'Escape' || event.defaultPrevented) return;
-        if (this.options.canClose && !this.options.canClose(this.host)) return;
+    hasFocus(target) {
+        const root = target.getRootNode?.() || this.host.renderRoot;
+        return root?.activeElement === target || this.document?.activeElement === target;
+    }
+
+    requestClose(reason, event) {
+        if (event?.defaultPrevented) return false;
+        if (this.options.canClose && !this.options.canClose(this.host, reason, event)) return false;
         const close = this.options.onClose;
-        if (typeof close !== 'function') return;
-        event.preventDefault();
-        close(this.host, event);
+        if (typeof close !== 'function') return false;
+        event?.preventDefault?.();
+        close(this.host, reason, event);
+        return true;
+    }
+
+    handleBackdropClick(event) {
+        if (event.target !== event.currentTarget) return false;
+        return this.requestClose('backdrop', event);
+    }
+
+    handleKeydown(event) {
+        if (event.key === 'Escape') this.requestClose('escape', event);
     }
 }

--- a/src/content/main/components/dialog-controller.test.js
+++ b/src/content/main/components/dialog-controller.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { DialogController } from './dialog-controller.js';
+
+function createFixture(options = {}) {
+    const listeners = new Map();
+    let restored = 0;
+    let focused = 0;
+    const initial = { focus: () => { focused += 1; } };
+    const document = {
+        activeElement: { isConnected: true, focus: () => { restored += 1; } },
+        addEventListener: (type, listener) => listeners.set(type, listener),
+        removeEventListener: (type) => listeners.delete(type)
+    };
+    const host = {
+        ownerDocument: document,
+        renderRoot: { querySelector: () => initial },
+        addController(controller) { this.controller = controller; }
+    };
+    const controller = new DialogController(host, options);
+    return { controller, host, listeners, counts: () => ({ restored, focused }) };
+}
+
+test('registers symmetrically, focuses the dialog, and restores prior focus', () => {
+    const fixture = createFixture();
+    fixture.controller.hostConnected();
+    fixture.controller.hostUpdated();
+    fixture.controller.hostUpdated();
+    assert.equal(fixture.counts().focused, 1);
+    assert.equal(fixture.listeners.has('keydown'), true);
+
+    fixture.controller.hostDisconnected();
+    assert.deepEqual(fixture.counts(), { restored: 1, focused: 1 });
+    assert.equal(fixture.listeners.has('keydown'), false);
+});
+
+test('closes on an unhandled Escape only when policy allows it', () => {
+    let closeCount = 0;
+    let prevented = 0;
+    const fixture = createFixture({
+        canClose: () => true,
+        onClose: () => { closeCount += 1; }
+    });
+    fixture.controller.hostConnected();
+    fixture.listeners.get('keydown')({
+        key: 'Escape', defaultPrevented: false, preventDefault: () => { prevented += 1; }
+    });
+    fixture.listeners.get('keydown')({
+        key: 'Enter', defaultPrevented: false, preventDefault: () => { prevented += 1; }
+    });
+
+    assert.equal(closeCount, 1);
+    assert.equal(prevented, 1);
+});
+
+test('does not close when the feature policy blocks dismissal', () => {
+    const fixture = createFixture({ canClose: () => false, onClose: assert.fail });
+    fixture.controller.hostConnected();
+    fixture.listeners.get('keydown')({ key: 'Escape', defaultPrevented: false });
+});

--- a/src/content/main/components/dialog-controller.test.js
+++ b/src/content/main/components/dialog-controller.test.js
@@ -7,7 +7,19 @@ function createFixture(options = {}) {
     const listeners = new Map();
     let restored = 0;
     let focused = 0;
-    const initial = { focus: () => { focused += 1; } };
+    const renderRoot = {
+        activeElement: null,
+        querySelector: () => initial,
+        querySelectorAll: () => [initial]
+    };
+    const initial = {
+        closest: () => null,
+        getRootNode: () => renderRoot,
+        focus: () => {
+            focused += 1;
+            renderRoot.activeElement = initial;
+        }
+    };
     const document = {
         activeElement: { isConnected: true, focus: () => { restored += 1; } },
         addEventListener: (type, listener) => listeners.set(type, listener),
@@ -15,7 +27,7 @@ function createFixture(options = {}) {
     };
     const host = {
         ownerDocument: document,
-        renderRoot: { querySelector: () => initial },
+        renderRoot,
         addController(controller) { this.controller = controller; }
     };
     const controller = new DialogController(host, options);
@@ -39,7 +51,7 @@ test('closes on an unhandled Escape only when policy allows it', () => {
     let closeCount = 0;
     let prevented = 0;
     const fixture = createFixture({
-        canClose: () => true,
+        canClose: (_host, reason) => reason === 'escape',
         onClose: () => { closeCount += 1; }
     });
     fixture.controller.hostConnected();
@@ -58,4 +70,52 @@ test('does not close when the feature policy blocks dismissal', () => {
     const fixture = createFixture({ canClose: () => false, onClose: assert.fail });
     fixture.controller.hostConnected();
     fixture.listeners.get('keydown')({ key: 'Escape', defaultPrevented: false });
+});
+
+test('skips hidden candidates and retries when focus does not move', () => {
+    const fixture = createFixture();
+    const hidden = { closest: () => ({ hidden: true }) };
+    let attempts = 0;
+    const retryTarget = {
+        closest: () => null,
+        getRootNode: () => fixture.host.renderRoot,
+        focus() {
+            attempts += 1;
+            if (attempts > 1) fixture.host.renderRoot.activeElement = retryTarget;
+        }
+    };
+    fixture.host.renderRoot.querySelector = () => hidden;
+    fixture.host.renderRoot.querySelectorAll = () => [hidden, retryTarget];
+
+    fixture.controller.hostConnected();
+    fixture.controller.hostUpdated();
+    assert.equal(fixture.controller.initialFocusApplied, false);
+    fixture.controller.hostUpdated();
+
+    assert.equal(attempts, 2);
+    assert.equal(fixture.controller.initialFocusApplied, true);
+});
+
+test('uses one close policy for backdrop and explicit close requests', () => {
+    const reasons = [];
+    const fixture = createFixture({
+        canClose: (_host, reason) => reason !== 'blocked',
+        onClose: (_host, reason) => reasons.push(reason)
+    });
+    const backdrop = {};
+    const backdropEvent = {
+        target: backdrop,
+        currentTarget: backdrop,
+        defaultPrevented: false,
+        preventDefault() {}
+    };
+
+    assert.equal(fixture.controller.handleBackdropClick(backdropEvent), true);
+    assert.equal(fixture.controller.handleBackdropClick({
+        ...backdropEvent,
+        target: {}
+    }), false);
+    assert.equal(fixture.controller.requestClose('close-button'), true);
+    assert.equal(fixture.controller.requestClose('blocked'), false);
+    assert.deepEqual(reasons, ['backdrop', 'close-button']);
 });

--- a/src/content/main/styles/foundations.js
+++ b/src/content/main/styles/foundations.js
@@ -1,17 +1,18 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import {
+    TOOLBOX_DESIGN_TOKENS,
+    createDesignTokenDeclarations
+} from '../../../shared/ui-design-tokens.js';
+
+const tokenDeclarations = unsafeCSS(createDesignTokenDeclarations());
 
 export const componentFoundationStyles = css`
     :host {
-        --edvibe-font-family: "Segoe UI", Inter, Arial, system-ui, sans-serif;
-        --edvibe-dialog-z-index: 2147483647;
-        --edvibe-overlay-background: rgba(15, 23, 42, 0.6);
-        --edvibe-surface: #fff;
-        --edvibe-text: #1f2937;
-        --edvibe-muted-text: #6b7280;
-        --edvibe-border: #d9dfe9;
-        --edvibe-primary: #4055d3;
-        --edvibe-danger: #c93a3a;
-        --edvibe-radius: 14px;
+        ${tokenDeclarations}
+        --edvibe-dialog-z-index: var(--edvibe-z-dialog);
+        --edvibe-overlay-background: var(--edvibe-overlay);
+        --edvibe-muted-text: var(--edvibe-text-muted);
+        --edvibe-radius: var(--edvibe-radius-dialog);
     }
 
     button,
@@ -27,3 +28,5 @@ export const dialogFoundationStyles = css`
         font-family: var(--edvibe-font-family);
     }
 `;
+
+export { TOOLBOX_DESIGN_TOKENS };

--- a/src/content/main/styles/primitives.js
+++ b/src/content/main/styles/primitives.js
@@ -9,6 +9,13 @@ export const dialogShellStyles = css`
         place-items: center;
         padding: 16px;
         background: var(--edvibe-overlay);
+        box-sizing: border-box;
+    }
+
+    [data-part="overlay"] *,
+    [data-part="overlay"] *::before,
+    [data-part="overlay"] *::after {
+        box-sizing: border-box;
     }
 
     [data-part="dialog"] {

--- a/src/content/main/styles/primitives.js
+++ b/src/content/main/styles/primitives.js
@@ -1,0 +1,145 @@
+import { css } from 'lit';
+
+export const dialogShellStyles = css`
+    [data-part="overlay"] {
+        position: fixed;
+        inset: 0;
+        z-index: var(--edvibe-z-dialog);
+        display: grid;
+        place-items: center;
+        padding: 16px;
+        background: var(--edvibe-overlay);
+    }
+
+    [data-part="dialog"] {
+        max-width: calc(100vw - 32px);
+        max-height: calc(100vh - 32px);
+        overflow: hidden;
+        border: 1px solid var(--edvibe-border-subtle);
+        border-radius: var(--edvibe-radius-dialog);
+        color: var(--edvibe-text);
+        background: var(--edvibe-surface);
+        box-shadow: var(--edvibe-shadow-dialog);
+    }
+
+    @media (max-width: 640px) {
+        [data-part="overlay"] { padding: 0; }
+        [data-part="dialog"] {
+            max-width: 100vw;
+            max-height: 100vh;
+            border-radius: 0;
+        }
+    }
+`;
+
+export const controlStyles = css`
+    [data-control] {
+        min-height: 36px;
+        padding: 8px 12px;
+        border: 1px solid var(--edvibe-primary);
+        border-radius: var(--edvibe-radius-control);
+        color: var(--edvibe-surface);
+        background: var(--edvibe-primary);
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+    }
+
+    [data-control="secondary"] {
+        border-color: var(--edvibe-border);
+        color: var(--edvibe-text);
+        background: var(--edvibe-surface);
+    }
+
+    [data-control="danger"] {
+        border-color: var(--edvibe-danger-border);
+        color: var(--edvibe-danger);
+        background: var(--edvibe-surface);
+    }
+
+    [data-control]:focus-visible,
+    [data-field] :is(input, textarea, select):focus-visible {
+        outline: 2px solid var(--edvibe-focus-outline);
+        outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--edvibe-focus-halo);
+    }
+
+    [data-control]:disabled,
+    [data-field] :is(input, textarea, select):disabled {
+        color: var(--edvibe-text-muted);
+        background: var(--edvibe-surface-subtle);
+        cursor: default;
+        opacity: .72;
+    }
+
+    [data-part="actions"] {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: flex-end;
+    }
+`;
+
+export const fieldStyles = css`
+    [data-field] {
+        display: grid;
+        gap: 4px;
+        color: var(--edvibe-text);
+        font-size: 13px;
+        font-weight: 650;
+    }
+
+    [data-field] :is(input, textarea, select) {
+        width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
+        padding: 9px 10px;
+        border: 1px solid var(--edvibe-border);
+        border-radius: var(--edvibe-radius-control);
+        color: var(--edvibe-text);
+        background: var(--edvibe-surface);
+        font: inherit;
+    }
+
+    [data-part="help"] { color: var(--edvibe-text-muted); font-size: 11px; }
+`;
+
+export const noticeStyles = css`
+    [data-notice] {
+        padding: 10px 12px;
+        border: 1px solid var(--edvibe-info-border);
+        border-radius: var(--edvibe-radius-control);
+        color: var(--edvibe-info);
+        background: var(--edvibe-info-surface);
+        font-size: 12px;
+        line-height: 1.45;
+    }
+
+    [data-notice="success"] { border-color: var(--edvibe-success-border); color: var(--edvibe-success); background: var(--edvibe-success-surface); }
+    [data-notice="warning"] { border-color: var(--edvibe-warning-border); color: var(--edvibe-warning); background: var(--edvibe-warning-surface); }
+    [data-notice="danger"] { border-color: var(--edvibe-danger-border); color: var(--edvibe-danger); background: var(--edvibe-danger-surface); }
+`;
+
+export const progressStyles = css`
+    [data-part="progress"] { accent-color: var(--edvibe-primary); }
+    [data-part="status"] { color: var(--edvibe-text-muted); font-size: 12px; }
+`;
+
+export const emptyStateStyles = css`
+    [data-part="empty-state"] {
+        padding: 24px;
+        border: 1px dashed var(--edvibe-border);
+        border-radius: var(--edvibe-radius-panel);
+        color: var(--edvibe-text-muted);
+        text-align: center;
+    }
+`;
+
+export const toolboxPrimitiveStyles = [
+    dialogShellStyles,
+    controlStyles,
+    fieldStyles,
+    noticeStyles,
+    progressStyles,
+    emptyStateStyles
+];

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -1,1 +1,4 @@
+import { applyDesignTokens } from '@/shared/ui-design-tokens.js';
 import '@/popup/components/popup-app.js';
+
+applyDesignTokens(document.documentElement);

--- a/src/shared/ui-design-tokens.js
+++ b/src/shared/ui-design-tokens.js
@@ -1,0 +1,45 @@
+export const TOOLBOX_DESIGN_TOKENS = Object.freeze({
+    '--edvibe-font-family': '"Segoe UI", Inter, Arial, system-ui, sans-serif',
+    '--edvibe-z-dialog': '2147483647',
+    '--edvibe-overlay': 'rgba(15, 23, 42, 0.6)',
+    '--edvibe-surface': '#fff',
+    '--edvibe-surface-subtle': '#f8fafc',
+    '--edvibe-surface-app': '#f4f6fa',
+    '--edvibe-text': '#1f2937',
+    '--edvibe-text-strong': '#111827',
+    '--edvibe-text-muted': '#6b7280',
+    '--edvibe-border': '#d1d5db',
+    '--edvibe-border-subtle': '#e5e7eb',
+    '--edvibe-primary': '#2563eb',
+    '--edvibe-brand': '#4055d3',
+    '--edvibe-danger': '#b91c1c',
+    '--edvibe-danger-surface': '#fef2f2',
+    '--edvibe-danger-border': '#fecaca',
+    '--edvibe-warning': '#9a3412',
+    '--edvibe-warning-surface': '#fff7ed',
+    '--edvibe-warning-border': '#fed7aa',
+    '--edvibe-success': '#166534',
+    '--edvibe-success-surface': '#f0fdf4',
+    '--edvibe-success-border': '#bbf7d0',
+    '--edvibe-info': '#1e3a8a',
+    '--edvibe-info-surface': '#eff6ff',
+    '--edvibe-info-border': '#bfdbfe',
+    '--edvibe-focus-outline': '#2563eb',
+    '--edvibe-focus-halo': 'rgba(37, 99, 235, 0.25)',
+    '--edvibe-radius-control': '8px',
+    '--edvibe-radius-panel': '10px',
+    '--edvibe-radius-dialog': '16px',
+    '--edvibe-radius-pill': '999px',
+    '--edvibe-shadow-card': '0 2px 7px rgba(30, 42, 70, 0.04)',
+    '--edvibe-shadow-dialog': '0 24px 80px rgba(15, 23, 42, 0.38)'
+});
+
+export function createDesignTokenDeclarations(tokens = TOOLBOX_DESIGN_TOKENS) {
+    return Object.entries(tokens)
+        .map(([name, value]) => `${name}: ${value};`)
+        .join('\n');
+}
+
+export function applyDesignTokens(target, tokens = TOOLBOX_DESIGN_TOKENS) {
+    for (const [name, value] of Object.entries(tokens)) target.style.setProperty(name, value);
+}

--- a/src/shared/ui-design-tokens.test.js
+++ b/src/shared/ui-design-tokens.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    TOOLBOX_DESIGN_TOKENS,
+    applyDesignTokens,
+    createDesignTokenDeclarations
+} from './ui-design-tokens.js';
+
+test('exposes the audited semantic token vocabulary as CSS custom properties', () => {
+    assert.equal(TOOLBOX_DESIGN_TOKENS['--edvibe-primary'], '#2563eb');
+    assert.equal(TOOLBOX_DESIGN_TOKENS['--edvibe-radius-dialog'], '16px');
+    assert.match(createDesignTokenDeclarations(), /--edvibe-focus-outline: #2563eb;/);
+});
+
+test('applies the same authoritative token values to a light-DOM root', () => {
+    const properties = new Map();
+    applyDesignTokens({
+        style: { setProperty: (name, value) => properties.set(name, value) }
+    });
+
+    assert.equal(properties.size, Object.keys(TOOLBOX_DESIGN_TOKENS).length);
+    assert.equal(properties.get('--edvibe-surface-app'), '#f4f6fa');
+});


### PR DESCRIPTION
## Summary

- establish one executable source of truth for the audited semantic design tokens and deliver it to both MAIN Shadow DOM styles and the popup light-DOM root
- add reusable MAIN Lit style modules for dialog shells, controls/actions, fields, notices, progress/status, and empty states
- add a reusable Lit dialog controller with a unified Escape/backdrop/explicit-close policy, verified initial focus, listener cleanup, and focus restoration
- ignore hidden/inert focus candidates and retry initial focus after unsuccessful focus attempts
- document the runtime adapters and cover token delivery and dialog behavior with focused tests

## Why

The UI audit in #98 found repeated visual roles and inconsistent modal behavior across the popup and MAIN features. This provides the small shared foundation needed by the follow-up migrations without moving feature-specific markup or orchestration into a design-system layer.

## Impact

Future UI migrations can consume canonical tokens and small `data-part`/`data-control` style contracts instead of copying generic CSS. Dialogs can adopt consistent keyboard, backdrop dismissal, and focus behavior while retaining their existing custom-element APIs and feature-owned close policies.

## Validation

- `npm run lint`
- `npm run test:ci` (57 tests passed)
- `npm run build`
- `npm run check:build-output`
- `git diff --check`

Fixes #99