### PR TITLE
Migrate batch user management UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/batch-user-management/batch-user-management-dialog.js
+++ b/src/content/main/features/batch-user-management/batch-user-management-dialog.js
@@ -1,12 +1,28 @@
 import { LitElement, html } from 'lit';
 import { componentFoundationStyles, dialogFoundationStyles } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    fieldStyles,
+    noticeStyles,
+    progressStyles
+} from '../../styles/primitives.js';
 import { batchUserManagementDialogStyles } from './batch-user-management-dialog.styles.js';
 
 const USER_MANAGEMENT_DIALOG_TAG = 'edvibe-toolbox-batch-user-management-dialog';
 const USER_MANAGEMENT_OVERLAY_ID = 'edvibe-toolbox-batch-user-management-overlay';
 
 class BatchUserManagementDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, batchUserManagementDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        noticeStyles,
+        progressStyles,
+        batchUserManagementDialogStyles
+    ];
 
     static properties = {
         rows: {state: true},
@@ -258,35 +274,37 @@ class BatchUserManagementDialog extends LitElement {
         const locked = this.isLocked();
         const statusClass = `edvibe-batch-user-management-status${this.statusError ? ' is-error' : ''}`;
         return html`
-<div class="edvibe-batch-user-management-overlay" @click=${this.handleBackdropClick}>
-                <section class="edvibe-batch-user-management-card" role="dialog" aria-modal="true"
+            <div class="edvibe-batch-user-management-overlay" data-part="overlay" @click=${this.handleBackdropClick}>
+                <section class="edvibe-batch-user-management-card" data-part="dialog" role="dialog" aria-modal="true"
                     aria-labelledby="edvibe-batch-user-management-title">
                     <header class="edvibe-batch-user-management-header">
                         <div><h2 id="edvibe-batch-user-management-title">Управление пользователями</h2>
                             <p class="edvibe-batch-user-management-description">Снимите кураторов и удалите пользователей по списку email.</p></div>
-                        <button class="edvibe-batch-user-management-close" type="button" aria-label="Закрыть"
+                        <button class="edvibe-batch-user-management-close" data-control="secondary" type="button" aria-label="Закрыть"
                             ?disabled=${!this.canClose()} @click=${() => this.close()}>&times;</button>
                     </header>
                     <div class="edvibe-batch-user-management-body">
                         <section class="edvibe-batch-user-management-configure">
-                            <label for="edvibe-batch-user-management-emails">Email пользователей</label>
-                            <textarea id="edvibe-batch-user-management-emails" class="edvibe-batch-user-management-emails"
-                                rows="5" placeholder="user@example.com" .value=${this.emailInput}
-                                ?disabled=${locked || completed || this.mode === 'fatal-error'} @input=${this.handleInput}></textarea>
-                            <div class="edvibe-batch-user-management-email-state" aria-live="polite">
-                                <span class="edvibe-batch-user-management-email-count">Уникальных email: ${this.emailState.validCount}</span>
-                                <span class="edvibe-batch-user-management-malformed-count">Некорректных: ${this.emailState.malformedCount}</span>
+                            <div class="edvibe-batch-user-management-email-field" data-field>
+                                <label for="edvibe-batch-user-management-emails">Email пользователей</label>
+                                <textarea id="edvibe-batch-user-management-emails" class="edvibe-batch-user-management-emails"
+                                    rows="5" placeholder="user@example.com" .value=${this.emailInput}
+                                    ?disabled=${locked || completed || this.mode === 'fatal-error'} @input=${this.handleInput}></textarea>
+                                <div class="edvibe-batch-user-management-email-state" data-part="help" aria-live="polite">
+                                    <span class="edvibe-batch-user-management-email-count">Уникальных email: ${this.emailState.validCount}</span>
+                                    <span class="edvibe-batch-user-management-malformed-count">Некорректных: ${this.emailState.malformedCount}</span>
+                                </div>
                             </div>
                         </section>
-                        <section class="edvibe-batch-user-management-errors" aria-live="polite" ?hidden=${this.errors.length === 0}>
+                        <section class="edvibe-batch-user-management-errors" data-notice="danger" aria-live="polite" ?hidden=${this.errors.length === 0}>
                             ${this.errors.map((error) => html`<p class="edvibe-batch-user-management-error">${error}</p>`)}
                         </section>
                         <section class="edvibe-batch-user-management-table-wrap" ?hidden=${this.rows.length === 0}>
                             <table class="edvibe-batch-user-management-table">
                                 <thead><tr><th scope="col">Пользователь</th>
-                                    <th scope="col">Снять куратора <button class="edvibe-batch-user-management-select-all-unassign" type="button"
+                                    <th scope="col">Снять куратора <button class="edvibe-batch-user-management-select-all-unassign" data-control="secondary" type="button"
                                         ?disabled=${locked || this.rows.length === 0} @click=${() => this.selectAll('unassign', !this.allSelected('unassign'))}>Выбрать все</button></th>
-                                    <th scope="col">Удалить пользователя <button class="edvibe-batch-user-management-select-all-delete" type="button"
+                                    <th scope="col">Удалить пользователя <button class="edvibe-batch-user-management-select-all-delete" data-control="secondary" type="button"
                                         ?disabled=${locked || this.rows.length === 0} @click=${() => this.selectAll('delete', !this.allSelected('delete'))}>Выбрать все</button></th>
                                     <th scope="col">Результат</th></tr></thead>
                                 <tbody class="edvibe-batch-user-management-table-body">${this.rows.map((row) => this.renderRow(row))}</tbody>
@@ -294,16 +312,16 @@ class BatchUserManagementDialog extends LitElement {
                         </section>
                     </div>
                     <div class="edvibe-batch-user-management-live-region">
-                        <p class=${statusClass} role="status" aria-live="polite">${this.statusMessage}</p>
-                        <progress class="edvibe-batch-user-management-progress" max=${this.progress.total}
+                        <p class=${statusClass} data-part="status" role="status" aria-live="polite">${this.statusMessage}</p>
+                        <progress class="edvibe-batch-user-management-progress" data-part="progress" max=${this.progress.total}
                             value=${this.progress.completed} ?hidden=${!this.progress.visible}></progress>
                     </div>
-                    <footer class="edvibe-batch-user-management-footer">
-                        <button class="edvibe-batch-user-management-restart" type="button" ?hidden=${!completed}
+                    <footer class="edvibe-batch-user-management-footer" data-part="actions">
+                        <button class="edvibe-batch-user-management-restart" data-control="secondary" type="button" ?hidden=${!completed}
                             ?disabled=${!completed} @click=${this.handleRestart}>Запустить другую группу</button>
-                        <button class="edvibe-batch-user-management-start" type="button" ?hidden=${this.mode !== 'review'}
+                        <button class="edvibe-batch-user-management-start" data-control type="button" ?hidden=${this.mode !== 'review'}
                             ?disabled=${!this.canStart()} @click=${this.handleStart}>Начать обработку</button>
-                        <button class="edvibe-batch-user-management-check" type="button"
+                        <button class="edvibe-batch-user-management-check" data-control type="button"
                             ?hidden=${!['configure', 'validation-error'].includes(this.mode)} ?disabled=${!this.canCheck()}
                             @click=${this.handleCheck}>Проверить пользователей</button>
                     </footer>

--- a/src/content/main/features/batch-user-management/batch-user-management-dialog.styles.js
+++ b/src/content/main/features/batch-user-management/batch-user-management-dialog.styles.js
@@ -1,30 +1,6 @@
 import { css } from 'lit';
 
 export const batchUserManagementDialogStyles = css`
-:host {
-    all: initial;
-}
-
-.edvibe-batch-user-management-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 16px;
-    box-sizing: border-box;
-    background: rgba(15, 23, 42, .6);
-    color: #1f2937;
-    font-family: "Segoe UI", Arial, sans-serif;
-}
-
-.edvibe-batch-user-management-overlay *,
-.edvibe-batch-user-management-overlay *::before,
-.edvibe-batch-user-management-overlay *::after {
-    box-sizing: border-box;
-}
-
 [hidden] {
     display: none !important;
 }
@@ -35,9 +11,6 @@ export const batchUserManagementDialogStyles = css`
     width: min(980px, calc(100vw - 32px));
     max-height: min(820px, calc(100vh - 32px));
     padding: 24px;
-    border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 24px 80px rgba(15, 23, 42, .38);
 }
 
 .edvibe-batch-user-management-header,
@@ -54,26 +27,23 @@ export const batchUserManagementDialogStyles = css`
 
 .edvibe-batch-user-management-header h2 {
     margin: 0;
-    color: #111827;
+    color: var(--edvibe-text-strong);
     font-size: 21px;
     line-height: 1.3;
 }
 
 .edvibe-batch-user-management-description {
     margin: 5px 0 0;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 13px;
     line-height: 1.4;
 }
 
 .edvibe-batch-user-management-close {
-    padding: 4px 8px;
-    border: 0;
-    background: transparent;
-    color: #6b7280;
+    min-width: 36px;
+    padding: 0;
     font-size: 24px;
     line-height: 1;
-    cursor: pointer;
 }
 
 .edvibe-batch-user-management-body {
@@ -83,56 +53,41 @@ export const batchUserManagementDialogStyles = css`
     margin-top: 18px;
 }
 
-.edvibe-batch-user-management-configure > label {
-    display: block;
-    color: #374151;
+.edvibe-batch-user-management-email-field {
     font-size: 13px;
-    font-weight: 650;
 }
 
 .edvibe-batch-user-management-emails {
-    display: block;
-    width: 100%;
     min-height: 112px;
-    margin-top: 7px;
-    padding: 10px 12px;
     resize: vertical;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    color: #111827;
-    font: inherit;
     line-height: 1.45;
-    outline: none;
 }
 
 .edvibe-batch-user-management-email-state {
     flex-wrap: wrap;
     gap: 8px 16px;
-    margin-top: 7px;
-    color: #6b7280;
-    font-size: 12px;
 }
 
-.edvibe-batch-user-management-table-wrap,
-.edvibe-batch-user-management-errors {
+.edvibe-batch-user-management-table-wrap {
     overflow: auto;
     max-height: 350px;
     margin-top: 18px;
-    border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface);
 }
 
 .edvibe-batch-user-management-table {
     width: 100%;
     border-collapse: collapse;
-    color: #1f2937;
+    color: var(--edvibe-text);
     font-size: 13px;
 }
 
 .edvibe-batch-user-management-table th,
 .edvibe-batch-user-management-table td {
     padding: 11px 12px;
-    border-bottom: 1px solid #f1f5f9;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
     text-align: left;
     vertical-align: top;
 }
@@ -141,8 +96,8 @@ export const batchUserManagementDialogStyles = css`
     position: sticky;
     top: 0;
     z-index: 1;
-    color: #374151;
-    background: #f8fafc;
+    color: var(--edvibe-text);
+    background: var(--edvibe-surface-subtle);
     font-size: 12px;
     font-weight: 700;
 }
@@ -161,14 +116,10 @@ export const batchUserManagementDialogStyles = css`
 
 .edvibe-batch-user-management-table th button {
     display: block;
+    min-height: 28px;
     margin: 5px auto 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: #2563eb;
-    font: inherit;
+    padding: 4px 8px;
     font-size: 11px;
-    cursor: pointer;
 }
 
 .edvibe-batch-user-management-user {
@@ -178,26 +129,27 @@ export const batchUserManagementDialogStyles = css`
 
 .edvibe-batch-user-management-result {
     min-width: 220px;
-    color: #4b5563;
+    color: var(--edvibe-text-muted);
     overflow-wrap: anywhere;
 }
 
 .edvibe-batch-user-management-errors {
-    border-color: #fecaca;
-    background: #fef2f2;
+    overflow: auto;
+    max-height: 350px;
+    margin-top: 18px;
 }
 
 .edvibe-batch-user-management-error {
     margin: 0;
-    padding: 11px 12px;
-    border-bottom: 1px solid #fee2e2;
-    color: #b91c1c;
+    color: inherit;
     font-size: 13px;
     line-height: 1.4;
 }
 
-.edvibe-batch-user-management-error:last-child {
-    border-bottom: 0;
+.edvibe-batch-user-management-error + .edvibe-batch-user-management-error {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid currentColor;
 }
 
 .edvibe-batch-user-management-live-region {
@@ -208,13 +160,12 @@ export const batchUserManagementDialogStyles = css`
 .edvibe-batch-user-management-status {
     min-height: 20px;
     margin: 0;
-    color: #4b5563;
     font-size: 13px;
     line-height: 1.4;
 }
 
 .edvibe-batch-user-management-status.is-error {
-    color: #b91c1c;
+    color: var(--edvibe-danger);
 }
 
 .edvibe-batch-user-management-progress {
@@ -222,66 +173,18 @@ export const batchUserManagementDialogStyles = css`
     width: 100%;
     height: 11px;
     margin-top: 10px;
-    overflow: hidden;
-    border: 0;
-    border-radius: 999px;
-    background: #e5e7eb;
-    appearance: none;
-}
-
-.edvibe-batch-user-management-progress::-webkit-progress-bar {
-    background: #e5e7eb;
-}
-
-.edvibe-batch-user-management-progress::-webkit-progress-value {
-    border-radius: 999px;
-    background: linear-gradient(90deg, #2563eb, #dc2626);
 }
 
 .edvibe-batch-user-management-footer {
     flex: 0 0 auto;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 10px;
     margin-top: 18px;
-}
-
-.edvibe-batch-user-management-footer button {
-    padding: 10px 16px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background: #fff;
-    color: #374151;
-    font: inherit;
-    font-size: 13px;
-    font-weight: 650;
-    cursor: pointer;
-}
-
-.edvibe-batch-user-management-check,
-.edvibe-batch-user-management-start {
-    border-color: #2563eb !important;
-    background: #2563eb !important;
-    color: #fff !important;
-}
-
-.edvibe-batch-user-management-footer button:disabled,
-.edvibe-batch-user-management-close:disabled,
-.edvibe-batch-user-management-emails:disabled {
-    cursor: not-allowed;
-    opacity: .58;
 }
 
 @media (max-width: 680px) {
     .edvibe-batch-user-management-card {
         width: 100%;
-        max-height: calc(100vh - 16px);
+        max-height: 100vh;
         padding: 18px;
-        border-radius: 12px;
-    }
-
-    .edvibe-batch-user-management-overlay {
-        padding: 8px;
     }
 
     .edvibe-batch-user-management-table {


### PR DESCRIPTION
Closes #111

## Summary
- compose shared dialog, control, field, notice, and progress styles into the batch user management dialog
- map generic dialog/form/status/action markup to the shared `data-*` contracts without changing workflow events or state transitions
- replace duplicated local palette and generic chrome with canonical Toolbox tokens
- keep the user-management table, operation selection, result presentation, and feature-specific layout local

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited