### PR TITLE
Migrate batch user onboarding UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/batch-user-onboarding/batch-user-onboarding-dialog.js
+++ b/src/content/main/features/batch-user-onboarding/batch-user-onboarding-dialog.js
@@ -1,11 +1,27 @@
 import { LitElement, html, nothing } from 'lit';
 import { componentFoundationStyles, dialogFoundationStyles } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    fieldStyles,
+    noticeStyles,
+    progressStyles
+} from '../../styles/primitives.js';
 import { batchUserOnboardingDialogStyles } from './batch-user-onboarding-dialog.styles.js';
 
 const BATCH_USER_ONBOARDING_DIALOG_TAG = 'edvibe-toolbox-batch-user-onboarding-dialog';
 
 class BatchUserOnboardingDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, batchUserOnboardingDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        noticeStyles,
+        progressStyles,
+        batchUserOnboardingDialogStyles
+    ];
 
     static properties = {
         options: {state: true},
@@ -277,38 +293,38 @@ class BatchUserOnboardingDialog extends LitElement {
         const reviewVisible = ['review', 'preflight', 'executing', 'complete', 'partial-complete'].includes(this.mode) && this.rows.length > 0;
         const completed = ['complete', 'partial-complete'].includes(this.mode);
         return html`
-<div class="overlay" @click=${(event) => { if (event.target === event.currentTarget) this.close(); }}>
-                <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="batch-user-onboarding-title">
+            <div class="overlay" data-part="overlay" @click=${(event) => { if (event.target === event.currentTarget) this.close(); }}>
+                <section class="dialog" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="batch-user-onboarding-title">
                     <header class="header"><div><p class="eyebrow">Edvibe Toolbox</p><h2 id="batch-user-onboarding-title">Добавить пользователей и назначить куратора</h2><p class="description">Проверьте весь список, подготовьте неизменяемый план и только потом подтвердите запись.</p></div>
-                        <button class="icon close" type="button" aria-label="Закрыть" ?disabled=${['loading', 'executing'].includes(this.mode)} @click=${() => this.close()}>×</button></header>
+                        <button class="icon close" data-control="secondary" type="button" aria-label="Закрыть" ?disabled=${['loading', 'executing'].includes(this.mode)} @click=${() => this.close()}>×</button></header>
                     <main class="body">
                         <section class="configure">
-                            <label class="field"><span>Email пользователей</span><textarea class="emails" rows="5" placeholder="user@example.com"
+                            <label class="field" data-field><span>Email пользователей</span><textarea class="emails" rows="5" placeholder="user@example.com"
                                 .value=${this.emailInput} ?disabled=${this.mode !== 'configure'}
                                 @input=${(event) => { this.emailInput = event.currentTarget.value; this.updateEmailCounts(); }}></textarea></label>
-                            <div class="email-state" aria-live="polite"><span class="valid-count">Уникальных email: ${this.emailCounts.valid}</span><span class="invalid-count">Некорректных: ${this.emailCounts.invalid}</span></div>
-                            <label class="field curator-field"><span>Целевой куратор</span>
+                            <div class="email-state" data-part="help" aria-live="polite"><span class="valid-count">Уникальных email: ${this.emailCounts.valid}</span><span class="invalid-count">Некорректных: ${this.emailCounts.invalid}</span></div>
+                            <label class="field curator-field" data-field><span>Целевой куратор</span>
                                 <select class="curator" .value=${this.targetModeratorId} ?disabled=${!['configure', 'review'].includes(this.mode)}
                                     @change=${(event) => { this.targetModeratorId = event.currentTarget.value; this.plan = null; }}>
                                     <option value="">Не выбран</option>
                                     ${(this.options?.moderators || []).map((moderator) => html`<option value=${String(moderator.id)}>${moderator.name ? `${moderator.name}${moderator.email ? ` · ${moderator.email}` : ''}` : moderator.email || `Moderator #${moderator.id}`}</option>`)}
-                                </select><small>Нужен только для строк с операцией назначения.</small></label>
+                                </select><small data-part="help">Нужен только для строк с операцией назначения.</small></label>
                         </section>
-                        <section class="errors" aria-live="polite" ?hidden=${this.errors.length === 0}>${this.errors.map((error) => html`<p>${error}</p>`)}</section>
+                        <section class="errors" data-notice="danger" aria-live="polite" ?hidden=${this.errors.length === 0}>${this.errors.map((error) => html`<p>${error}</p>`)}</section>
                         <section class="review" ?hidden=${!reviewVisible}><div class="review-toolbar"><strong class="review-count">${this.rows.length} строк</strong><span>Все операции по умолчанию выключены.</span></div>
-                            <div class="table-wrap"><table><thead><tr><th>Пользователь</th><th>Статус</th><th>Текущие кураторы</th><th>Добавить<button class="select-all-add" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('addSelected')}>Выбрать все</button></th><th>Назначить<button class="select-all-assign" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('assignSelected')}>Выбрать все</button></th><th>Проверка / результат</th></tr></thead><tbody class="rows">${this.rows.map((row) => this.renderRow(row))}</tbody></table></div>
+                            <div class="table-wrap"><table><thead><tr><th>Пользователь</th><th>Статус</th><th>Текущие кураторы</th><th>Добавить<button class="select-all-add" data-control="secondary" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('addSelected')}>Выбрать все</button></th><th>Назначить<button class="select-all-assign" data-control="secondary" type="button" ?disabled=${this.mode !== 'review'} @click=${() => this.selectAll('assignSelected')}>Выбрать все</button></th><th>Проверка / результат</th></tr></thead><tbody class="rows">${this.rows.map((row) => this.renderRow(row))}</tbody></table></div>
                         </section>
                         ${this.renderPreflight()}
-                        <section class="result" ?hidden=${!completed}><label class="field"><span>Отчёт</span><textarea class="report" rows="12" readonly .value=${this.report}></textarea></label>
-                            <div class="result-actions"><button class="copy secondary" type="button" @click=${() => this.options?.onCopy?.(this.report)}>Скопировать отчёт</button><button class="history secondary" type="button" ?hidden=${!this.executionId} @click=${() => this.executionId && this.options?.onOpenHistory?.(this.executionId)}>Открыть в истории</button></div></section>
+                        <section class="result" ?hidden=${!completed}><label class="field" data-field><span>Отчёт</span><textarea class="report" rows="12" readonly .value=${this.report}></textarea></label>
+                            <div class="result-actions" data-part="actions"><button class="copy secondary" data-control="secondary" type="button" @click=${() => this.options?.onCopy?.(this.report)}>Скопировать отчёт</button><button class="history secondary" data-control="secondary" type="button" ?hidden=${!this.executionId} @click=${() => this.executionId && this.options?.onOpenHistory?.(this.executionId)}>Открыть в истории</button></div></section>
                     </main>
-                    <div class="live-region"><p class="status" role="status" aria-live="polite">${this.statusMessage}</p><progress class="progress" max=${this.progress.total} value=${this.progress.completed} ?hidden=${!this.progress.visible}></progress></div>
-                    <footer class="footer">
-                        <button class="restart secondary" type="button" ?hidden=${!completed} @click=${this.restart}>Запустить другую группу</button>
-                        <button class="edit secondary" type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.returnToReview}>Изменить выбор</button>
-                        <button class="discover primary" type="button" ?hidden=${this.mode !== 'configure'} @click=${this.discover}>Проверить пользователей</button>
-                        <button class="prepare primary" type="button" ?hidden=${this.mode !== 'review'} @click=${this.preparePlan}>Подготовить план</button>
-                        <button class="execute primary" type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.execute}>Подтвердить и выполнить</button>
+                    <div class="live-region"><p class="status" data-part="status" role="status" aria-live="polite">${this.statusMessage}</p><progress class="progress" data-part="progress" max=${this.progress.total} value=${this.progress.completed} ?hidden=${!this.progress.visible}></progress></div>
+                    <footer class="footer" data-part="actions">
+                        <button class="restart secondary" data-control="secondary" type="button" ?hidden=${!completed} @click=${this.restart}>Запустить другую группу</button>
+                        <button class="edit secondary" data-control="secondary" type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.returnToReview}>Изменить выбор</button>
+                        <button class="discover primary" data-control type="button" ?hidden=${this.mode !== 'configure'} @click=${this.discover}>Проверить пользователей</button>
+                        <button class="prepare primary" data-control type="button" ?hidden=${this.mode !== 'review'} @click=${this.preparePlan}>Подготовить план</button>
+                        <button class="execute primary" data-control type="button" ?hidden=${this.mode !== 'preflight'} @click=${this.execute}>Подтвердить и выполнить</button>
                     </footer>
                 </section>
             </div>`;

--- a/src/content/main/features/batch-user-onboarding/batch-user-onboarding-dialog.styles.js
+++ b/src/content/main/features/batch-user-onboarding/batch-user-onboarding-dialog.styles.js
@@ -1,32 +1,8 @@
 import { css } from 'lit';
 
 export const batchUserOnboardingDialogStyles = css`
-:host {
-    all: initial;
-}
-
 [hidden] {
     display: none !important;
-}
-
-.overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 16px;
-    box-sizing: border-box;
-    background: rgba(15, 23, 42, .62);
-    color: #1f2937;
-    font-family: "Segoe UI", Arial, sans-serif;
-}
-
-.overlay *,
-.overlay *::before,
-.overlay *::after {
-    box-sizing: border-box;
 }
 
 .dialog {
@@ -35,9 +11,6 @@ export const batchUserOnboardingDialogStyles = css`
     width: min(1180px, calc(100vw - 32px));
     max-height: min(880px, calc(100vh - 32px));
     padding: 24px;
-    border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 24px 80px rgba(15, 23, 42, .38);
 }
 
 .header,
@@ -56,7 +29,7 @@ export const batchUserOnboardingDialogStyles = css`
 
 .eyebrow {
     margin: 0 0 4px;
-    color: #2563eb;
+    color: var(--edvibe-primary);
     font-size: 11px;
     font-weight: 750;
     letter-spacing: .08em;
@@ -65,26 +38,23 @@ export const batchUserOnboardingDialogStyles = css`
 
 .header h2 {
     margin: 0;
-    color: #111827;
+    color: var(--edvibe-text-strong);
     font-size: 21px;
     line-height: 1.3;
 }
 
 .description {
     margin: 5px 0 0;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 13px;
     line-height: 1.4;
 }
 
 .icon {
-    padding: 4px 8px;
-    border: 0;
-    background: transparent;
-    color: #6b7280;
+    min-width: 36px;
+    padding: 0;
     font-size: 24px;
     line-height: 1;
-    cursor: pointer;
 }
 
 .body {
@@ -101,37 +71,7 @@ export const batchUserOnboardingDialogStyles = css`
 }
 
 .field {
-    display: block;
-    color: #374151;
     font-size: 13px;
-    font-weight: 650;
-}
-
-.field > span {
-    display: block;
-    margin-bottom: 7px;
-}
-
-.field small {
-    display: block;
-    margin-top: 5px;
-    color: #6b7280;
-    font-size: 11px;
-    font-weight: 400;
-}
-
-.emails,
-.curator,
-.report {
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    background: #fff;
-    color: #111827;
-    font: inherit;
-    line-height: 1.45;
-    outline: none;
 }
 
 .emails,
@@ -153,8 +93,6 @@ export const batchUserOnboardingDialogStyles = css`
     flex-wrap: wrap;
     gap: 8px 16px;
     margin-top: -8px;
-    color: #6b7280;
-    font-size: 12px;
 }
 
 .curator-field {
@@ -164,12 +102,6 @@ export const batchUserOnboardingDialogStyles = css`
 
 .errors {
     margin-top: 14px;
-    padding: 10px 12px;
-    border: 1px solid #fecaca;
-    border-radius: 8px;
-    background: #fef2f2;
-    color: #b91c1c;
-    font-size: 13px;
 }
 
 .errors p {
@@ -184,33 +116,34 @@ export const batchUserOnboardingDialogStyles = css`
     justify-content: space-between;
     gap: 12px;
     margin-bottom: 8px;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 12px;
 }
 
 .review-toolbar strong {
-    color: #374151;
+    color: var(--edvibe-text);
 }
 
 .table-wrap {
     overflow: auto;
     max-height: 390px;
-    border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface);
 }
 
 table {
     width: 100%;
     min-width: 1020px;
     border-collapse: collapse;
-    color: #1f2937;
+    color: var(--edvibe-text);
     font-size: 12px;
 }
 
 th,
 td {
     padding: 10px 11px;
-    border-bottom: 1px solid #f1f5f9;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
     text-align: left;
     vertical-align: top;
 }
@@ -219,8 +152,8 @@ th {
     position: sticky;
     top: 0;
     z-index: 1;
-    background: #f8fafc;
-    color: #374151;
+    background: var(--edvibe-surface-subtle);
+    color: var(--edvibe-text);
     font-weight: 700;
 }
 
@@ -234,14 +167,10 @@ td:nth-child(5) {
 
 th button {
     display: block;
+    min-height: 28px;
     margin: 5px auto 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: #2563eb;
-    font: inherit;
+    padding: 4px 8px;
     font-size: 10px;
-    cursor: pointer;
 }
 
 td strong,
@@ -252,7 +181,7 @@ td small {
 
 td small {
     margin-top: 3px;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
 }
 
 .is-error,
@@ -261,33 +190,33 @@ td small {
 }
 
 .is-error {
-    color: #b91c1c;
+    color: var(--edvibe-danger);
 }
 
 .row-status {
     min-width: 190px;
-    color: #4b5563;
+    color: var(--edvibe-text-muted);
 }
 
 .preflight,
 .result {
     margin-top: 18px;
     padding: 14px;
-    border: 1px solid #dbeafe;
-    border-radius: 10px;
-    background: #f8fbff;
+    border: 1px solid var(--edvibe-info-border);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-info-surface);
 }
 
 .preflight h3 {
     margin: 0 0 7px;
-    color: #111827;
+    color: var(--edvibe-text-strong);
     font-size: 15px;
 }
 
 .preflight p,
 .preflight ul {
     margin: 7px 0 0;
-    color: #4b5563;
+    color: var(--edvibe-text-muted);
     font-size: 12px;
     line-height: 1.45;
 }
@@ -299,8 +228,6 @@ td small {
 }
 
 .result-actions {
-    justify-content: flex-end;
-    gap: 8px;
     margin-top: 10px;
 }
 
@@ -312,7 +239,6 @@ td small {
 .status {
     min-height: 20px;
     margin: 0;
-    color: #4b5563;
     font-size: 13px;
     line-height: 1.4;
 }
@@ -326,60 +252,14 @@ td small {
 
 .footer {
     flex: 0 0 auto;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 9px;
     margin-top: 18px;
 }
 
-.footer button,
-.result-actions button {
-    padding: 9px 14px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    font: inherit;
-    font-size: 12px;
-    font-weight: 650;
-    cursor: pointer;
-}
-
-.primary {
-    border-color: #2563eb !important;
-    background: #2563eb;
-    color: #fff;
-}
-
-.secondary {
-    background: #fff;
-    color: #374151;
-}
-
-button:disabled,
-textarea:disabled,
-select:disabled,
-input:disabled {
-    cursor: not-allowed;
-    opacity: .58;
-}
-
-button:focus-visible,
-textarea:focus-visible,
-select:focus-visible,
-input:focus-visible {
-    outline: 2px solid #2563eb;
-    outline-offset: 2px;
-}
-
 @media (max-width: 760px) {
-    .overlay {
-        padding: 8px;
-    }
-
     .dialog {
         width: 100%;
-        max-height: calc(100vh - 16px);
+        max-height: 100vh;
         padding: 18px;
-        border-radius: 12px;
     }
 
     .configure {


### PR DESCRIPTION
Closes #112

## Summary
- compose shared dialog, control, field, notice, and progress styles into the onboarding dialog
- migrate generic dialog/form/action/status markup to the shared `data-*` contracts while preserving the existing onboarding workflow and events
- replace duplicated local control/focus/dialog styling with canonical Toolbox tokens and primitives
- keep onboarding-specific review table, immutable preflight plan, report, and result presentation feature-owned

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited