### PR TITLE
Diagnose unavailable auth context in batch section image uploads

### DIFF
--- a/src/content/main/features/batch-section-creation/batch-section-creation-history-record.js
+++ b/src/content/main/features/batch-section-creation/batch-section-creation-history-record.js
@@ -88,6 +88,7 @@ function serializeResult(result, definitionSummary, terminalStatus) {
     const normalizedResult = { ...result, status };
     const code = resultCode(normalizedResult, terminalStatus);
     const message = resultMessage(normalizedResult, terminalStatus);
+    const diagnostics = historyDiagnostics(result);
     return Object.freeze({
         itemId: lesson.lessonId === null ? null : String(lesson.lessonId),
         label: `${lesson.number ?? '?'}. ${lesson.name}`,
@@ -95,7 +96,7 @@ function serializeResult(result, definitionSummary, terminalStatus) {
         code,
         message,
         attempts,
-        ...(historyDiagnostics(result) ? { diagnostics: historyDiagnostics(result) } : {}),
+        ...(diagnostics ? { diagnostics } : {}),
         data: Object.freeze({
             lesson,
             section: definitionSummary,
@@ -126,6 +127,24 @@ function inferTerminalStatus(explicitStatus, fatalError, results) {
         : 'completed';
 }
 
+function attachFatalDiagnostics(results, fatalError) {
+    const diagnostics = historyDiagnostics(fatalError);
+    if (!diagnostics) return results;
+    let attached = false;
+    return results.map((result) => {
+        if (
+            attached
+            || !modelApi.isFailureStatus(result?.status)
+            || historyDiagnostics(result)
+            || (fatalError?.code && result?.code !== fatalError.code)
+        ) {
+            return result;
+        }
+        attached = true;
+        return { ...result, diagnostics };
+    });
+}
+
 function buildExecutionHistoryInput({
     plan,
     result = {},
@@ -142,7 +161,10 @@ function buildExecutionHistoryInput({
     const definitionSummary = modelApi.serializeSectionDefinition(
         plan?.definition || result?.definition || {}
     );
-    const materialized = modelApi.materializeResults(plan, result, materializationStatus);
+    const materialized = attachFatalDiagnostics(
+        modelApi.materializeResults(plan, result, materializationStatus),
+        fatalError || result?.fatalError
+    );
     const results = materialized.map((entry) => serializeResult(
         entry,
         definitionSummary,
@@ -172,5 +194,6 @@ export {
     serializeCleanup,
     serializeResult,
     inferTerminalStatus,
+    attachFatalDiagnostics,
     buildExecutionHistoryInput
 };

--- a/src/content/main/features/batch-section-creation/batch-section-creation-history-record.test.js
+++ b/src/content/main/features/batch-section-creation/batch-section-creation-history-record.test.js
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { serializeIdentifiers, serializeSectionDefinition } from '#src/content/main/features/batch-section-creation/batch-section-creation-history-model.js';
-import { serializeResult } from '#src/content/main/features/batch-section-creation/batch-section-creation-history-record.js';
+import {
+    buildExecutionHistoryInput,
+    serializeResult
+} from '#src/content/main/features/batch-section-creation/batch-section-creation-history-record.js';
 
 function attempt(correlationId, requestId, transportCode = 'SERVER_REJECTED') {
     return {
@@ -46,6 +49,62 @@ test('preserves server rejection and transport failure diagnostics for recipe re
         assert.equal(result.diagnostics.requestAttempts[0].requestId, id);
         assert.equal(result.diagnostics.requestAttempts[0].correlationId, 'lesson:1');
     }
+});
+
+test('attaches fatal diagnostics after execution-result materialization', () => {
+    const fatalError = Object.assign(new Error('Authorization unavailable'), {
+        code: 'AUTH_CONTEXT_UNAVAILABLE',
+        diagnostics: {
+            requestAttempts: [attempt(
+                'media-upload-auth-context',
+                null,
+                'AUTH_CONTEXT_UNAVAILABLE'
+            )]
+        }
+    });
+    const history = buildExecutionHistoryInput({
+        plan: {
+            definition: {
+                name: 'Announcement',
+                blocks: [{
+                    id: 'block-1',
+                    type: 'image',
+                    url: 'https://media-files-y.edvibe.com/local-upload/client-1'
+                }]
+            },
+            selectedLessonIds: [1],
+            eligible: [{
+                lessonId: 1,
+                marathonLessonId: 2,
+                number: 1,
+                name: 'Lesson'
+            }],
+            rejected: []
+        },
+        result: {
+            results: [{
+                lessonId: 1,
+                marathonLessonId: 2,
+                lessonNumber: 1,
+                lessonName: 'Lesson',
+                status: 'failed',
+                code: 'AUTH_CONTEXT_UNAVAILABLE',
+                message: 'Authorization unavailable',
+                attempts: 1
+            }]
+        },
+        startedAt: '2026-08-18T08:00:00.000Z',
+        completedAt: '2026-08-18T08:00:01.000Z',
+        marathonId: '18508',
+        terminalStatus: 'interrupted',
+        fatalError
+    });
+
+    assert.equal(history.results[0].code, 'AUTH_CONTEXT_UNAVAILABLE');
+    assert.equal(
+        history.results[0].diagnostics.requestAttempts[0].correlationId,
+        'media-upload-auth-context'
+    );
 });
 
 test('preserves base64 lesson content and credential-named identifiers', () => {

--- a/src/content/main/features/batch-section-creation/batch-section-image-upload.js
+++ b/src/content/main/features/batch-section-creation/batch-section-image-upload.js
@@ -58,47 +58,190 @@ function readHeader(headers, name, HeadersCtor = globalThis.Headers) {
     return '';
 }
 
+function readStorageKeys(storage) {
+    if (!storage) return null;
+    try {
+        return Array.from({ length: storage.length }, (_, index) => storage.key(index))
+            .filter(Boolean)
+            .map(String)
+            .sort();
+    } catch (_) {
+        return null;
+    }
+}
+
+function readCookieNames(documentObject) {
+    if (!documentObject) return null;
+    try {
+        const cookie = String(documentObject.cookie || '');
+        if (!cookie) return [];
+        return cookie
+            .split(';')
+            .map((entry) => entry.split('=', 1)[0].trim())
+            .filter(Boolean)
+            .sort();
+    } catch (_) {
+        return null;
+    }
+}
+
 function createAuthorizationCapture(rootObject) {
     let authorization = '';
+    let authorizationCaptureCount = 0;
+    let fetchTrustedRequestCount = 0;
+    let manualTrustedRequestCount = 0;
+    let trustedRequestCount = 0;
+    let xhrTrustedRequestCount = 0;
+    let lastAuthorizationCapture = null;
+    let lastTrustedRequest = null;
     const baseUrl = rootObject.location?.href || 'https://edvibe.com/';
     const originalFetch = rootObject.fetch;
     const HeadersCtor = rootObject.Headers;
+    const xhrPrototype = rootObject.XMLHttpRequest?.prototype;
+    const fetchHookInstalled = typeof originalFetch === 'function';
+    const xhrHookInstalled = Boolean(xhrPrototype?.open && xhrPrototype?.setRequestHeader);
+    const installedAt = new Date().toISOString();
 
-    function capture(input, headers) {
-        if (!isTrustedEdvibeUrl(input, baseUrl)) return;
-        const value = readHeader(headers, 'authorization', HeadersCtor);
-        if (value) authorization = value;
+    function summarizeRequestUrl(input) {
+        const url = normalizeRequestUrl(input, baseUrl);
+        return url ? `${url.origin}${url.pathname}` : null;
     }
 
-    if (typeof originalFetch === 'function') {
+    function recordTrustedRequest(input, source = 'manual', method = 'GET') {
+        if (!isTrustedEdvibeUrl(input, baseUrl)) return false;
+        trustedRequestCount += 1;
+        if (source === 'fetch') fetchTrustedRequestCount += 1;
+        else if (source === 'xhr') xhrTrustedRequestCount += 1;
+        else manualTrustedRequestCount += 1;
+        lastTrustedRequest = Object.freeze({
+            source,
+            method: String(method || 'GET').toUpperCase(),
+            url: summarizeRequestUrl(input),
+            observedAt: new Date().toISOString()
+        });
+        return true;
+    }
+
+    function capture(input, headers, {
+        source = 'manual',
+        method = 'GET',
+        observeRequest = true
+    } = {}) {
+        if (observeRequest) {
+            if (!recordTrustedRequest(input, source, method)) return;
+        } else if (!isTrustedEdvibeUrl(input, baseUrl)) {
+            return;
+        }
+        const value = readHeader(headers, 'authorization', HeadersCtor);
+        if (!value) return;
+        authorization = value;
+        authorizationCaptureCount += 1;
+        lastAuthorizationCapture = Object.freeze({
+            source,
+            method: String(method || 'GET').toUpperCase(),
+            url: summarizeRequestUrl(input),
+            observedAt: new Date().toISOString()
+        });
+    }
+
+    if (fetchHookInstalled) {
         rootObject.fetch = function edvibeToolboxFetch(input, init) {
-            capture(input, init?.headers || input?.headers);
+            capture(input, init?.headers || input?.headers, {
+                source: 'fetch',
+                method: init?.method || input?.method || 'GET'
+            });
             return originalFetch.apply(this, arguments);
         };
     }
 
-    const xhrPrototype = rootObject.XMLHttpRequest?.prototype;
-    if (xhrPrototype?.open && xhrPrototype?.setRequestHeader) {
+    if (xhrHookInstalled) {
         const originalOpen = xhrPrototype.open;
         const originalSetRequestHeader = xhrPrototype.setRequestHeader;
-        const urls = new WeakMap();
+        const requests = new WeakMap();
         xhrPrototype.open = function open(method, url) {
-            urls.set(this, url);
+            requests.set(this, { method, url });
+            recordTrustedRequest(url, 'xhr', method);
             return originalOpen.apply(this, arguments);
         };
         xhrPrototype.setRequestHeader = function setRequestHeader(name, value) {
-            if (
-                String(name).toLowerCase() === 'authorization'
-                && isTrustedEdvibeUrl(urls.get(this), baseUrl)
-                && value
-            ) {
-                authorization = String(value);
+            if (String(name).toLowerCase() === 'authorization' && value) {
+                const request = requests.get(this) || {};
+                capture(request.url, { authorization: value }, {
+                    source: 'xhr',
+                    method: request.method,
+                    observeRequest: false
+                });
             }
             return originalSetRequestHeader.apply(this, arguments);
         };
     }
 
-    return Object.freeze({ getAuthorization: () => authorization, capture });
+    function getDiagnostics() {
+        return Object.freeze({
+            installedAt,
+            hasAuthorization: Boolean(authorization),
+            hooks: Object.freeze({
+                fetch: fetchHookInstalled,
+                xhr: xhrHookInstalled
+            }),
+            trustedRequests: Object.freeze({
+                total: trustedRequestCount,
+                fetch: fetchTrustedRequestCount,
+                xhr: xhrTrustedRequestCount,
+                manual: manualTrustedRequestCount
+            }),
+            authorizationCaptureCount,
+            lastTrustedRequest,
+            lastAuthorizationCapture,
+            storage: Object.freeze({
+                localStorageKeys: readStorageKeys(rootObject.localStorage),
+                sessionStorageKeys: readStorageKeys(rootObject.sessionStorage),
+                cookieNames: readCookieNames(rootObject.document)
+            })
+        });
+    }
+
+    return Object.freeze({
+        getAuthorization: () => authorization,
+        getDiagnostics,
+        capture
+    });
+}
+
+function createAuthorizationFailureDiagnostics(captureDiagnostics, imageBlockCount) {
+    const completedAt = new Date().toISOString();
+    const startedAt = captureDiagnostics?.installedAt || completedAt;
+    const startedAtMs = Date.parse(startedAt);
+    const completedAtMs = Date.parse(completedAt);
+    const durationMs = Number.isFinite(startedAtMs) && Number.isFinite(completedAtMs)
+        ? Math.max(0, completedAtMs - startedAtMs)
+        : null;
+    return Object.freeze({
+        requestAttempts: Object.freeze([
+            Object.freeze({
+                correlationId: 'media-upload-auth-context',
+                operationName: 'resolve-image-upload-authorization',
+                controller: null,
+                method: 'captureAuthorizationHeader',
+                projectName: 'MediaFile',
+                requestId: null,
+                attemptNumber: 1,
+                startedAt,
+                completedAt,
+                durationMs,
+                outcome: 'failure',
+                transportCode: 'AUTH_CONTEXT_UNAVAILABLE',
+                serverErrorCode: null,
+                serverErrorMessage: null,
+                requestSummary: Object.freeze({
+                    endpoint: UPLOAD_ENDPOINT,
+                    imageBlockCount,
+                    authorizationCapture: captureDiagnostics || null
+                }),
+                responseSummary: null
+            })
+        ])
+    });
 }
 
 function createDynamicImageRecipe(recipe) {
@@ -132,6 +275,7 @@ async function uploadImageAssets({
     definition,
     registry,
     authorization,
+    authorizationContext = null,
     fetchFn,
     FormDataCtor
 }) {
@@ -140,7 +284,13 @@ async function uploadImageAssets({
     if (!authorization) {
         throw createUploadError(
             'AUTH_CONTEXT_UNAVAILABLE',
-            'Edvibe authorization context is unavailable. Reload the page and try again.'
+            'Edvibe authorization context is unavailable. Reload the page and try again.',
+            {
+                diagnostics: createAuthorizationFailureDiagnostics(
+                    authorizationContext,
+                    imageBlocks.length
+                )
+            }
         );
     }
 
@@ -236,6 +386,7 @@ function createEnhancedAdapterFactory({
                     definition,
                     registry,
                     authorization: authorizationCapture.getAuthorization(),
+                    authorizationContext: authorizationCapture.getDiagnostics?.() || null,
                     fetchFn,
                     FormDataCtor
                 });
@@ -300,7 +451,10 @@ export {
     normalizeRequestUrl,
     isTrustedEdvibeUrl,
     readHeader,
+    readStorageKeys,
+    readCookieNames,
     createAuthorizationCapture,
+    createAuthorizationFailureDiagnostics,
     createDynamicImageRecipe,
     uploadImageAssets,
     createEnhancedAdapterFactory,

--- a/src/content/main/features/batch-section-creation/batch-section-image-upload.test.js
+++ b/src/content/main/features/batch-section-creation/batch-section-image-upload.test.js
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    createAuthorizationCapture,
+    uploadImageAssets
+} from '#src/content/main/features/batch-section-creation/batch-section-image-upload.js';
+
+function storage(keys) {
+    return {
+        length: keys.length,
+        key(index) {
+            return keys[index] ?? null;
+        }
+    };
+}
+
+test('authorization capture reports trusted traffic without persisting credentials', async () => {
+    const calls = [];
+    const root = {
+        location: { href: 'https://edvibe.com/cabinet' },
+        Headers,
+        document: { cookie: 'session=cookie-secret; theme=dark' },
+        localStorage: storage(['accessToken', 'locale']),
+        sessionStorage: storage(['activeSchool']),
+        async fetch(...args) {
+            calls.push(args);
+            return { ok: true };
+        }
+    };
+    const capture = createAuthorizationCapture(root);
+
+    await root.fetch('https://edvibe.com/api/without-auth?secret=query-secret', {
+        method: 'POST'
+    });
+    let diagnostics = capture.getDiagnostics();
+    assert.equal(diagnostics.hasAuthorization, false);
+    assert.deepEqual(diagnostics.trustedRequests, {
+        total: 1,
+        fetch: 1,
+        xhr: 0,
+        manual: 0
+    });
+    assert.equal(diagnostics.lastTrustedRequest.url, 'https://edvibe.com/api/without-auth');
+
+    await root.fetch('https://media-files-y.edvibe.com/api/test', {
+        headers: { authorization: 'token-secret' }
+    });
+    diagnostics = capture.getDiagnostics();
+
+    assert.equal(capture.getAuthorization(), 'token-secret');
+    assert.equal(diagnostics.hasAuthorization, true);
+    assert.equal(diagnostics.authorizationCaptureCount, 1);
+    assert.deepEqual(diagnostics.storage.localStorageKeys, ['accessToken', 'locale']);
+    assert.deepEqual(diagnostics.storage.sessionStorageKeys, ['activeSchool']);
+    assert.deepEqual(diagnostics.storage.cookieNames, ['session', 'theme']);
+    assert.equal(calls.length, 2);
+
+    const serialized = JSON.stringify(diagnostics);
+    assert.equal(serialized.includes('token-secret'), false);
+    assert.equal(serialized.includes('cookie-secret'), false);
+    assert.equal(serialized.includes('query-secret'), false);
+});
+
+test('missing authorization produces history-compatible diagnostics before upload', async () => {
+    const authorizationContext = {
+        installedAt: '2026-08-18T08:00:00.000Z',
+        hasAuthorization: false,
+        hooks: { fetch: true, xhr: true },
+        trustedRequests: { total: 0, fetch: 0, xhr: 0, manual: 0 },
+        authorizationCaptureCount: 0,
+        lastTrustedRequest: null,
+        lastAuthorizationCapture: null,
+        storage: {
+            localStorageKeys: ['accessToken'],
+            sessionStorageKeys: [],
+            cookieNames: ['session']
+        }
+    };
+    let fetchCalled = false;
+
+    await assert.rejects(
+        uploadImageAssets({
+            definition: {
+                name: 'Announcement',
+                blocks: [{
+                    id: 'block-1',
+                    type: 'image',
+                    url: 'https://media-files-y.edvibe.com/local-upload/client-1'
+                }]
+            },
+            registry: { get: () => ({ name: 'banner.png' }) },
+            authorization: '',
+            authorizationContext,
+            fetchFn: async () => {
+                fetchCalled = true;
+                return { ok: true };
+            },
+            FormDataCtor: class {}
+        }),
+        (error) => {
+            assert.equal(error.code, 'AUTH_CONTEXT_UNAVAILABLE');
+            assert.equal(error.diagnostics.requestAttempts.length, 1);
+            const diagnostic = error.diagnostics.requestAttempts[0];
+            assert.equal(diagnostic.transportCode, 'AUTH_CONTEXT_UNAVAILABLE');
+            assert.equal(diagnostic.operationName, 'resolve-image-upload-authorization');
+            assert.equal(diagnostic.requestSummary.imageBlockCount, 1);
+            assert.deepEqual(diagnostic.requestSummary.authorizationCapture, authorizationContext);
+            return true;
+        }
+    );
+
+    assert.equal(fetchCalled, false);
+});


### PR DESCRIPTION
## Summary

- record non-secret diagnostics for Edvibe authorization-header capture used by batch section image uploads
- include trusted HTTP traffic counts, capture-hook state, last observed trusted request metadata, and storage/cookie names without persisting credential values
- persist fatal image-upload diagnostics into execution history instead of dropping them during result materialization
- add regression coverage for credential-safe capture diagnostics and history persistence

## Why

A real batch section creation run can pass preflight and then fail with `AUTH_CONTEXT_UNAVAILABLE` before any section identifiers exist. The image uploader currently depends on passively observing a future Edvibe `Authorization` header, but the history record does not show whether such traffic was ever observed.

This change intentionally does not guess an alternative token source or attempt an unauthenticated upload. A reproduced history export should now show enough evidence to choose the correct fix.

## Validation

GitHub Actions is the authoritative validation environment for this repository. Manual validation should reproduce one image-only batch section attempt and inspect the exported execution history; no authorization or cookie values should appear in the diagnostics.