### PR TITLE
Migrate action recorder UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/action-recorder/action-recorder-dialog.js
+++ b/src/content/main/features/action-recorder/action-recorder-dialog.js
@@ -3,6 +3,13 @@ import {
     componentFoundationStyles,
     dialogFoundationStyles
 } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    emptyStateStyles,
+    fieldStyles,
+    noticeStyles
+} from '../../styles/primitives.js';
 import { actionRecorderDialogStyles } from './action-recorder-dialog.styles.js';
 
 const RECORDER_DIALOG_TAG = 'edvibe-toolbox-action-recorder';
@@ -12,6 +19,11 @@ class ActionRecorderDialog extends LitElement {
     static styles = [
         componentFoundationStyles,
         dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        noticeStyles,
+        emptyStateStyles,
         actionRecorderDialogStyles,
     ];
 
@@ -174,7 +186,7 @@ class ActionRecorderDialog extends LitElement {
             ].join(' · ')}</p>
                     ${this.renderJsonBlock('Запрос Value', operation.requestValue)}
                     ${this.renderJsonBlock('Ответ', operation.response)}
-                    <button type="button" class="button copy-request"
+                    <button type="button" class="button copy-request" data-control="secondary"
                         @click=${() => this.callbacks.onCopyRequest?.(operation.sequence)}>
                         Копировать запрос
                     </button>
@@ -204,18 +216,18 @@ class ActionRecorderDialog extends LitElement {
                 <span></span><strong>REC</strong>
                 <span class="indicator-count">${visibleOperations.length}</span>
             </button>
-            <div class="recorder-overlay" ?hidden=${this.minimized}>
-                <section class="recorder-panel" role="dialog" aria-labelledby="recorder-title">
+            <div class="recorder-overlay" data-part="overlay" ?hidden=${this.minimized}>
+                <section class="recorder-panel" data-part="dialog" role="dialog" aria-labelledby="recorder-title">
                     <header class="recorder-header">
                         <div>
                             <h2 id="recorder-title">Запись действий WebSocket</h2>
                             <p class="recorder-subtitle">Выполните одно действие в Edvibe и изучите обмен сообщениями.</p>
                         </div>
-                        <div class="header-actions">
-                            <button class="icon-button recorder-minimize" type="button" aria-label="Свернуть" @click=${() => { this.minimized = true; }}>
+                        <div class="header-actions" data-part="actions">
+                            <button class="icon-button recorder-minimize" data-control="secondary" type="button" aria-label="Свернуть" @click=${() => { this.minimized = true; }}>
                                 -
                             </button>
-                            <button class="icon-button recorder-close" type="button" aria-label="Закрыть" @click=${() => this.handleClose()}>
+                            <button class="icon-button recorder-close" data-control="secondary" type="button" aria-label="Закрыть" @click=${() => this.handleClose()}>
                                 &times;
                             </button>
                         </div>
@@ -226,26 +238,26 @@ class ActionRecorderDialog extends LitElement {
                             <strong class="state-label">${labels[this.state.status] || labels.idle}</strong>
                             <span class="elapsed">${this.elapsedLabel}</span>
                         </div>
-                        <div class="toolbar-actions">
-                            <button class="button primary recorder-start" type="button" ?hidden=${recording} @click=${() => this.handleStart()}>
+                        <div class="toolbar-actions" data-part="actions">
+                            <button class="button primary recorder-start" data-control type="button" ?hidden=${recording} @click=${() => this.handleStart()}>
                                 Начать запись
                             </button>
-                            <button class="button danger recorder-stop" type="button" ?hidden=${!recording} @click=${() => this.callbacks.onStop?.()}>
+                            <button class="button danger recorder-stop" data-control="danger" type="button" ?hidden=${!recording} @click=${() => this.callbacks.onStop?.()}>
                                 Остановить
                             </button>
-                            <button class="button recorder-clear" type="button" ?disabled=${!hasSession} @click=${() => this.handleClear()}>
+                            <button class="button recorder-clear" data-control="secondary" type="button" ?disabled=${!hasSession} @click=${() => this.handleClear()}>
                                 Очистить
                             </button>
-                            <button class="button recorder-copy" type="button" ?disabled=${!hasSession || operations.length === 0} @click=${() => this.callbacks.onCopyRecipe?.()}>
+                            <button class="button recorder-copy" data-control="secondary" type="button" ?disabled=${!hasSession || operations.length === 0} @click=${() => this.callbacks.onCopyRecipe?.()}>
                                 Копировать рецепт
                             </button>
-                            <button class="button recorder-export" type="button" ?disabled=${!hasSession} @click=${() => this.callbacks.onExport?.()}>
+                            <button class="button recorder-export" data-control="secondary" type="button" ?disabled=${!hasSession} @click=${() => this.callbacks.onExport?.()}>
                                 Экспорт JSON
                             </button>
                         </div>
                     </div>
                     <div class="recorder-body">
-                        <aside class="privacy-warning">
+                        <aside class="privacy-warning" data-notice="warning">
                             Запись может содержать данные учеников, уроки, ответы и идентификаторы.
                             Проверьте файл перед отправкой или коммитом.
                         </aside>
@@ -258,17 +270,17 @@ class ActionRecorderDialog extends LitElement {
                                 Показать трафик Toolbox
                             </label>
                         </div>
-                        <p class="recorder-notice" role="status" ?hidden=${!this.state.notice}>${this.state.notice || ''}</p>
+                        <p class="recorder-notice" data-notice="success" role="status" ?hidden=${!this.state.notice}>${this.state.notice || ''}</p>
                         <section>
                             <h3>Операции</h3>
                             <div class="operation-list">${visibleOperations.map((operation) => this.renderOperation(operation))}</div>
-                            <p class="empty-operations" ?hidden=${visibleOperations.length > 0}> Запустите запись и выполните действие в Edvibe.</p>
+                            <p class="empty-operations" data-part="empty-state" ?hidden=${visibleOperations.length > 0}> Запустите запись и выполните действие в Edvibe.</p>
                         </section>
                         <details class="other-section">
                             <summary>Другие кадры (<span class="other-count">${otherFrames.length}</span>)</summary>
                             <div class="other-list">${otherFrames.map((frame) => html`<pre>${JSON.stringify(frame, null, 2)}</pre>`)}</div>
                         </details>
-                        <label class="copy-fallback" ?hidden=${!copyFallback}>
+                        <label class="copy-fallback" data-field ?hidden=${!copyFallback}>
                             Скопируйте текст вручную
                             <textarea readonly .value=${copyFallback}></textarea>
                         </label>

--- a/src/content/main/features/action-recorder/action-recorder-dialog.styles.js
+++ b/src/content/main/features/action-recorder/action-recorder-dialog.styles.js
@@ -2,26 +2,9 @@ import { css } from 'lit';
 
 export const actionRecorderDialogStyles = css`
 :host {
-    color: #172033;
-    font: 13px/1.45 Inter, "Segoe UI", system-ui, sans-serif;
-}
-
-* {
-    box-sizing: border-box;
-}
-
-button,
-textarea,
-input {
-    font: inherit;
-}
-
-.recorder-overlay {
-    position: fixed;
-    z-index: 2147483646;
-    inset: 0;
-    padding: 28px;
-    background: rgba(19, 27, 45, 0.52);
+    color: var(--edvibe-text);
+    font-size: 13px;
+    line-height: 1.45;
 }
 
 .recorder-overlay[hidden],
@@ -34,12 +17,8 @@ input {
     width: min(920px, 100%);
     max-height: calc(100vh - 56px);
     margin: 0 auto;
-    overflow: hidden;
     flex-direction: column;
-    border: 1px solid #dce2ec;
-    border-radius: 14px;
-    background: #f5f7fb;
-    box-shadow: 0 24px 70px rgba(15, 23, 42, 0.3);
+    background: var(--edvibe-surface-app);
 }
 
 .recorder-header,
@@ -49,8 +28,8 @@ input {
     justify-content: space-between;
     align-items: center;
     padding: 16px 18px;
-    border-bottom: 1px solid #e0e5ee;
-    background: #fff;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
+    background: var(--edvibe-surface);
 }
 
 .recorder-header h2,
@@ -66,7 +45,7 @@ input {
 
 .recorder-subtitle {
     margin-top: 3px !important;
-    color: #687386;
+    color: var(--edvibe-text-muted);
     font-size: 12px;
 }
 
@@ -80,67 +59,36 @@ input {
 }
 
 .icon-button {
-    width: 31px;
-    height: 31px;
-    border: 1px solid #d9dfe9;
-    border-radius: 7px;
-    color: #4e596b;
-    background: #fff;
-    cursor: pointer;
+    width: 36px;
+    height: 36px;
+    padding: 0;
 }
 
 .recorder-toolbar {
     padding-block: 11px;
-    background: #fbfcfe;
+    background: var(--edvibe-surface-subtle);
 }
 
 .state-dot {
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background: #9da5b4;
+    background: var(--edvibe-text-muted);
 }
 
 .recorder-state[data-status="recording"] .state-dot {
-    background: #df3636;
-    box-shadow: 0 0 0 4px #fde4e4;
+    background: var(--edvibe-danger);
+    box-shadow: 0 0 0 4px var(--edvibe-danger-border);
 }
 
 .recorder-state[data-status="limit-reached"] .state-dot {
-    background: #d58a14;
+    background: var(--edvibe-warning);
 }
 
 .elapsed {
     min-width: 34px;
-    color: #687386;
+    color: var(--edvibe-text-muted);
     font-variant-numeric: tabular-nums;
-}
-
-.button {
-    padding: 7px 10px;
-    border: 1px solid #d5dbe6;
-    border-radius: 7px;
-    color: #263248;
-    background: #fff;
-    cursor: pointer;
-}
-
-.button.primary {
-    border-color: #4055d3;
-    color: #fff;
-    background: #4055d3;
-}
-
-.button.danger {
-    border-color: #c93a3a;
-    color: #fff;
-    background: #c93a3a;
-}
-
-.button:disabled {
-    color: #9299a7;
-    background: #edf0f4;
-    cursor: not-allowed;
 }
 
 .recorder-body {
@@ -148,23 +96,15 @@ input {
     padding: 16px 18px 20px;
 }
 
-.privacy-warning {
-    padding: 10px 12px;
-    border: 1px solid #ecd292;
-    border-radius: 8px;
-    color: #765313;
-    background: #fff8e6;
-}
-
 .recorder-summary {
     margin: 13px 0;
     flex-wrap: wrap;
-    color: #596579;
+    color: var(--edvibe-text-muted);
 }
 
 .recorder-summary > span {
     padding-right: 10px;
-    border-right: 1px solid #d9dfe8;
+    border-right: 1px solid var(--edvibe-border-subtle);
 }
 
 .recorder-summary label {
@@ -173,10 +113,6 @@ input {
 
 .recorder-notice {
     margin-bottom: 12px;
-    padding: 9px 10px;
-    border-radius: 7px;
-    color: #34503e;
-    background: #e6f4eb;
 }
 
 .recorder-body h3 {
@@ -190,9 +126,10 @@ input {
 }
 
 .operation {
-    border: 1px solid #dbe1eb;
-    border-radius: 9px;
-    background: #fff;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface);
+    box-shadow: var(--edvibe-shadow-card);
 }
 
 .operation > summary {
@@ -206,7 +143,7 @@ input {
 
 .operation-sequence,
 .operation-duration {
-    color: #778195;
+    color: var(--edvibe-text-muted);
     font-variant-numeric: tabular-nums;
 }
 
@@ -218,20 +155,20 @@ input {
 
 .operation-result {
     text-align: right;
-    color: #28805a;
+    color: var(--edvibe-success);
 }
 
 .operation-result.is-error {
-    color: #b42f2f;
+    color: var(--edvibe-danger);
 }
 
 .operation-content {
     padding: 0 12px 12px;
-    border-top: 1px solid #e6eaf1;
+    border-top: 1px solid var(--edvibe-border-subtle);
 }
 
 .operation-content > p {
-    color: #697487;
+    color: var(--edvibe-text-muted);
     word-break: break-all;
 }
 
@@ -240,27 +177,17 @@ input {
     margin: 10px 0 4px;
 }
 
-pre,
-textarea {
+pre {
     width: 100%;
     overflow: auto;
     padding: 10px;
-    border: 1px solid #dce2eb;
-    border-radius: 7px;
-    color: #233048;
-    background: #f7f9fc;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-control);
+    color: var(--edvibe-text);
+    background: var(--edvibe-surface-subtle);
     font: 11px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
     white-space: pre-wrap;
     word-break: break-word;
-}
-
-.empty-operations {
-    padding: 28px;
-    border: 1px dashed #ccd3df;
-    border-radius: 9px;
-    color: #788397;
-    text-align: center;
-    background: #fafbfc;
 }
 
 .empty-operations[hidden],
@@ -274,35 +201,37 @@ textarea {
 }
 
 .other-section > summary {
-    color: #596579;
+    color: var(--edvibe-text-muted);
     cursor: pointer;
 }
 
 .copy-fallback {
-    display: block;
     margin-top: 14px;
-    color: #765313;
+    color: var(--edvibe-warning);
 }
 
 .copy-fallback textarea {
     min-height: 150px;
     margin-top: 5px;
+    font: 11px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .recorder-indicator {
     position: fixed;
-    z-index: 2147483646;
+    z-index: var(--edvibe-z-dialog);
     right: 20px;
     bottom: 20px;
     display: flex;
     gap: 7px;
     align-items: center;
     padding: 9px 12px;
-    border: 1px solid #ccd3df;
-    border-radius: 999px;
-    color: #38445a;
-    background: #fff;
-    box-shadow: 0 8px 28px rgba(23, 32, 51, 0.2);
+    border: 1px solid var(--edvibe-border);
+    border-radius: var(--edvibe-radius-pill);
+    color: var(--edvibe-text);
+    background: var(--edvibe-surface);
+    box-shadow: var(--edvibe-shadow-card);
     cursor: pointer;
 }
 
@@ -310,19 +239,15 @@ textarea {
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background: #9da5b4;
+    background: var(--edvibe-text-muted);
 }
 
 .recorder-indicator.is-recording > span:first-child {
-    background: #df3636;
-    box-shadow: 0 0 0 3px #fde4e4;
+    background: var(--edvibe-danger);
+    box-shadow: 0 0 0 3px var(--edvibe-danger-border);
 }
 
 @media (max-width: 720px) {
-    .recorder-overlay {
-        padding: 8px;
-    }
-
     .recorder-header,
     .recorder-toolbar {
         align-items: flex-start;


### PR DESCRIPTION
Closes #109

## Summary
- compose the shared MAIN dialog, control, field, notice, and empty-state primitives into the action recorder
- mark common recorder markup with the shared `data-*` contracts while preserving recorder-specific states and interactions
- replace the recorder's competing local palette and generic chrome styles with canonical Toolbox design tokens
- keep the REC indicator, operation list, privacy messaging, minimized behavior, and workflow-specific presentation feature-owned

## Validation
- GitHub Actions is expected to run the repository's lint, tests, production build, and build-output checks for this PR
- no generated `dist/` files were edited