### PR TITLE
Migrate batch section deletion UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/batch-section-deletion/batch-section-deletion-dialog.js
+++ b/src/content/main/features/batch-section-deletion/batch-section-deletion-dialog.js
@@ -1,11 +1,25 @@
 import { LitElement, html, nothing } from 'lit';
 import { componentFoundationStyles, dialogFoundationStyles } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    fieldStyles,
+    noticeStyles
+} from '../../styles/primitives.js';
 import { batchSectionDeletionDialogStyles } from './batch-section-deletion-dialog.styles.js';
 
 const BATCH_SECTION_DELETION_DIALOG_TAG = 'edvibe-toolbox-batch-section-deletion-dialog';
 
 class BatchSectionDeletionDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, batchSectionDeletionDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        noticeStyles,
+        batchSectionDeletionDialogStyles
+    ];
 
     static properties = {
         options: {state: true},
@@ -149,7 +163,7 @@ class BatchSectionDeletionDialog extends LitElement {
     renderPlan() {
         if (!this.plan) return nothing;
         return html`
-            <section class="preflight">
+            <section class="preflight" data-notice>
                 <h3>Preflight</h3>
                 <dl>
                     <div><dt>Selected</dt><dd>${this.plan.selectedCount}</dd></div>
@@ -168,20 +182,20 @@ class BatchSectionDeletionDialog extends LitElement {
         const lessons = this.options?.lessons || [];
         const canExecute = Boolean(this.plan?.eligible?.length) && !this.resultVisible;
         return html`
-<div class="overlay">
-                <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="title">
+            <div class="overlay" data-part="overlay">
+                <section class="dialog" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="title">
                     <header>
                         <div><h2 id="title">Delete section from lessons</h2><p>Every lesson is inspected before any deletion.</p></div>
-                        <button class="icon close" type="button" aria-label="Close" ?disabled=${this.busy}
+                        <button class="icon close" data-control="secondary" type="button" aria-label="Close" ?disabled=${this.busy}
                             @click=${() => this.close()}>×</button>
                     </header>
                     <main>
-                        <label>Exact section name<input class="section-name" type="text" autocomplete="off"
+                        <label data-field>Exact section name<input class="section-name" type="text" autocomplete="off"
                             placeholder="Ogłoszenie" .value=${this.sectionName} ?disabled=${this.busy}
                             @input=${(event) => { this.sectionName = event.currentTarget.value; }}></label>
-                        <div class="toolbar">
-                            <button class="select-all" type="button" ?disabled=${this.busy} @click=${this.selectAll}>Select all</button>
-                            <button class="clear" type="button" ?disabled=${this.busy} @click=${this.clearSelection}>Clear</button>
+                        <div class="toolbar" data-part="actions">
+                            <button class="select-all" data-control="secondary" type="button" ?disabled=${this.busy} @click=${this.selectAll}>Select all</button>
+                            <button class="clear" data-control="secondary" type="button" ?disabled=${this.busy} @click=${this.clearSelection}>Clear</button>
                             <span class="selection">${this.selectedLessonIds.size} selected</span>
                         </div>
                         <div class="lessons">
@@ -195,24 +209,24 @@ class BatchSectionDeletionDialog extends LitElement {
                                 </label>
                             `)}
                         </div>
-                        <div class="status" ?hidden=${!this.statusVisible}>${this.statusMessage}</div>
+                        <div class="status" data-notice ?hidden=${!this.statusVisible}>${this.statusMessage}</div>
                         ${this.renderPlan()}
                         <section class="result" ?hidden=${!this.resultVisible}>
-                            <textarea readonly .value=${this.resultReport}></textarea>
-                            <div class="result-actions">
-                                <button class="copy" type="button" ?disabled=${this.busy}
+                            <label data-field><span>Report</span><textarea readonly .value=${this.resultReport}></textarea></label>
+                            <div class="result-actions" data-part="actions">
+                                <button class="copy" data-control="secondary" type="button" ?disabled=${this.busy}
                                     @click=${() => this.options?.onCopy?.(this.resultReport)}>Copy report</button>
-                                <button class="history" type="button" ?hidden=${!this.executionId}
+                                <button class="history" data-control type="button" ?hidden=${!this.executionId}
                                     ?disabled=${this.busy} @click=${this.openHistory}>Open in history</button>
                             </div>
                         </section>
                     </main>
-                    <footer>
-                        <button class="secondary close" type="button" ?disabled=${this.busy}
+                    <footer data-part="actions">
+                        <button class="secondary close" data-control="secondary" type="button" ?disabled=${this.busy}
                             @click=${() => this.close()}>Cancel</button>
-                        <button class="inspect" type="button" ?hidden=${this.resultVisible} ?disabled=${this.busy}
+                        <button class="inspect" data-control type="button" ?hidden=${this.resultVisible} ?disabled=${this.busy}
                             @click=${this.inspect}>${this.plan ? 'Run preflight again' : 'Inspect selected lessons'}</button>
-                        <button class="danger execute" type="button" ?hidden=${!canExecute} ?disabled=${this.busy}
+                        <button class="danger execute" data-control="danger" type="button" ?hidden=${!canExecute} ?disabled=${this.busy}
                             @click=${this.execute}>Confirm deletion</button>
                     </footer>
                 </section>

--- a/src/content/main/features/batch-section-deletion/batch-section-deletion-dialog.styles.js
+++ b/src/content/main/features/batch-section-deletion/batch-section-deletion-dialog.styles.js
@@ -1,6 +1,144 @@
 import { css } from 'lit';
 
 export const batchSectionDeletionDialogStyles = css`
-:host{all:initial;font-family:Inter,system-ui,sans-serif;color:#202124}.overlay{position:fixed;inset:0;z-index:2147483647;background:rgba(16,20,30,.66);display:grid;place-items:center;padding:24px}.dialog{width:min(900px,96vw);max-height:92vh;background:#fff;border-radius:16px;box-shadow:0 24px 80px rgba(0,0,0,.35);display:flex;flex-direction:column;overflow:hidden}.dialog header,.dialog footer{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 22px;border-bottom:1px solid #e6e8ec}.dialog footer{border-bottom:0;border-top:1px solid #e6e8ec;justify-content:flex-end}.dialog h2,.dialog p{margin:0}.dialog p{margin-top:4px;color:#68707d}.dialog main{padding:20px 22px;overflow:auto;display:grid;gap:16px}label{display:grid;gap:6px;font-weight:600}input[type=text]{padding:10px 12px;border:1px solid #b9c0ca;border-radius:8px;font:inherit}.toolbar{display:flex;align-items:center;gap:8px}.selection{margin-left:auto;color:#68707d}.lessons{border:1px solid #dde1e7;border-radius:10px;max-height:280px;overflow:auto}.lesson{display:flex;grid-template-columns:none;align-items:center;gap:10px;padding:10px 12px;font-weight:400;border-bottom:1px solid #edf0f3}.lesson:last-child{border-bottom:0}.status{padding:10px 12px;background:#f3f5f8;border-radius:8px}.preflight,.result{border:1px solid #dde1e7;border-radius:10px;padding:14px}.preflight h3,.preflight h4{margin:0 0 8px}.preflight dl{display:flex;gap:20px;margin:0 0 14px}.preflight dl div{display:flex;gap:6px}.preflight dd{margin:0;font-weight:700}.preflight ul{margin:0 0 14px;padding-left:20px}.result textarea{box-sizing:border-box;width:100%;min-height:220px;resize:vertical;font:12px/1.5 ui-monospace,monospace}.result-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}.result-actions .history{background:#315efb;color:#fff}button{border:0;border-radius:8px;padding:9px 13px;font:600 14px/1.2 inherit;background:#eef1f5;color:#222;cursor:pointer}button:hover{filter:brightness(.97)}button:disabled{opacity:.5;cursor:not-allowed}.inspect{background:#315efb;color:#fff}.danger{background:#c62828;color:#fff}.secondary{background:#eef1f5}.icon{font-size:24px;line-height:1;padding:5px 9px;background:transparent}@media(max-width:640px){.overlay{padding:8px}.dialog{max-height:98vh}.dialog header,.dialog footer,.dialog main{padding:14px}.dialog footer{flex-wrap:wrap}.preflight dl{flex-wrap:wrap}}
+.dialog {
+    display: flex;
+    flex-direction: column;
+    width: min(900px, 96vw);
+    max-height: 92vh;
+}
 
+.dialog header,
+.dialog footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 22px;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
+}
+
+.dialog footer {
+    border-bottom: 0;
+    border-top: 1px solid var(--edvibe-border-subtle);
+}
+
+.dialog h2,
+.dialog p {
+    margin: 0;
+}
+
+.dialog header p {
+    margin-top: 4px;
+    color: var(--edvibe-text-muted);
+}
+
+.icon {
+    min-width: 36px;
+    padding: 0;
+    font-size: 24px;
+    line-height: 1;
+}
+
+.dialog main {
+    display: grid;
+    gap: 16px;
+    overflow: auto;
+    padding: 20px 22px;
+}
+
+.toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.selection {
+    margin-left: auto;
+    color: var(--edvibe-text-muted);
+}
+
+.lessons {
+    max-height: 280px;
+    overflow: auto;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface);
+}
+
+.lesson {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
+    font-weight: 400;
+}
+
+.lesson:last-child {
+    border-bottom: 0;
+}
+
+.preflight,
+.result {
+    padding: 14px;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+}
+
+.preflight {
+    border: 0;
+}
+
+.preflight h3,
+.preflight h4 {
+    margin: 0 0 8px;
+}
+
+.preflight dl {
+    display: flex;
+    gap: 20px;
+    margin: 0 0 14px;
+}
+
+.preflight dl div {
+    display: flex;
+    gap: 6px;
+}
+
+.preflight dd {
+    margin: 0;
+    font-weight: 700;
+}
+
+.preflight ul {
+    margin: 0 0 14px;
+    padding-left: 20px;
+}
+
+.result textarea {
+    min-height: 220px;
+    resize: vertical;
+    font: 12px/1.5 ui-monospace, monospace;
+}
+
+.result-actions {
+    margin-top: 8px;
+}
+
+@media(max-width:640px) {
+    .dialog {
+        max-height: 100vh;
+    }
+
+    .dialog header,
+    .dialog footer,
+    .dialog main {
+        padding: 14px;
+    }
+
+    .preflight dl {
+        flex-wrap: wrap;
+    }
+}
 `;


### PR DESCRIPTION
Closes #114

## Summary
- compose shared dialog, control, field, and notice primitives into section deletion
- migrate common dialog, form, status, report, and action markup to the shared `data-*` contracts
- replace the previous minified local generic UI rules with readable feature-specific styles backed by Toolbox tokens
- preserve lesson selection, preflight inspection, deletion confirmation, history navigation, and report behavior

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited