### PR TITLE
Migrate reset lessons UI to Toolbox design primitives

### DIFF
--- a/src/content/main/features/reset-lessons/reset-lessons-dialog.js
+++ b/src/content/main/features/reset-lessons/reset-lessons-dialog.js
@@ -3,13 +3,29 @@ import {
     componentFoundationStyles,
     dialogFoundationStyles
 } from '../../styles/foundations.js';
+import {
+    controlStyles,
+    dialogShellStyles,
+    emptyStateStyles,
+    fieldStyles,
+    progressStyles
+} from '../../styles/primitives.js';
 import { resetLessonsDialogStyles } from './reset-lessons-dialog.styles.js';
 
 const RESET_DIALOG_TAG = 'edvibe-toolbox-reset-dialog';
 const RESET_OVERLAY_ID = 'edvibe-toolbox-reset-overlay';
 
 class ResetLessonsDialog extends LitElement {
-    static styles = [componentFoundationStyles, dialogFoundationStyles, resetLessonsDialogStyles];
+    static styles = [
+        componentFoundationStyles,
+        dialogFoundationStyles,
+        dialogShellStyles,
+        controlStyles,
+        fieldStyles,
+        progressStyles,
+        emptyStateStyles,
+        resetLessonsDialogStyles
+    ];
 
     static properties = {
         currentStep: { state: true },
@@ -279,7 +295,7 @@ class ResetLessonsDialog extends LitElement {
 
     renderPupilRows() {
         const visiblePupils = this.filterPupils(this.appliedSearchQuery);
-        if (visiblePupils.length === 0) return html`<p class="edvibe-reset-empty">Пользователи не найдены.</p>`;
+        if (visiblePupils.length === 0) return html`<p class="edvibe-reset-empty" data-part="empty-state">Пользователи не найдены.</p>`;
         const busy = this.isPupilLoadingVisible();
         return visiblePupils.map((pupil) => {
             const selected = pupil.PupilId === this.selectedPupil?.PupilId;
@@ -288,7 +304,7 @@ class ResetLessonsDialog extends LitElement {
         });
     }
     renderLessonRows(inputsBlocked) {
-        if (this.lessons.length === 0) return html`<p class="edvibe-reset-empty">Для пользователя нет уроков.</p>`;
+        if (this.lessons.length === 0) return html`<p class="edvibe-reset-empty" data-part="empty-state">Для пользователя нет уроков.</p>`;
         return this.lessons.map((lesson) => html`<label class="edvibe-reset-row edvibe-reset-lesson"><input type="checkbox" .value=${String(lesson.MarathonLessonId)} .checked=${this.selectedLessonIds.has(lesson.MarathonLessonId)} ?disabled=${inputsBlocked} @change=${(event) => this.toggleLesson(lesson.MarathonLessonId, event.currentTarget.checked)}><span class="edvibe-reset-row-copy"><span class="edvibe-reset-row-name">${Number(lesson.Number) + 1}. ${lesson.Name}</span><span class="edvibe-reset-row-email">${lesson.LastRequest ? `Статус последнего запроса: ${lesson.LastRequest.Status}` : 'Нет запросов на проверку'}</span></span></label>`);
     }
     render() {
@@ -300,15 +316,15 @@ class ResetLessonsDialog extends LitElement {
         const progressValue = this.progressIndeterminate ? nothing : this.progressValue;
         const selectedPupilLabel = this.selectedPupil ? `${this.selectedPupil.Name || 'Без имени'} — ${this.selectedPupil.Email || ''}` : '';
         return html`
-<div class="edvibe-reset-overlay" @click=${this.handleBackdropClick}>
-                <div class="edvibe-reset-card" role="dialog" aria-modal="true" aria-labelledby="edvibe-reset-title">
-                    <div class="edvibe-reset-header"><div><h2 id="edvibe-reset-title" class="edvibe-reset-title">Сброс уроков</h2><p class="edvibe-reset-subtitle"><span class="edvibe-reset-step-indicator">${view.showingUsers ? 'Шаг 1 из 2' : 'Шаг 2 из 2'}</span><span class="edvibe-reset-step-description">${view.showingUsers ? 'Выберите пользователя.' : 'Выберите уроки для сброса прогресса.'}</span></p></div><button class="edvibe-reset-close" type="button" aria-label="Закрыть" ?disabled=${view.closeDisabled} @click=${() => this.close()}>&times;</button></div>
+            <div class="edvibe-reset-overlay" data-part="overlay" @click=${this.handleBackdropClick}>
+                <div class="edvibe-reset-card" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="edvibe-reset-title">
+                    <div class="edvibe-reset-header"><div><h2 id="edvibe-reset-title" class="edvibe-reset-title">Сброс уроков</h2><p class="edvibe-reset-subtitle"><span class="edvibe-reset-step-indicator">${view.showingUsers ? 'Шаг 1 из 2' : 'Шаг 2 из 2'}</span><span class="edvibe-reset-step-description">${view.showingUsers ? 'Выберите пользователя.' : 'Выберите уроки для сброса прогресса.'}</span></p></div><button class="edvibe-reset-close" data-control="secondary" type="button" aria-label="Закрыть" ?disabled=${view.closeDisabled} @click=${() => this.close()}>&times;</button></div>
                     <div class="edvibe-reset-body">
-                        <section class="edvibe-reset-user-step" aria-label="Выбор пользователя" ?hidden=${!view.showingUsers}><label class="edvibe-reset-label" for="edvibe-reset-search">Поиск по email</label><input id="edvibe-reset-search" class="edvibe-reset-search" type="search" placeholder="user@example.com" autocomplete="off" .value=${this.searchValue} ?disabled=${inputsBlocked} @input=${this.handleSearchInput}><div class=${`edvibe-reset-pupils-shell${pupilBusy ? ' is-loading' : ''}`}><div class="edvibe-reset-list edvibe-reset-pupils" role="listbox" aria-label="Пользователи марафона" aria-busy=${String(pupilBusy)} .inert=${pupilBusy} @scroll=${this.handlePupilsScroll}>${this.renderPupilRows()}</div><div class="edvibe-reset-pupils-loading" role="status" aria-live="polite" ?hidden=${!pupilBusy}><span class="edvibe-reset-spinner" aria-hidden="true"></span><span>Загрузка пользователей...</span></div></div></section>
+                        <section class="edvibe-reset-user-step" aria-label="Выбор пользователя" ?hidden=${!view.showingUsers}><div class="edvibe-reset-search-field" data-field><label class="edvibe-reset-label" for="edvibe-reset-search">Поиск по email</label><input id="edvibe-reset-search" class="edvibe-reset-search" type="search" placeholder="user@example.com" autocomplete="off" .value=${this.searchValue} ?disabled=${inputsBlocked} @input=${this.handleSearchInput}></div><div class=${`edvibe-reset-pupils-shell${pupilBusy ? ' is-loading' : ''}`}><div class="edvibe-reset-list edvibe-reset-pupils" role="listbox" aria-label="Пользователи марафона" aria-busy=${String(pupilBusy)} .inert=${pupilBusy} @scroll=${this.handlePupilsScroll}>${this.renderPupilRows()}</div><div class="edvibe-reset-pupils-loading" role="status" aria-live="polite" ?hidden=${!pupilBusy}><span class="edvibe-reset-spinner" aria-hidden="true"></span><span>Загрузка пользователей...</span></div></div></section>
                         <section class="edvibe-reset-lesson-step" aria-label="Выбор уроков" ?hidden=${view.showingUsers}><div class="edvibe-reset-label edvibe-reset-selected-pupil">${selectedPupilLabel}</div><label class="edvibe-reset-select-all"><input class="edvibe-reset-select-all-input" type="checkbox" .checked=${selectAllChecked} .indeterminate=${selectAllIndeterminate} ?disabled=${inputsBlocked || this.lessons.length === 0} @change=${this.handleSelectAll}>Выбрать все уроки</label><div class="edvibe-reset-list edvibe-reset-lessons" aria-label="Уроки пользователя" tabindex="-1">${this.renderLessonRows(inputsBlocked)}</div></section>
                     </div>
-                    <div class="edvibe-reset-live-region"><p class=${statusClass} aria-live="polite">${this.statusMessage}</p><progress class=${progressClass} max="100" value=${progressValue}></progress></div>
-                    <div class="edvibe-reset-footer"><button class="edvibe-reset-button edvibe-reset-cancel" type="button" ?disabled=${view.closeDisabled} @click=${() => this.close()}>Закрыть</button><button class="edvibe-reset-button edvibe-reset-back" type="button" ?hidden=${view.showingUsers} ?disabled=${view.backDisabled} @click=${this.handleBack}>${this.finished ? 'Сбросить для другого пользователя' : 'Назад'}</button><button class="edvibe-reset-button edvibe-reset-next" type="button" ?hidden=${!view.showingUsers} ?disabled=${view.nextDisabled} @click=${this.handleNext}>Далее</button><button class="edvibe-reset-button edvibe-reset-submit" type="button" ?hidden=${view.showingUsers} ?disabled=${view.submitDisabled} @click=${this.handleSubmit}>Сбросить прогресс</button></div>
+                    <div class="edvibe-reset-live-region"><p class=${statusClass} data-part="status" aria-live="polite">${this.statusMessage}</p><progress class=${progressClass} data-part="progress" max="100" value=${progressValue}></progress></div>
+                    <div class="edvibe-reset-footer" data-part="actions"><button class="edvibe-reset-button edvibe-reset-cancel" data-control="secondary" type="button" ?disabled=${view.closeDisabled} @click=${() => this.close()}>Закрыть</button><button class="edvibe-reset-button edvibe-reset-back" data-control="secondary" type="button" ?hidden=${view.showingUsers} ?disabled=${view.backDisabled} @click=${this.handleBack}>${this.finished ? 'Сбросить для другого пользователя' : 'Назад'}</button><button class="edvibe-reset-button edvibe-reset-next" data-control type="button" ?hidden=${!view.showingUsers} ?disabled=${view.nextDisabled} @click=${this.handleNext}>Далее</button><button class="edvibe-reset-button edvibe-reset-submit" data-control="danger" type="button" ?hidden=${view.showingUsers} ?disabled=${view.submitDisabled} @click=${this.handleSubmit}>Сбросить прогресс</button></div>
                 </div>
             </div>`;
     }

--- a/src/content/main/features/reset-lessons/reset-lessons-dialog.styles.js
+++ b/src/content/main/features/reset-lessons/reset-lessons-dialog.styles.js
@@ -1,36 +1,12 @@
 import { css } from 'lit';
 
 export const resetLessonsDialogStyles = css`
-:host {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: block;
-    font-family: "Segoe UI", Arial, sans-serif;
-}
-
 :host([hidden]) {
     display: none !important;
 }
 
 :host(.is-running) .edvibe-reset-body {
     display: none;
-}
-
-.edvibe-reset-overlay {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 16px;
-    background: rgba(15, 23, 42, .6);
-    box-sizing: border-box;
-}
-
-.edvibe-reset-overlay *,
-.edvibe-reset-overlay {
-    box-sizing: border-box;
 }
 
 [hidden] {
@@ -43,10 +19,6 @@ export const resetLessonsDialogStyles = css`
     width: min(760px, calc(100vw - 32px));
     max-height: min(820px, calc(100vh - 32px));
     padding: 24px;
-    border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 24px 80px rgba(15, 23, 42, .38);
-    color: #1f2937;
 }
 
 .edvibe-reset-header {
@@ -58,31 +30,28 @@ export const resetLessonsDialogStyles = css`
 
 .edvibe-reset-title {
     margin: 0;
-    color: #111827;
+    color: var(--edvibe-text-strong);
     font-size: 21px;
     line-height: 1.3;
 }
 
 .edvibe-reset-subtitle {
     margin: 5px 0 0;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 13px;
 }
 
 .edvibe-reset-step-indicator {
     margin-right: 8px;
-    color: #2563eb;
+    color: var(--edvibe-primary);
     font-weight: 700;
 }
 
 .edvibe-reset-close {
-    border: 0;
-    padding: 4px 8px;
-    background: transparent;
-    color: #6b7280;
+    min-width: 36px;
+    padding: 0;
     font-size: 24px;
     line-height: 1;
-    cursor: pointer;
 }
 
 .edvibe-reset-body {
@@ -92,34 +61,25 @@ export const resetLessonsDialogStyles = css`
     margin-top: 18px;
 }
 
+.edvibe-reset-search-field {
+    font-size: 13px;
+}
+
 .edvibe-reset-label {
     display: block;
     margin-bottom: 7px;
-    color: #374151;
+    color: var(--edvibe-text);
     font-size: 13px;
     font-weight: 650;
-}
-
-.edvibe-reset-search {
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 8px;
-    outline: none;
-    font: inherit;
-}
-
-.edvibe-reset-search:focus {
-    border-color: #3498db;
-    box-shadow: 0 0 0 3px rgba(52, 152, 219, .15);
 }
 
 .edvibe-reset-list {
     overflow: auto;
     max-height: 250px;
     margin-top: 10px;
-    border: 1px solid #e5e7eb;
-    border-radius: 10px;
+    border: 1px solid var(--edvibe-border-subtle);
+    border-radius: var(--edvibe-radius-panel);
+    background: var(--edvibe-surface);
 }
 
 .edvibe-reset-pupils-shell {
@@ -142,9 +102,9 @@ export const resetLessonsDialogStyles = css`
     align-items: center;
     justify-content: center;
     gap: 10px;
-    border-radius: 10px;
-    background: rgba(255, 255, 255, .48);
-    color: #374151;
+    border-radius: var(--edvibe-radius-panel);
+    background: color-mix(in srgb, var(--edvibe-surface) 72%, transparent);
+    color: var(--edvibe-text);
     font-size: 13px;
     font-weight: 650;
 }
@@ -152,8 +112,8 @@ export const resetLessonsDialogStyles = css`
 .edvibe-reset-spinner {
     width: 22px;
     height: 22px;
-    border: 3px solid #bfdbfe;
-    border-top-color: #2563eb;
+    border: 3px solid var(--edvibe-info-border);
+    border-top-color: var(--edvibe-primary);
     border-radius: 50%;
     animation: edvibe-reset-spinner-rotate .8s linear infinite;
 }
@@ -165,9 +125,10 @@ export const resetLessonsDialogStyles = css`
     gap: 10px;
     padding: 11px 12px;
     border: 0;
-    border-bottom: 1px solid #f1f5f9;
-    background: #fff;
-    color: #1f2937;
+    border-bottom: 1px solid var(--edvibe-border-subtle);
+    background: var(--edvibe-surface);
+    color: var(--edvibe-text);
+    font: inherit;
     text-align: left;
     cursor: pointer;
 }
@@ -178,7 +139,17 @@ export const resetLessonsDialogStyles = css`
 
 .edvibe-reset-row:hover,
 .edvibe-reset-row.is-selected {
-    background: #eff6ff;
+    background: var(--edvibe-info-surface);
+}
+
+.edvibe-reset-row:focus-visible {
+    outline: 3px solid var(--edvibe-focus-outline);
+    outline-offset: -3px;
+}
+
+.edvibe-reset-row:disabled {
+    cursor: not-allowed;
+    opacity: .58;
 }
 
 .edvibe-reset-row-copy {
@@ -200,7 +171,7 @@ export const resetLessonsDialogStyles = css`
 
 .edvibe-reset-row-email {
     margin-top: 2px;
-    color: #6b7280;
+    color: var(--edvibe-text-muted);
     font-size: 12px;
 }
 
@@ -211,6 +182,11 @@ export const resetLessonsDialogStyles = css`
     margin-bottom: 8px;
     font-size: 13px;
     font-weight: 650;
+}
+
+.edvibe-reset-select-all input:disabled {
+    cursor: not-allowed;
+    opacity: .58;
 }
 
 .edvibe-reset-lesson {
@@ -224,16 +200,11 @@ export const resetLessonsDialogStyles = css`
 
 .edvibe-reset-empty {
     margin: 0;
-    padding: 22px;
-    color: #6b7280;
-    text-align: center;
-    font-size: 13px;
 }
 
 .edvibe-reset-status {
     min-height: 38px;
     margin: 0;
-    color: #4b5563;
     font-size: 13px;
     line-height: 1.4;
     white-space: pre-line;
@@ -245,88 +216,30 @@ export const resetLessonsDialogStyles = css`
 }
 
 .edvibe-reset-status.is-error {
-    color: #b91c1c;
+    color: var(--edvibe-danger);
 }
 
 .edvibe-reset-status.is-success {
-    color: #15803d;
+    color: var(--edvibe-success);
 }
 
 .edvibe-reset-progress {
     display: none;
-    width: 100%;
-    overflow: hidden;
     height: 11px;
-    border: 0;
     margin-top: 10px;
-    border-radius: 999px;
-    background: #e5e7eb;
-    appearance: none;
+    accent-color: var(--edvibe-danger);
 }
 
 .edvibe-reset-progress.is-visible {
     display: block;
 }
 
-.edvibe-reset-progress::-webkit-progress-bar {
-    background: #e5e7eb;
-}
-
-.edvibe-reset-progress::-webkit-progress-value {
-    border-radius: 999px;
-    background: linear-gradient(90deg, #e74c3c, #f59e0b);
-    transition: width .2s ease;
-}
-
 .edvibe-reset-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
     margin-top: 18px;
 }
 
 .edvibe-reset-button {
-    padding: 10px 16px;
-    border: 0;
-    border-radius: 8px;
-    color: #fff;
     font-size: 13px;
-    font-weight: 650;
-    cursor: pointer;
-}
-
-.edvibe-reset-button:disabled,
-button:disabled,
-input:disabled {
-    cursor: not-allowed;
-    opacity: .58;
-}
-
-.edvibe-reset-cancel,
-.edvibe-reset-back {
-    background: #64748b;
-}
-
-.edvibe-reset-next {
-    background: #2563eb;
-}
-
-.edvibe-reset-submit {
-    background: #e74c3c;
-}
-
-@keyframes edvibe-reset-progress-slide {
-    0% {
-        transform: translateX(-120%)
-    }
-
-    50% {
-        transform: translateX(90%)
-    }
-
-    100% {
-        transform: translateX(270%)
-    }
 }
 
 @keyframes edvibe-reset-spinner-rotate {


### PR DESCRIPTION
Closes #118

## Summary
- compose shared dialog, control, field, progress, and empty-state primitives into reset lessons
- migrate the dialog shell, email search, status/progress region, empty states, and footer actions to the shared `data-*` contracts
- replace duplicated local dialog/form/button/progress styling with canonical Toolbox tokens and shared behavior
- keep pupil/lesson rows, loading overlay, two-step navigation, selection, and destructive reset workflow feature-owned

## Validation
- GitHub Actions is expected to run lint, tests, production build, and build-output checks
- no generated `dist/` files were edited