### PR TITLE
Migrate execution history UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/execution-history/execution-history-dialog.js
+++ b/src/content/main/features/execution-history/execution-history-dialog.js
@@ -3,6 +3,13 @@ import {
     componentFoundationStyles,
     dialogFoundationStyles
 } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    emptyStateStyles,
+    fieldStyles,
+    noticeStyles
+} from '../../styles/primitives.js';
 import { executionHistoryDialogStyles } from './execution-history-dialog.styles.js';
 
 const EXECUTION_HISTORY_DIALOG_TAG = 'edvibe-toolbox-execution-history-dialog';
@@ -48,7 +55,16 @@ function isExecutionInterruption(result) {
 }
 
 class ExecutionHistoryDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, executionHistoryDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        noticeStyles,
+        emptyStateStyles,
+        executionHistoryDialogStyles
+    ];
 
     static properties = {
         options: {state: true},
@@ -354,7 +370,7 @@ class ExecutionHistoryDialog extends LitElement {
         const record = this.selectedRecord;
         if (!record) {
             return html`
-                <div class="detail-placeholder">
+                <div class="detail-placeholder" data-part="empty-state">
                     <span aria-hidden="true">↗</span>
                     <h3>Select an execution</h3>
                     <p>Its summary and ordered item outcomes will appear here.</p>
@@ -375,9 +391,9 @@ class ExecutionHistoryDialog extends LitElement {
                     <h3>${record.operationType}</h3>
                     <p>${formatExecutionStatus(record.status)} · ${formatExecutionDate(record.completedAt)}</p>
                 </div>
-                <div class="detail-actions">
-                    <button type="button" class="secondary" @click=${() => this.handleAction('download-one')}>Download JSON</button>
-                    <button type="button" class="danger secondary" @click=${() => this.handleAction('delete-one')}>Delete</button>
+                <div class="detail-actions" data-part="actions">
+                    <button type="button" class="secondary" data-control="secondary" @click=${() => this.handleAction('download-one')}>Download JSON</button>
+                    <button type="button" class="danger secondary" data-control="danger" @click=${() => this.handleAction('delete-one')}>Delete</button>
                 </div>
             </section>
             <dl class="summary-grid">
@@ -412,31 +428,31 @@ class ExecutionHistoryDialog extends LitElement {
         const toastClass = `toast${this.toastError ? ' is-error' : ''}`;
 
         return html`
-<div class="overlay">
-                <section class="dialog" role="dialog" aria-modal="true" aria-labelledby="history-title">
+            <div class="overlay" data-part="overlay">
+                <section class="dialog" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="history-title">
                     <header class="dialog-header">
                         <div><p class="eyebrow">Edvibe Toolbox</p><h2 id="history-title">Execution history</h2><p class="header-copy">Browse terminal operation reports stored in this browser.</p></div>
-                        <button class="icon-button" type="button" data-action="close" aria-label="Close" @click=${() => this.handleAction('close')}>×</button>
+                        <button class="icon-button" data-control="secondary" type="button" data-action="close" aria-label="Close" @click=${() => this.handleAction('close')}>×</button>
                     </header>
                     <div class="workspace">
                         <aside class="browser-panel">
                             <form class="filters" data-role="filters" @submit=${(event) => { event.preventDefault(); this.loadRecords(); }}>
-                                <label>Operation<select name="operationType" .value=${this.filterOperationType} @change=${(event) => this.setFilter('operationType', event.currentTarget.value)}>
+                                <label data-field>Operation<select name="operationType" .value=${this.filterOperationType} @change=${(event) => this.setFilter('operationType', event.currentTarget.value)}>
                                     <option value="">All operations</option>
                                     ${this.operationTypes.map((operationType) => html`<option value=${operationType}>${operationType}</option>`)}
                                 </select></label>
-                                <label>Status<select name="status" .value=${this.filterStatus} @change=${(event) => this.setFilter('status', event.currentTarget.value)}>
+                                <label data-field>Status<select name="status" .value=${this.filterStatus} @change=${(event) => this.setFilter('status', event.currentTarget.value)}>
                                     <option value="">All statuses</option><option value="completed">Completed</option><option value="completed_with_failures">Completed with failures</option><option value="cancelled">Cancelled</option><option value="interrupted">Interrupted</option>
                                 </select></label>
-                                <label>Marathon<input name="marathonId" type="search" inputmode="numeric" placeholder="Any marathon" .value=${this.filterMarathonId} @input=${(event) => this.setFilter('marathonId', event.currentTarget.value)}></label>
+                                <label data-field>Marathon<input name="marathonId" type="search" inputmode="numeric" placeholder="Any marathon" .value=${this.filterMarathonId} @input=${(event) => this.setFilter('marathonId', event.currentTarget.value)}></label>
                                 <div class="date-fields">
-                                    <label>From<input name="from" type="date" .value=${this.filterFrom} @input=${(event) => this.setFilter('from', event.currentTarget.value)}></label>
-                                    <label>To<input name="to" type="date" .value=${this.filterTo} @input=${(event) => this.setFilter('to', event.currentTarget.value)}></label>
+                                    <label data-field>From<input name="from" type="date" .value=${this.filterFrom} @input=${(event) => this.setFilter('from', event.currentTarget.value)}></label>
+                                    <label data-field>To<input name="to" type="date" .value=${this.filterTo} @input=${(event) => this.setFilter('to', event.currentTarget.value)}></label>
                                 </div>
-                                <div class="filter-actions"><button type="submit">Apply</button><button type="button" class="secondary" @click=${() => this.handleAction('reset-filters')}>Reset</button></div>
+                                <div class="filter-actions" data-part="actions"><button data-control type="submit">Apply</button><button data-control="secondary" type="button" class="secondary" @click=${() => this.handleAction('reset-filters')}>Reset</button></div>
                             </form>
-                            <div class="list-toolbar"><strong data-role="record-count">${this.records.length} execution${this.records.length === 1 ? '' : 's'}</strong><button type="button" class="secondary compact" @click=${() => this.handleAction('export-filtered')}>Export filtered</button></div>
-                            <div class=${stateClass} data-role="state" ?hidden=${!stateVisible}>${this.listMessage}</div>
+                            <div class="list-toolbar"><strong data-role="record-count">${this.records.length} execution${this.records.length === 1 ? '' : 's'}</strong><button type="button" data-control="secondary" class="secondary compact" @click=${() => this.handleAction('export-filtered')}>Export filtered</button></div>
+                            <div class=${stateClass} data-part="empty-state" data-role="state" ?hidden=${!stateVisible}>${this.listMessage}</div>
                             <div class="record-list" data-role="record-list" ?hidden=${!listVisible}>${this.records.map((record) => this.renderRecord(record))}</div>
                         </aside>
                         <main class="detail-panel" data-role="detail">${this.renderDetail()}</main>
@@ -444,13 +460,13 @@ class ExecutionHistoryDialog extends LitElement {
                     <footer class="dialog-footer">
                         <details class="retention-settings"><summary>Retention & automatic export</summary><div class="settings-grid">
                             <label class="checkbox"><input type="checkbox" name="keepIndefinitely" .checked=${indefinite} @change=${(event) => this.updatePreference('mode', event.currentTarget.checked ? 'indefinite' : 'limits')}>Keep indefinitely</label>
-                            <label>Newest executions<input type="number" name="maxCount" min="1" step="1" .value=${String(this.preferences.maxCount)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxCount', event.currentTarget.value)}></label>
-                            <label>Maximum age, days<input type="number" name="maxAgeDays" min="1" step="1" .value=${String(this.preferences.maxAgeDays)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxAgeDays', event.currentTarget.value)}></label>
+                            <label data-field>Newest executions<input type="number" name="maxCount" min="1" step="1" .value=${String(this.preferences.maxCount)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxCount', event.currentTarget.value)}></label>
+                            <label data-field>Maximum age, days<input type="number" name="maxAgeDays" min="1" step="1" .value=${String(this.preferences.maxAgeDays)} ?disabled=${indefinite} @input=${(event) => this.updatePreference('maxAgeDays', event.currentTarget.value)}></label>
                             <label class="checkbox"><input type="checkbox" name="autoExport" .checked=${this.preferences.autoExport} @change=${(event) => this.updatePreference('autoExport', event.currentTarget.checked)}>Download JSON after persistence</label>
-                            <button type="button" @click=${() => this.handleAction('save-preferences')}>Save settings</button>
+                            <button type="button" data-control @click=${() => this.handleAction('save-preferences')}>Save settings</button>
                         </div></details>
-                        <div class="footer-actions"><button type="button" class="danger secondary" @click=${() => this.handleAction('clear-all')}>Clear all history</button><button type="button" @click=${() => this.handleAction('close')}>Close</button></div>
-                        <p class=${toastClass} data-role="toast" role="status" ?hidden=${!this.toastMessage}>${this.toastMessage}</p>
+                        <div class="footer-actions" data-part="actions"><button type="button" data-control="danger" class="danger secondary" @click=${() => this.handleAction('clear-all')}>Clear all history</button><button type="button" data-control @click=${() => this.handleAction('close')}>Close</button></div>
+                        <p class=${toastClass} data-notice=${this.toastError ? 'danger' : 'success'} data-role="toast" role="status" ?hidden=${!this.toastMessage}>${this.toastMessage}</p>
                     </footer>
                 </section>
             </div>

--- a/src/content/main/features/execution-history/execution-history-dialog.styles.js
+++ b/src/content/main/features/execution-history/execution-history-dialog.styles.js
@@ -2,28 +2,15 @@ import { css } from 'lit';
 
 export const executionHistoryDialogStyles = css`
 :host {
-    all: initial;
-    --history-accent: #5267e8;
-    --history-text: #172033;
-    --history-muted: #697386;
-    --history-border: #dfe4ee;
-    --history-surface: #ffffff;
+    --history-accent: var(--edvibe-primary);
+    --history-text: var(--edvibe-text);
+    --history-muted: var(--edvibe-text-muted);
+    --history-border: var(--edvibe-border-subtle);
+    --history-surface: var(--edvibe-surface);
     color: var(--history-text);
-    font-family: Inter, "Segoe UI", system-ui, sans-serif;
 }
 
-* { box-sizing: border-box; }
-button, input, select { font: inherit; }
-button { cursor: pointer; }
-
 .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483646;
-    display: grid;
-    place-items: center;
-    padding: 24px;
-    background: rgba(17, 24, 39, 0.62);
     backdrop-filter: blur(5px);
 }
 
@@ -32,121 +19,545 @@ button { cursor: pointer; }
     grid-template-rows: auto minmax(0, 1fr) auto;
     width: min(1180px, 96vw);
     height: min(820px, 94vh);
-    overflow: hidden;
-    border: 1px solid rgba(255,255,255,.5);
-    border-radius: 22px;
-    background: #f6f8fc;
-    box-shadow: 0 28px 80px rgba(0,0,0,.28);
+    background: var(--edvibe-surface-app);
 }
 
-.dialog-header, .dialog-footer {
+.dialog-header,
+.dialog-footer {
     padding: 20px 24px;
     background: var(--history-surface);
 }
+
 .dialog-header {
     display: flex;
     justify-content: space-between;
     gap: 24px;
     border-bottom: 1px solid var(--history-border);
 }
-.eyebrow { margin: 0 0 4px; color: var(--history-accent); font-size: 11px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
-h2, h3, h4, p { margin: 0; }
-h2 { font-size: 24px; letter-spacing: -.025em; }
-.header-copy { margin-top: 5px; color: var(--history-muted); font-size: 13px; }
-.icon-button { width: 38px; height: 38px; border: 0; border-radius: 12px; color: var(--history-muted); background: #f2f4f8; font-size: 25px; line-height: 1; }
-.icon-button:hover { color: var(--history-text); background: #e9edf5; }
 
-.workspace { display: grid; grid-template-columns: minmax(340px, 40%) minmax(0, 1fr); min-height: 0; }
-.browser-panel { display: flex; min-height: 0; flex-direction: column; padding: 18px; border-right: 1px solid var(--history-border); }
-.filters { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; padding: 14px; border: 1px solid var(--history-border); border-radius: 15px; background: var(--history-surface); }
-.filters label, .settings-grid label { display: grid; gap: 5px; color: var(--history-muted); font-size: 11px; font-weight: 700; }
-.filters input, .filters select, .settings-grid input { width: 100%; min-width: 0; padding: 9px 10px; border: 1px solid #d7ddea; border-radius: 9px; color: var(--history-text); background: #fff; }
-.date-fields { display: grid; grid-column: 1 / -1; grid-template-columns: 1fr 1fr; gap: 10px; }
-.filter-actions { display: flex; grid-column: 1 / -1; gap: 8px; }
-button { padding: 9px 13px; border: 1px solid var(--history-accent); border-radius: 9px; color: #fff; background: var(--history-accent); font-weight: 700; }
-button:hover { filter: brightness(.97); }
-button:focus-visible, input:focus-visible, select:focus-visible, summary:focus-visible { outline: 3px solid rgba(82, 103, 232, .25); outline-offset: 2px; }
-button.secondary { border-color: #d7ddea; color: #344054; background: #fff; }
-button.danger { border-color: #efcaca; color: #a33c3c; }
-button.compact { padding: 7px 9px; font-size: 11px; }
-.list-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 15px 2px 9px; }
-.list-toolbar strong { font-size: 12px; }
-.state-card { padding: 22px; border: 1px dashed #cfd6e4; border-radius: 14px; color: var(--history-muted); text-align: center; }
-.state-card.is-error, .toast.is-error { color: #9b3030; background: #fff0f0; }
-.record-list { min-height: 0; overflow: auto; padding-right: 4px; }
-.record-card { display: grid; width: 100%; gap: 5px; margin-bottom: 8px; padding: 13px; border: 1px solid var(--history-border); border-radius: 13px; color: var(--history-text); background: var(--history-surface); text-align: left; }
-.record-card:hover, .record-card[aria-pressed="true"] { border-color: #aeb9ee; box-shadow: 0 6px 20px rgba(42, 59, 130, .08); }
-.record-heading { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
-.record-heading strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.status-chip { display: inline-flex; flex: none; padding: 3px 7px; border-radius: 999px; color: #475467; background: #eef1f6; font-size: 10px; font-weight: 800; }
-.record-card[data-status="completed"] .status-chip { color: #196b4a; background: #ddf5e9; }
-.record-card[data-status="completed_with_failures"] .status-chip { color: #8b5b13; background: #fff0cf; }
-.record-card[data-status="interrupted"] .status-chip, .record-card[data-status="cancelled"] .status-chip { color: #943c3c; background: #fde7e7; }
-.record-context, .record-outcome, time { color: var(--history-muted); font-size: 11px; }
-time { margin-top: 2px; }
+.eyebrow {
+    margin: 0 0 4px;
+    color: var(--history-accent);
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+}
 
-.detail-panel { min-width: 0; overflow: auto; padding: 24px; background: #fff; }
-.detail-placeholder { display: grid; height: 100%; place-content: center; justify-items: center; color: var(--history-muted); text-align: center; }
-.detail-placeholder span { display: grid; width: 52px; height: 52px; place-items: center; margin-bottom: 12px; border-radius: 16px; color: var(--history-accent); background: #eef0ff; font-size: 24px; }
-.detail-placeholder h3 { color: var(--history-text); }
-.detail-placeholder p { margin-top: 5px; font-size: 12px; }
-.detail-header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; }
-.detail-header h3 { font-size: 20px; }
-.detail-header p { margin-top: 4px; color: var(--history-muted); font-size: 12px; }
-.detail-actions { display: flex; gap: 7px; }
-.summary-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 20px 0; }
-.summary-grid div { min-width: 0; padding: 12px; border: 1px solid var(--history-border); border-radius: 12px; background: #f9fafc; }
-.summary-grid dt { color: var(--history-muted); font-size: 10px; font-weight: 800; text-transform: uppercase; }
-.summary-grid dd { overflow-wrap: anywhere; margin: 5px 0 0; font-size: 12px; }
-.counts { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
-.counts div { display: grid; gap: 2px; padding: 11px; border-radius: 11px; background: #f1f3f8; }
-.counts strong { font-size: 18px; }
-.counts span { color: var(--history-muted); font-size: 10px; text-transform: capitalize; }
-.outcomes { margin-top: 22px; }
-.outcomes h4 { margin-bottom: 10px; }
-.outcome-card { margin-bottom: 8px; padding: 12px; border: 1px solid var(--history-border); border-radius: 12px; }
-.outcome-card > div { display: flex; justify-content: space-between; gap: 10px; }
-.outcome-card p { margin-top: 5px; color: #475467; font-size: 12px; line-height: 1.45; }
-.outcome-card small { display: block; margin-top: 6px; color: var(--history-muted); }
-.outcome-card details { margin-top: 9px; color: var(--history-muted); font-size: 11px; }
-.outcome-card pre { overflow: auto; margin: 7px 0 0; padding: 10px; border-radius: 9px; color: #344054; background: #f5f7fa; font: 11px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre-wrap; }
-.interruptions { margin-bottom: 22px; padding: 14px; border: 1px solid #efcaca; border-radius: 14px; background: #fff8f8; }
-.interruptions > .muted { margin: -4px 0 10px; }
-.diagnostics > summary { cursor: pointer; color: #475467; font-weight: 800; }
-.diagnostic-attempts { display: grid; gap: 10px; margin-top: 9px; }
-.diagnostic-attempt { min-width: 0; padding: 11px; border: 1px solid var(--history-border); border-radius: 10px; background: #fafbfc; }
-.diagnostic-metadata { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; }
-.diagnostic-metadata div { min-width: 0; }
-.diagnostic-metadata dt, .diagnostic-message strong, .diagnostic-summaries h5 { color: var(--history-muted); font-size: 10px; font-weight: 800; text-transform: uppercase; }
-.diagnostic-metadata dd { overflow-wrap: anywhere; margin: 2px 0 0; color: var(--history-text); }
-.diagnostic-message { margin-top: 10px; }
-.diagnostic-message p { overflow-wrap: anywhere; margin-top: 3px; }
-.diagnostic-summaries { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 10px; }
-.diagnostic-summaries section { min-width: 0; }
-.diagnostic-summaries h5 { margin: 0; }
-.diagnostic-summaries pre { max-width: 100%; max-height: 240px; overflow: auto; overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap; }
-.muted { color: var(--history-muted); font-size: 12px; }
+h2,
+h3,
+h4,
+p {
+    margin: 0;
+}
 
-.dialog-footer { border-top: 1px solid var(--history-border); }
-.retention-settings summary { cursor: pointer; color: #475467; font-size: 12px; font-weight: 800; }
-.settings-grid { display: grid; grid-template-columns: 1.2fr 1fr 1fr 1.5fr auto; gap: 10px; align-items: end; margin-top: 12px; }
-.settings-grid label.checkbox { display: flex; align-items: center; gap: 7px; padding-bottom: 9px; }
-.settings-grid label.checkbox input { width: auto; }
-.footer-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
-.toast { margin-top: 10px; padding: 8px 10px; border-radius: 9px; color: #196b4a; background: #e7f6ee; font-size: 11px; }
+h2 {
+    font-size: 24px;
+    letter-spacing: -.025em;
+}
+
+.header-copy {
+    margin-top: 5px;
+    color: var(--history-muted);
+    font-size: 13px;
+}
+
+.icon-button {
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    font-size: 25px;
+    line-height: 1;
+}
+
+.workspace {
+    display: grid;
+    grid-template-columns: minmax(340px, 40%) minmax(0, 1fr);
+    min-height: 0;
+}
+
+.browser-panel {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    padding: 18px;
+    border-right: 1px solid var(--history-border);
+}
+
+.filters {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    padding: 14px;
+    border: 1px solid var(--history-border);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--history-surface);
+}
+
+.filters [data-field],
+.settings-grid [data-field] {
+    font-size: 11px;
+}
+
+.date-fields {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+.filter-actions {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+}
+
+button.compact {
+    min-height: 32px;
+    padding: 6px 9px;
+    font-size: 11px;
+}
+
+.list-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 15px 2px 9px;
+}
+
+.list-toolbar strong {
+    font-size: 12px;
+}
+
+.state-card {
+    margin: 0;
+}
+
+.state-card.is-error {
+    border-color: var(--edvibe-danger-border);
+    color: var(--edvibe-danger);
+    background: var(--edvibe-danger-surface);
+}
+
+.record-list {
+    min-height: 0;
+    overflow: auto;
+    padding-right: 4px;
+}
+
+.record-card {
+    display: grid;
+    width: 100%;
+    gap: 5px;
+    margin-bottom: 8px;
+    padding: 13px;
+    border: 1px solid var(--history-border);
+    border-radius: var(--edvibe-radius-card);
+    color: var(--history-text);
+    background: var(--history-surface);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.record-card:hover,
+.record-card[aria-pressed="true"] {
+    border-color: var(--edvibe-info-border);
+    box-shadow: var(--edvibe-shadow-card);
+}
+
+.record-card:focus-visible,
+summary:focus-visible {
+    outline: 3px solid var(--edvibe-focus-outline);
+    outline-offset: 2px;
+}
+
+.record-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+}
+
+.record-heading strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.status-chip {
+    display: inline-flex;
+    flex: none;
+    padding: 3px 7px;
+    border-radius: var(--edvibe-radius-pill);
+    color: var(--history-muted);
+    background: var(--edvibe-surface-subtle);
+    font-size: 10px;
+    font-weight: 800;
+}
+
+.record-card[data-status="completed"] .status-chip {
+    color: var(--edvibe-success);
+    background: var(--edvibe-success-surface);
+}
+
+.record-card[data-status="completed_with_failures"] .status-chip {
+    color: var(--edvibe-warning);
+    background: var(--edvibe-warning-surface);
+}
+
+.record-card[data-status="interrupted"] .status-chip,
+.record-card[data-status="cancelled"] .status-chip {
+    color: var(--edvibe-danger);
+    background: var(--edvibe-danger-surface);
+}
+
+.record-context,
+.record-outcome,
+time {
+    color: var(--history-muted);
+    font-size: 11px;
+}
+
+time {
+    margin-top: 2px;
+}
+
+.detail-panel {
+    min-width: 0;
+    overflow: auto;
+    padding: 24px;
+    background: var(--history-surface);
+}
+
+.detail-placeholder {
+    display: grid;
+    height: 100%;
+    place-content: center;
+    justify-items: center;
+}
+
+.detail-placeholder span {
+    display: grid;
+    width: 52px;
+    height: 52px;
+    place-items: center;
+    margin-bottom: 12px;
+    border-radius: var(--edvibe-radius-panel);
+    color: var(--history-accent);
+    background: var(--edvibe-info-surface);
+    font-size: 24px;
+}
+
+.detail-placeholder h3 {
+    color: var(--history-text);
+}
+
+.detail-placeholder p {
+    margin-top: 5px;
+    font-size: 12px;
+}
+
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.detail-header h3 {
+    font-size: 20px;
+}
+
+.detail-header p {
+    margin-top: 4px;
+    color: var(--history-muted);
+    font-size: 12px;
+}
+
+.detail-actions {
+    flex-wrap: nowrap;
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin: 20px 0;
+}
+
+.summary-grid div {
+    min-width: 0;
+    padding: 12px;
+    border: 1px solid var(--history-border);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface-subtle);
+}
+
+.summary-grid dt {
+    color: var(--history-muted);
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.summary-grid dd {
+    overflow-wrap: anywhere;
+    margin: 5px 0 0;
+    font-size: 12px;
+}
+
+.counts {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+}
+
+.counts div {
+    display: grid;
+    gap: 2px;
+    padding: 11px;
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface-subtle);
+}
+
+.counts strong {
+    font-size: 18px;
+}
+
+.counts span {
+    color: var(--history-muted);
+    font-size: 10px;
+    text-transform: capitalize;
+}
+
+.outcomes {
+    margin-top: 22px;
+}
+
+.outcomes h4 {
+    margin-bottom: 10px;
+}
+
+.outcome-card {
+    margin-bottom: 8px;
+    padding: 12px;
+    border: 1px solid var(--history-border);
+    border-radius: var(--edvibe-radius-panel);
+}
+
+.outcome-card > div {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.outcome-card p {
+    margin-top: 5px;
+    color: var(--edvibe-text-muted);
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.outcome-card small {
+    display: block;
+    margin-top: 6px;
+    color: var(--history-muted);
+}
+
+.outcome-card details {
+    margin-top: 9px;
+    color: var(--history-muted);
+    font-size: 11px;
+}
+
+.outcome-card pre {
+    overflow: auto;
+    margin: 7px 0 0;
+    padding: 10px;
+    border-radius: var(--edvibe-radius-control);
+    color: var(--history-text);
+    background: var(--edvibe-surface-subtle);
+    font: 11px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
+    white-space: pre-wrap;
+}
+
+.interruptions {
+    margin-bottom: 22px;
+    padding: 14px;
+    border: 1px solid var(--edvibe-danger-border);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-danger-surface);
+}
+
+.interruptions > .muted {
+    margin: -4px 0 10px;
+}
+
+.diagnostics > summary {
+    cursor: pointer;
+    color: var(--edvibe-text-muted);
+    font-weight: 800;
+}
+
+.diagnostic-attempts {
+    display: grid;
+    gap: 10px;
+    margin-top: 9px;
+}
+
+.diagnostic-attempt {
+    min-width: 0;
+    padding: 11px;
+    border: 1px solid var(--history-border);
+    border-radius: var(--edvibe-radius-control);
+    background: var(--edvibe-surface-subtle);
+}
+
+.diagnostic-metadata {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin: 0;
+}
+
+.diagnostic-metadata div {
+    min-width: 0;
+}
+
+.diagnostic-metadata dt,
+.diagnostic-message strong,
+.diagnostic-summaries h5 {
+    color: var(--history-muted);
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.diagnostic-metadata dd {
+    overflow-wrap: anywhere;
+    margin: 2px 0 0;
+    color: var(--history-text);
+}
+
+.diagnostic-message {
+    margin-top: 10px;
+}
+
+.diagnostic-message p {
+    overflow-wrap: anywhere;
+    margin-top: 3px;
+}
+
+.diagnostic-summaries {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.diagnostic-summaries section {
+    min-width: 0;
+}
+
+.diagnostic-summaries h5 {
+    margin: 0;
+}
+
+.diagnostic-summaries pre {
+    max-width: 100%;
+    max-height: 240px;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+.muted {
+    color: var(--history-muted);
+    font-size: 12px;
+}
+
+.dialog-footer {
+    border-top: 1px solid var(--history-border);
+}
+
+.retention-settings summary {
+    cursor: pointer;
+    color: var(--edvibe-text-muted);
+    font-size: 12px;
+    font-weight: 800;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr 1fr 1.5fr auto;
+    gap: 10px;
+    align-items: end;
+    margin-top: 12px;
+}
+
+.settings-grid label.checkbox {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding-bottom: 9px;
+    color: var(--history-muted);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.settings-grid label.checkbox input {
+    width: auto;
+}
+
+.footer-actions {
+    margin-top: 14px;
+}
+
+.toast {
+    margin-top: 10px;
+    font-size: 11px;
+}
 
 @media (max-width: 840px) {
-    .overlay { padding: 0; }
-    .dialog { width: 100vw; height: 100vh; border-radius: 0; }
-    .workspace { grid-template-columns: 1fr; overflow: auto; }
-    .browser-panel { min-height: 450px; border-right: 0; border-bottom: 1px solid var(--history-border); }
-    .detail-panel { min-height: 500px; }
-    .diagnostic-metadata, .diagnostic-summaries { grid-template-columns: 1fr; }
-    .settings-grid { grid-template-columns: 1fr 1fr; }
+    .dialog {
+        width: 100vw;
+        height: 100vh;
+    }
+
+    .workspace {
+        grid-template-columns: 1fr;
+        overflow: auto;
+    }
+
+    .browser-panel {
+        min-height: 450px;
+        border-right: 0;
+        border-bottom: 1px solid var(--history-border);
+    }
+
+    .detail-panel {
+        min-height: 500px;
+    }
+
+    .diagnostic-metadata,
+    .diagnostic-summaries {
+        grid-template-columns: 1fr;
+    }
+
+    .settings-grid {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        transition: none !important;
+    }
 }
 
 `;


### PR DESCRIPTION
Closes #116

## Summary
- compose shared dialog, control, field, notice, and empty-state primitives into execution history
- migrate filters, common actions, list state, detail placeholder, retention fields, and toast roles to the shared `data-*` contracts
- replace history-local generic dialog/form/control palette with canonical Toolbox tokens
- keep record cards, status chips, outcome/diagnostic presentation, retention layout, and history interactions feature-owned

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited