### PR TITLE
Migrate marathon export UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/marathon-export/export-progress-dialog.js
+++ b/src/content/main/features/marathon-export/export-progress-dialog.js
@@ -3,12 +3,24 @@ import {
     componentFoundationStyles,
     dialogFoundationStyles
 } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    progressStyles
+} from '../../styles/primitives.js';
 import { exportProgressDialogStyles } from './export-progress-dialog.styles.js';
 
 const EXPORT_PROGRESS_TAG = 'edvibe-toolbox-export-progress';
 
 class ExportProgressDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, exportProgressDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        progressStyles,
+        exportProgressDialogStyles
+    ];
 
     static properties = {
         statusText: { state: true },
@@ -81,16 +93,16 @@ class ExportProgressDialog extends LitElement {
             : nothing;
 
         return html`
-            <div class="overlay">
-                <section class="card" role="dialog" aria-modal="true" aria-labelledby="export-progress-title">
+            <div class="overlay" data-part="overlay">
+                <section class="card" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="export-progress-title">
                     <h2 id="export-progress-title">Exporting marathon</h2>
-                    <p class="status">${this.statusText}</p>
-                    <progress class="progress" max="100" value=${progressValue}></progress>
+                    <p class="status" data-part="status">${this.statusText}</p>
+                    <progress class="progress" data-part="progress" max="100" value=${progressValue}></progress>
                     <div class="meta">
                         <span class="count">${count}</span>
                         <span class="percent">${progressPercent}%</span>
                     </div>
-                    <button class="close" type="button" @click=${() => this.remove()}>Close</button>
+                    <button class="close" data-control type="button" @click=${() => this.remove()}>Close</button>
                 </section>
             </div>
         `;

--- a/src/content/main/features/marathon-export/export-progress-dialog.styles.js
+++ b/src/content/main/features/marathon-export/export-progress-dialog.styles.js
@@ -1,79 +1,53 @@
 import { css } from 'lit';
 
 export const exportProgressDialogStyles = css`
-:host {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    font-family: "Segoe UI", Arial, sans-serif;
-}
-
-.overlay {
-    display: flex;
-    width: 100%;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-    background: rgba(15, 23, 42, 0.55);
-}
-
 .card {
     width: min(630px, calc(100vw - 32px));
     padding: 24px;
-    border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 24px 80px rgba(15, 23, 42, 0.35);
-    color: #1f2937;
 }
 
-h2 { margin: 0 0 8px; color: #111827; font-size: 20px; line-height: 1.3; }
+h2 {
+    margin: 0 0 8px;
+    color: var(--edvibe-text-strong);
+    font-size: 20px;
+    line-height: 1.3;
+}
+
 .status {
     min-height: 40px;
     margin: 0 0 16px;
-    color: #4b5563;
     font-size: 14px;
     line-height: 1.4;
     white-space: pre-line;
 }
+
 .progress {
-    display: block;
-    width: 100%;
     height: 12px;
-    overflow: hidden;
-    border: 0;
-    border-radius: 999px;
-    background: #e5e7eb;
-    appearance: none;
 }
-.progress::-webkit-progress-bar { background: #e5e7eb; }
-.progress::-webkit-progress-value {
-    border-radius: 999px;
-    background: linear-gradient(90deg, #3498db, #22c55e);
-    transition: width 0.25s ease;
+
+:host([error]) .progress {
+    accent-color: var(--edvibe-danger);
 }
-:host([error]) .progress::-webkit-progress-value { background: #e74c3c; }
+
 .meta {
     display: flex;
     justify-content: space-between;
     gap: 16px;
     margin-top: 10px;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 12px;
 }
+
 .close {
     display: none;
     width: 100%;
     margin-top: 18px;
-    padding: 9px 12px;
-    border: 0;
-    border-radius: 8px;
-    background: #3498db;
-    color: #fff;
-    cursor: pointer;
     font-size: 13px;
-    font-weight: 600;
 }
+
 :host([complete]) .close,
-:host([error]) .close { display: block; }
+:host([error]) .close {
+    display: block;
+}
 
 `;


### PR DESCRIPTION
Closes #117

## Summary
- compose shared dialog, control, and progress primitives into marathon export progress
- migrate overlay, dialog card, status, progress, and dismiss control to the shared `data-*` contracts
- remove duplicated local dialog, button, and progress-track styling in favor of canonical Toolbox foundations
- keep export-specific status copy, progress metadata, compact layout, and error accent feature-owned

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited