### PR TITLE
Restore MAIN runtime regression safety net

### DIFF
--- a/src/content/isolated/bridge.test.js
+++ b/src/content/isolated/bridge.test.js
@@ -12,7 +12,7 @@ import {
     createRuntimeExportStatusMessage,
     createStorageRequest,
     createStorageResponse
-} from '#src/shared/messaging/protocol.js';
+} from '#src/shared/messaging/index.js';
 
 function createHarness(initialStorage = {}) {
     const windowListeners = new Set();

--- a/src/content/main/feature-dispatcher.js
+++ b/src/content/main/feature-dispatcher.js
@@ -50,7 +50,13 @@ export class FeatureDispatcher {
         if (!handler) {
             return false;
         }
-        handler(message);
+        try {
+            Promise.resolve(handler(message)).catch((error) => {
+                this.logger.log(`Feature "${message.type}" failed:`, error);
+            });
+        } catch (error) {
+            this.logger.log(`Feature "${message.type}" failed:`, error);
+        }
         return true;
     }
 }

--- a/src/content/main/feature-dispatcher.test.js
+++ b/src/content/main/feature-dispatcher.test.js
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { FeatureDispatcher } from '#src/content/main/feature-dispatcher.js';
+import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
+
+class FakeWebSocket {
+    static OPEN = 1;
+}
+
+function installBrowserGlobals() {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const windowApi = {
+        WebSocket: FakeWebSocket,
+        Blob: class Blob { },
+        URL: {},
+        crypto: { randomUUID: () => 'test-id' },
+        indexedDB: { open() { } },
+        addEventListener() { },
+        removeEventListener() { },
+        postMessage() { }
+    };
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        writable: true,
+        value: windowApi
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        writable: true,
+        value: {}
+    });
+    return () => {
+        if (previousWindow) {
+            Object.defineProperty(globalThis, 'window', previousWindow);
+        } else {
+            delete globalThis.window;
+        }
+        if (previousDocument) {
+            Object.defineProperty(globalThis, 'document', previousDocument);
+        } else {
+            delete globalThis.document;
+        }
+    };
+}
+
+function createLogger() {
+    const entries = [];
+    const logger = {
+        entries,
+        createChildLogger() {
+            return logger;
+        },
+        log(...args) {
+            entries.push(args);
+        }
+    };
+    return logger;
+}
+
+function withDispatcher(features, callback) {
+    const restore = installBrowserGlobals();
+    const logger = createLogger();
+    try {
+        return callback(new FeatureDispatcher({ logger, features }), logger);
+    } finally {
+        restore();
+    }
+}
+
+test('rejects invalid and duplicate feature definitions', () => {
+    const restore = installBrowserGlobals();
+    const logger = createLogger();
+    try {
+        assert.throws(
+            () => new FeatureDispatcher({ logger, features: [{ type: null, create() { } }] }),
+            /must provide a type and create function/
+        );
+        assert.throws(
+            () => new FeatureDispatcher({
+                logger,
+                features: [
+                    { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => () => { } },
+                    { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => () => { } }
+                ]
+            }),
+            /already registered/
+        );
+        assert.throws(
+            () => new FeatureDispatcher({
+                logger,
+                features: [{ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => null }]
+            }),
+            /must create a command handler/
+        );
+    } finally {
+        restore();
+    }
+});
+
+test('registers features with the shared runtime context', () => {
+    let receivedContext;
+    withDispatcher([
+        {
+            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+            create(context) {
+                receivedContext = context;
+                return () => { };
+            }
+        }
+    ], (dispatcher, logger) => {
+        assert.equal(receivedContext.logger, logger);
+        assert.equal(receivedContext.transport, dispatcher.transport);
+        assert.equal(receivedContext.operationGuard, dispatcher.operationGuard);
+        assert.equal(receivedContext.executionHistoryService, dispatcher.executionHistoryService);
+        assert.equal(receivedContext.dispatch, dispatcher.dispatch);
+    });
+});
+
+test('rejects malformed and unregistered messages without invoking a handler', () => {
+    let calls = 0;
+    withDispatcher([
+        {
+            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+            create: () => () => {
+                calls += 1;
+            }
+        }
+    ], (dispatcher) => {
+        assert.equal(dispatcher.dispatch(null), false);
+        assert.equal(dispatcher.dispatch({}), false);
+        assert.equal(dispatcher.dispatch({ type: 'UNKNOWN' }), false);
+        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.START_EXPORT }), false);
+        assert.equal(calls, 0);
+    });
+});
+
+test('dispatches a valid registered command to its handler', () => {
+    let receivedMessage = null;
+    withDispatcher([
+        {
+            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+            create: () => (message) => {
+                receivedMessage = message;
+            }
+        }
+    ], (dispatcher) => {
+        const message = { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER };
+        assert.equal(dispatcher.dispatch(message), true);
+        assert.equal(receivedMessage, message);
+    });
+});
+
+test('isolates synchronous handler failures and continues dispatching', () => {
+    const failure = new Error('feature exploded');
+    let healthyCalls = 0;
+    withDispatcher([
+        {
+            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+            create: () => () => {
+                throw failure;
+            }
+        },
+        {
+            type: WINDOW_MESSAGE_TYPES.OPEN_EXECUTION_HISTORY,
+            create: () => () => {
+                healthyCalls += 1;
+            }
+        }
+    ], (dispatcher, logger) => {
+        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER }), true);
+        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_EXECUTION_HISTORY }), true);
+        assert.equal(healthyCalls, 1);
+        assert.equal(logger.entries.length, 1);
+        assert.match(logger.entries[0][0], /OPEN_RECORDER/);
+        assert.equal(logger.entries[0][1], failure);
+    });
+});
+
+test('isolates rejected asynchronous handlers', async () => {
+    const failure = new Error('async feature exploded');
+    const restore = installBrowserGlobals();
+    const logger = createLogger();
+    try {
+        const dispatcher = new FeatureDispatcher({
+            logger,
+            features: [{
+                type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+                create: () => async () => {
+                    throw failure;
+                }
+            }]
+        });
+
+        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER }), true);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        assert.equal(logger.entries.length, 1);
+        assert.match(logger.entries[0][0], /OPEN_RECORDER/);
+        assert.equal(logger.entries[0][1], failure);
+    } finally {
+        restore();
+    }
+});

--- a/src/content/main/feature-dispatcher.test.js
+++ b/src/content/main/feature-dispatcher.test.js
@@ -45,7 +45,7 @@ function installBrowserGlobals() {
     };
 }
 
-function createLogger() {
+function createLogger(onLog = () => { }) {
     const entries = [];
     const logger = {
         entries,
@@ -54,108 +54,168 @@ function createLogger() {
         },
         log(...args) {
             entries.push(args);
+            onLog(args);
         }
     };
     return logger;
 }
 
-function withDispatcher(features, callback) {
+function createDispatcherHarness(features, logger = createLogger()) {
     const restore = installBrowserGlobals();
-    const logger = createLogger();
     try {
-        return callback(new FeatureDispatcher({ logger, features }), logger);
-    } finally {
+        return {
+            dispatcher: new FeatureDispatcher({ logger, features }),
+            logger,
+            restore
+        };
+    } catch (error) {
         restore();
+        throw error;
     }
 }
 
-test('rejects invalid and duplicate feature definitions', () => {
+test('FeatureDispatcher should reject feature definitions when type or create is invalid', (t) => {
+    // Given
     const restore = installBrowserGlobals();
+    t.after(restore);
     const logger = createLogger();
-    try {
-        assert.throws(
-            () => new FeatureDispatcher({ logger, features: [{ type: null, create() { } }] }),
-            /must provide a type and create function/
-        );
-        assert.throws(
-            () => new FeatureDispatcher({
-                logger,
-                features: [
-                    { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => () => { } },
-                    { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => () => { } }
-                ]
-            }),
-            /already registered/
-        );
-        assert.throws(
-            () => new FeatureDispatcher({
-                logger,
-                features: [{ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER, create: () => null }]
-            }),
-            /must create a command handler/
-        );
-    } finally {
-        restore();
-    }
+    const construct = () => new FeatureDispatcher({
+        logger,
+        features: [{ type: null, create() { } }]
+    });
+
+    // When
+    const invoke = () => construct();
+
+    // Then
+    assert.throws(invoke, /must provide a type and create function/);
 });
 
-test('registers features with the shared runtime context', () => {
+test('FeatureDispatcher should reject registration when feature type is already registered', (t) => {
+    // Given
+    const restore = installBrowserGlobals();
+    t.after(restore);
+    const logger = createLogger();
+    const definition = {
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create: () => () => { }
+    };
+    const construct = () => new FeatureDispatcher({
+        logger,
+        features: [definition, definition]
+    });
+
+    // When
+    const invoke = () => construct();
+
+    // Then
+    assert.throws(invoke, /already registered/);
+});
+
+test('FeatureDispatcher should reject registration when feature factory does not create a handler', (t) => {
+    // Given
+    const restore = installBrowserGlobals();
+    t.after(restore);
+    const logger = createLogger();
+    const construct = () => new FeatureDispatcher({
+        logger,
+        features: [{
+            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+            create: () => null
+        }]
+    });
+
+    // When
+    const invoke = () => construct();
+
+    // Then
+    assert.throws(invoke, /must create a command handler/);
+});
+
+test('FeatureDispatcher should provide runtime dependencies when feature is registered', (t) => {
+    // Given
     let receivedContext;
-    withDispatcher([
-        {
-            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
-            create(context) {
-                receivedContext = context;
-                return () => { };
-            }
+    const harness = createDispatcherHarness([{
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create(context) {
+            receivedContext = context;
+            return () => { };
         }
-    ], (dispatcher, logger) => {
-        assert.equal(receivedContext.logger, logger);
-        assert.equal(receivedContext.transport, dispatcher.transport);
-        assert.equal(receivedContext.operationGuard, dispatcher.operationGuard);
-        assert.equal(receivedContext.executionHistoryService, dispatcher.executionHistoryService);
-        assert.equal(receivedContext.dispatch, dispatcher.dispatch);
-    });
+    }]);
+    t.after(harness.restore);
+
+    // When
+    const context = receivedContext;
+
+    // Then
+    assert.equal(context.logger, harness.logger);
+    assert.equal(context.dispatch, harness.dispatcher.dispatch);
+    assert.equal(typeof context.transport.sendRequest, 'function');
+    assert.equal(typeof context.operationGuard.canStart, 'function');
+    assert.equal(typeof context.executionHistoryService.persistTerminal, 'function');
 });
 
-test('rejects malformed and unregistered messages without invoking a handler', () => {
+test('FeatureDispatcher should ignore messages when message contract is invalid', (t) => {
+    // Given
     let calls = 0;
-    withDispatcher([
-        {
-            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
-            create: () => () => {
-                calls += 1;
-            }
+    const harness = createDispatcherHarness([{
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create: () => () => {
+            calls += 1;
         }
-    ], (dispatcher) => {
-        assert.equal(dispatcher.dispatch(null), false);
-        assert.equal(dispatcher.dispatch({}), false);
-        assert.equal(dispatcher.dispatch({ type: 'UNKNOWN' }), false);
-        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.START_EXPORT }), false);
-        assert.equal(calls, 0);
-    });
+    }]);
+    t.after(harness.restore);
+    const invalidMessages = [null, {}, { type: 'UNKNOWN' }];
+
+    // When
+    const results = invalidMessages.map((message) => harness.dispatcher.dispatch(message));
+
+    // Then
+    assert.deepEqual(results, [false, false, false]);
+    assert.equal(calls, 0);
 });
 
-test('dispatches a valid registered command to its handler', () => {
+test('FeatureDispatcher should return false when valid command has no registered handler', (t) => {
+    // Given
+    const harness = createDispatcherHarness([{
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create: () => () => { }
+    }]);
+    t.after(harness.restore);
+    const message = { type: WINDOW_MESSAGE_TYPES.START_EXPORT };
+
+    // When
+    const handled = harness.dispatcher.dispatch(message);
+
+    // Then
+    assert.equal(handled, false);
+});
+
+test('FeatureDispatcher should dispatch message when command type is registered', (t) => {
+    // Given
     let receivedMessage = null;
-    withDispatcher([
-        {
-            type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
-            create: () => (message) => {
-                receivedMessage = message;
-            }
+    const harness = createDispatcherHarness([{
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create: () => (message) => {
+            receivedMessage = message;
         }
-    ], (dispatcher) => {
-        const message = { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER };
-        assert.equal(dispatcher.dispatch(message), true);
-        assert.equal(receivedMessage, message);
-    });
+    }]);
+    t.after(harness.restore);
+    const message = { type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER };
+
+    // When
+    const handled = harness.dispatcher.dispatch(message);
+
+    // Then
+    assert.equal(handled, true);
+    assert.equal(receivedMessage, message);
 });
 
-test('isolates synchronous handler failures and continues dispatching', () => {
+test('FeatureDispatcher should isolate synchronous failure when later command is dispatched', (t) => {
+    // Given
     const failure = new Error('feature exploded');
     let healthyCalls = 0;
-    withDispatcher([
+    const harness = createDispatcherHarness([
         {
             type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
             create: () => () => {
@@ -168,39 +228,50 @@ test('isolates synchronous handler failures and continues dispatching', () => {
                 healthyCalls += 1;
             }
         }
-    ], (dispatcher, logger) => {
-        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER }), true);
-        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_EXECUTION_HISTORY }), true);
-        assert.equal(healthyCalls, 1);
-        assert.equal(logger.entries.length, 1);
-        assert.match(logger.entries[0][0], /OPEN_RECORDER/);
-        assert.equal(logger.entries[0][1], failure);
+    ]);
+    t.after(harness.restore);
+
+    // When
+    const failedHandled = harness.dispatcher.dispatch({
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER
     });
+    const healthyHandled = harness.dispatcher.dispatch({
+        type: WINDOW_MESSAGE_TYPES.OPEN_EXECUTION_HISTORY
+    });
+
+    // Then
+    assert.equal(failedHandled, true);
+    assert.equal(healthyHandled, true);
+    assert.equal(healthyCalls, 1);
+    assert.equal(harness.logger.entries.length, 1);
+    assert.match(harness.logger.entries[0][0], /OPEN_RECORDER/);
+    assert.equal(harness.logger.entries[0][1], failure);
 });
 
-test('isolates rejected asynchronous handlers', async () => {
+test('FeatureDispatcher should isolate asynchronous failure when handler promise rejects', async (t) => {
+    // Given
     const failure = new Error('async feature exploded');
-    const restore = installBrowserGlobals();
-    const logger = createLogger();
-    try {
-        const dispatcher = new FeatureDispatcher({
-            logger,
-            features: [{
-                type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
-                create: () => async () => {
-                    throw failure;
-                }
-            }]
-        });
+    let resolveLogged;
+    const logged = new Promise((resolve) => {
+        resolveLogged = resolve;
+    });
+    const logger = createLogger(resolveLogged);
+    const harness = createDispatcherHarness([{
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER,
+        create: () => async () => {
+            throw failure;
+        }
+    }], logger);
+    t.after(harness.restore);
 
-        assert.equal(dispatcher.dispatch({ type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER }), true);
-        await Promise.resolve();
-        await Promise.resolve();
+    // When
+    const handled = harness.dispatcher.dispatch({
+        type: WINDOW_MESSAGE_TYPES.OPEN_ACTION_RECORDER
+    });
+    const loggedEntry = await logged;
 
-        assert.equal(logger.entries.length, 1);
-        assert.match(logger.entries[0][0], /OPEN_RECORDER/);
-        assert.equal(logger.entries[0][1], failure);
-    } finally {
-        restore();
-    }
+    // Then
+    assert.equal(handled, true);
+    assert.match(loggedEntry[0], /OPEN_RECORDER/);
+    assert.equal(loggedEntry[1], failure);
 });

--- a/src/content/main/features/index.test.js
+++ b/src/content/main/features/index.test.js
@@ -170,34 +170,53 @@ function createRuntimeContext() {
     };
 }
 
-test('registered MAIN features construct lazily and cross their browser adapter boundary', async () => {
+test('registered MAIN features should expose unique command types when definitions are loaded', () => {
+    // Given
+    const registeredTypes = features.map(({ type }) => type);
+
+    // When
+    const uniqueTypes = new Set(registeredTypes);
+
+    // Then
+    assert.ok(registeredTypes.length > 0);
+    assert.equal(uniqueTypes.size, registeredTypes.length);
+});
+
+test('registered MAIN features should reach browser UI adapter when opened with representative runtime dependencies', async (t) => {
+    // Given
     const browser = installBrowserGlobals();
-    try {
-        assert.ok(features.length > 0);
-        assert.equal(new Set(features.map(({ type }) => type)).size, features.length);
+    t.after(browser.restore);
+    const outcomes = [];
 
-        for (const definition of features) {
-            const beforeCreate = browser.createdElements.length;
-            const handler = definition.create(createRuntimeContext());
-            assert.equal(typeof handler, 'function', `${definition.type} must create a handler`);
-            assert.equal(
-                browser.createdElements.length,
-                beforeCreate,
-                `${definition.type} must not create browser UI during registration`
-            );
-
-            const result = handler({ type: definition.type });
-            if (result && typeof result.then === 'function') {
-                await result;
+    // When
+    for (const definition of features) {
+        const createdBeforeOpen = browser.createdElements.length;
+        let handler;
+        let error = null;
+        try {
+            handler = definition.create(createRuntimeContext());
+            if (typeof handler === 'function') {
+                const result = handler({ type: definition.type });
+                if (result && typeof result.then === 'function') {
+                    await result;
+                }
+                await Promise.resolve();
             }
-            await Promise.resolve();
-
-            assert.ok(
-                browser.createdElements.length > beforeCreate,
-                `${definition.type} must reach its browser UI adapter when opened`
-            );
+        } catch (cause) {
+            error = cause;
         }
-    } finally {
-        browser.restore();
+        outcomes.push({
+            type: definition.type,
+            handlerType: typeof handler,
+            error,
+            createdElements: browser.createdElements.length - createdBeforeOpen
+        });
+    }
+
+    // Then
+    for (const outcome of outcomes) {
+        assert.equal(outcome.handlerType, 'function', `${outcome.type} must create a handler`);
+        assert.equal(outcome.error, null, `${outcome.type} must open without adapter contract errors`);
+        assert.ok(outcome.createdElements > 0, `${outcome.type} must reach its browser UI adapter`);
     }
 });

--- a/src/content/main/features/index.test.js
+++ b/src/content/main/features/index.test.js
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import features from '#src/content/main/features/index.js';
+import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
+
+function createDialog(documentApi) {
+    return {
+        elements: {
+            footer: { appendChild() { } },
+            status: { textContent: '' }
+        },
+        ownerDocument: documentApi,
+        shadowRoot: { querySelector() { return null; } },
+        addEventListener() { },
+        close() { },
+        complete() { },
+        completeRun() { },
+        configure() { },
+        dismissAfter() { },
+        error() { },
+        lock() { },
+        mount() { },
+        remove() { },
+        restore() { },
+        setEmailState() { },
+        setLessons() { },
+        setLoadError() { },
+        setLoading() { },
+        setProgress() { },
+        setState() { },
+        setStatus() { },
+        showChecking() { },
+        showComplete() { },
+        showConfigure() { },
+        showConfirmation() { },
+        showDiscovery() { },
+        showError() { },
+        showExecution() { },
+        showFatalError() { },
+        showLoading() { },
+        showProgress() { },
+        showPupils() { },
+        showReview() { },
+        showStatus() { },
+        showValidationErrors() { },
+        unlockAfterRun() { }
+    };
+}
+
+function installBrowserGlobals() {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const previousLocation = Object.getOwnPropertyDescriptor(globalThis, 'location');
+    const createdElements = [];
+    let documentApi;
+    const body = {
+        append(element) {
+            return element;
+        },
+        appendChild(element) {
+            return element;
+        },
+        removeChild(element) {
+            return element;
+        }
+    };
+    documentApi = {
+        body,
+        documentElement: body,
+        title: 'Test marathon',
+        createElement(tagName) {
+            createdElements.push(tagName);
+            return createDialog(documentApi);
+        },
+        getElementById() {
+            return null;
+        },
+        querySelector() {
+            return null;
+        }
+    };
+    const location = {
+        href: 'https://edvibe.com/marathon/123',
+        hostname: 'edvibe.com',
+        origin: 'https://edvibe.com',
+        pathname: '/marathon/123'
+    };
+    const windowApi = {
+        crypto: { randomUUID: () => 'smoke-id' },
+        location,
+        alert() { },
+        confirm() {
+            return true;
+        },
+        postMessage() { }
+    };
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        writable: true,
+        value: windowApi
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        writable: true,
+        value: documentApi
+    });
+    Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        writable: true,
+        value: location
+    });
+    return {
+        createdElements,
+        restore() {
+            for (const [name, descriptor] of [
+                ['window', previousWindow],
+                ['document', previousDocument],
+                ['location', previousLocation]
+            ]) {
+                if (descriptor) {
+                    Object.defineProperty(globalThis, name, descriptor);
+                } else {
+                    delete globalThis[name];
+                }
+            }
+        }
+    };
+}
+
+function createLogger() {
+    const logger = {
+        createChildLogger() {
+            return logger;
+        },
+        log() { }
+    };
+    return logger;
+}
+
+function createRuntimeContext() {
+    const transportFailure = new Error('Smoke transport stopped at the adapter boundary.');
+    transportFailure.code = 'WS_UNAVAILABLE';
+    return {
+        dispatch() {
+            return true;
+        },
+        executionHistoryService: {
+            clear: async () => { },
+            delete: async () => { },
+            exportFiltered: async () => { },
+            exportRecord: async () => { },
+            get: async () => null,
+            getPreferences: async () => ({}),
+            list: async () => [],
+            persistTerminal: async () => Object.freeze({ stored: false }),
+            setPreferences: async () => ({})
+        },
+        logger: createLogger(),
+        operationGuard: new OperationGuard(),
+        transport: {
+            getConnectionState: () => ({ isOpen: true, ready: true }),
+            getResponseDiagnostics: () => undefined,
+            sendRequest: async () => {
+                throw transportFailure;
+            },
+            sendWithoutResponse() { },
+            subscribeFrames: () => () => { }
+        }
+    };
+}
+
+test('registered MAIN features construct lazily and cross their browser adapter boundary', async () => {
+    const browser = installBrowserGlobals();
+    try {
+        assert.ok(features.length > 0);
+        assert.equal(new Set(features.map(({ type }) => type)).size, features.length);
+
+        for (const definition of features) {
+            const beforeCreate = browser.createdElements.length;
+            const handler = definition.create(createRuntimeContext());
+            assert.equal(typeof handler, 'function', `${definition.type} must create a handler`);
+            assert.equal(
+                browser.createdElements.length,
+                beforeCreate,
+                `${definition.type} must not create browser UI during registration`
+            );
+
+            const result = handler({ type: definition.type });
+            if (result && typeof result.then === 'function') {
+                await result;
+            }
+            await Promise.resolve();
+
+            assert.ok(
+                browser.createdElements.length > beforeCreate,
+                `${definition.type} must reach its browser UI adapter when opened`
+            );
+        }
+    } finally {
+        browser.restore();
+    }
+});

--- a/src/content/main/features/video-attachment/video-attachment-runtime.test.js
+++ b/src/content/main/features/video-attachment/video-attachment-runtime.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createVideoAttachmentFeatureV2 } from '#src/content/main/features/video-attachment/video-attachment.js';
+
+function createDialog() {
+    return {
+        configuration: null,
+        configure(configuration) {
+            this.configuration = configuration;
+        },
+        remove() { },
+        setLessons() { },
+        setLoadError() { }
+    };
+}
+
+function installBrowserGlobals(createDialogElement) {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    const appended = [];
+    const windowApi = {
+        location: { href: 'https://edvibe.com/marathon/123' },
+        alert() { }
+    };
+    const documentApi = {
+        body: {
+            append(dialog) {
+                appended.push(dialog);
+            }
+        },
+        createElement() {
+            return createDialogElement();
+        }
+    };
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        writable: true,
+        value: windowApi
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        writable: true,
+        value: documentApi
+    });
+    return {
+        appended,
+        restore() {
+            if (previousWindow) {
+                Object.defineProperty(globalThis, 'window', previousWindow);
+            } else {
+                delete globalThis.window;
+            }
+            if (previousDocument) {
+                Object.defineProperty(globalThis, 'document', previousDocument);
+            } else {
+                delete globalThis.document;
+            }
+        }
+    };
+}
+
+test('createVideoAttachmentFeatureV2 should create fresh dialog when feature is reopened', (t) => {
+    // Given
+    const dialogs = [];
+    const browser = installBrowserGlobals(() => {
+        const dialog = createDialog();
+        dialogs.push(dialog);
+        return dialog;
+    });
+    t.after(browser.restore);
+    const feature = createVideoAttachmentFeatureV2({
+        transport: {
+            sendRequest: () => new Promise(() => { }),
+            getConnectionState: () => ({ isOpen: true })
+        },
+        operationGuard: {
+            canStart: () => true,
+            guardedActiveChange: () => () => { }
+        },
+        logger: {
+            createChildLogger: () => ({ log() { } })
+        }
+    });
+
+    // When
+    feature.open();
+    dialogs[0].configuration.onClose();
+    feature.open();
+
+    // Then
+    assert.equal(dialogs.length, 2);
+    assert.notEqual(dialogs[0], dialogs[1]);
+    assert.deepEqual(browser.appended, dialogs);
+});

--- a/src/content/main/features/video-attachment/video-attachment.js
+++ b/src/content/main/features/video-attachment/video-attachment.js
@@ -313,7 +313,7 @@ export function createVideoAttachmentFeatureV2({
         canStart: operationGuard.canStart,
         onActiveChange: operationGuard.guardedActiveChange('video-attachment'),
 
-        createDialog: document.createElement(VIDEO_ATTACHMENT_DIALOG_TAG),
+        createDialog: () => document.createElement(VIDEO_ATTACHMENT_DIALOG_TAG),
         getLocationHref: () => window.location.href,
         appendDialog: (dialog) => document.body.append(dialog),
         alertUser: (message) => window.alert(message),

--- a/src/content/main/infrastructure/websocket-transport.test.js
+++ b/src/content/main/infrastructure/websocket-transport.test.js
@@ -107,7 +107,7 @@ test('attaches response diagnostics to server rejection errors', async () => {
         assert.equal(error.code, 'SERVER_REJECTED');
         assert.deepEqual(error.diagnostics.response, {
             requestId: 'request-1', success: false, errorCode: 'DUPLICATE',
-            className: 'UserService', method: null, elapsedMs: 5,
+            className: 'UserService', method: 'Create', elapsedMs: 5,
             serverMessage: 'Already exists'
         });
         return true;

--- a/src/content/main/infrastructure/websocket-transport.test.js
+++ b/src/content/main/infrastructure/websocket-transport.test.js
@@ -72,16 +72,21 @@ function setup(options = {}) {
     } };
 }
 
-test('exposes full diagnostics for a successful response without changing it', async () => {
+test('createWebSocketTransport should preserve successful response when diagnostics are recorded', async () => {
+    // Given
     const { transport, socket, advance } = setup();
+    const response = { RequestId: 'request-1', IsSuccess: true, Value: { Count: 2 } };
+
+    // When
     const promise = transport.sendRequest('Users', 'Get', 'School', { Page: 1 });
     advance(12);
-    const response = { RequestId: 'request-1', IsSuccess: true, Value: { Count: 2 } };
     socket.respond(response);
-
     const resolved = await promise;
+    const diagnostics = transport.getResponseDiagnostics(resolved);
+
+    // Then
     assert.deepEqual(resolved, response);
-    assert.deepEqual(transport.getResponseDiagnostics(resolved), {
+    assert.deepEqual(diagnostics, {
         request: {
             controller: 'Users', method: 'Get', projectName: 'School',
             requestId: 'request-1', startedAt: 100, value: { Page: 1 }
@@ -94,8 +99,11 @@ test('exposes full diagnostics for a successful response without changing it', a
     assert.deepEqual(Object.keys(resolved), Object.keys(response));
 });
 
-test('attaches response diagnostics to server rejection errors', async () => {
+test('createWebSocketTransport should attach response diagnostics when server rejects request', async () => {
+    // Given
     const { transport, socket, advance } = setup();
+
+    // When
     const promise = transport.sendRequest('Users', 'Create', 'School', { Name: 'Sam' });
     advance(5);
     socket.respond({
@@ -103,6 +111,7 @@ test('attaches response diagnostics to server rejection errors', async () => {
         Class: 'UserService', Method: 'Create', Message: 'Already exists'
     });
 
+    // Then
     await assert.rejects(promise, (error) => {
         assert.equal(error.code, 'SERVER_REJECTED');
         assert.deepEqual(error.diagnostics.response, {
@@ -114,10 +123,15 @@ test('attaches response diagnostics to server rejection errors', async () => {
     });
 });
 
-test('attaches request diagnostics to timeout errors', async () => {
+test('createWebSocketTransport should attach request diagnostics when request times out', async () => {
+    // Given
     const { transport, timers } = setup({ requestTimeoutMs: 9 });
+
+    // When
     const promise = transport.sendRequest('Lessons', 'Get', 'Books', { LessonId: 7 });
     timers[0]();
+
+    // Then
     await assert.rejects(promise, (error) => {
         assert.equal(error.code, 'REQUEST_TIMEOUT');
         assert.equal(error.diagnostics.request.requestId, 'request-1');
@@ -126,17 +140,23 @@ test('attaches request diagnostics to timeout errors', async () => {
     });
 });
 
-test('attaches request diagnostics to synchronous send failures', async () => {
+test('createWebSocketTransport should attach request diagnostics when socket send fails synchronously', async () => {
+    // Given
     const { transport, socket } = setup();
     socket.sendError = new Error('socket closed');
+
+    // When
+    const promise = transport.sendRequest('Lessons', 'Save', 'Books', { LessonId: 7 });
+
+    // Then
     await assert.rejects(
-        transport.sendRequest('Lessons', 'Save', 'Books', { LessonId: 7 }),
+        promise,
         (error) => error.code === 'SEND_FAILED'
             && error.diagnostics.request.controller === 'Lessons'
     );
 });
 
-test('preserves sensitive, long, deep, and wide request and response fields', async () => {
+test('createWebSocketTransport should preserve complete fields when diagnostics contain sensitive or large values', async () => {
     // Given
     const { transport, socket } = setup();
     const long = 'x'.repeat(800);
@@ -163,13 +183,18 @@ test('preserves sensitive, long, deep, and wide request and response fields', as
     assert.deepEqual(diagnostics.response.value, { Cookie: 'raw', ImageData: 'raw', SafeCount: 3, long, deep, wide });
 });
 
-test('retains malformed server error payloads in diagnostics', async () => {
+test('createWebSocketTransport should preserve malformed server payload when rejection diagnostics are recorded', async () => {
+    // Given
     const { transport, socket } = setup();
+
+    // When
     const promise = transport.sendRequest('Users', 'Create', 'School', {});
     socket.respond({
         RequestId: 'request-1', IsSuccess: false,
         ErrorCode: { unexpected: true }, Message: { private: 'payload' }
     });
+
+    // Then
     await assert.rejects(promise, (error) => {
         assert.equal(error.code, 'SERVER_REJECTED');
         assert.deepEqual(error.diagnostics.response.serverMessage, { private: 'payload' });

--- a/src/content/main/infrastructure/websocket-transport.test.js
+++ b/src/content/main/infrastructure/websocket-transport.test.js
@@ -29,25 +29,46 @@ class FakeWebSocket {
     }
 }
 
+function createLogger() {
+    const logger = {
+        createChildLogger() {
+            return logger;
+        },
+        log() { }
+    };
+    return logger;
+}
+
 function setup(options = {}) {
     let time = 100;
     const timers = [];
-    const transport = createWebSocketTransport({
-        WebSocketClass: FakeWebSocket,
-        cryptoApi: { randomUUID: () => 'request-1' },
-        now: () => time,
-        setTimeoutFn: (callback) => {
-            timers.push(callback);
-            return timers.length;
-        },
-        clearTimeoutFn: () => {},
-        ...options
-    });
     const root = {};
-    transport.install(root);
+    const previousWindow = globalThis.window;
+    globalThis.window = root;
+    let transport;
+    try {
+        transport = createWebSocketTransport({
+            WebSocketClass: FakeWebSocket,
+            cryptoApi: { randomUUID: () => 'request-1' },
+            logger: createLogger(),
+            now: () => time,
+            setTimeoutFn: (callback) => {
+                timers.push(callback);
+                return timers.length;
+            },
+            clearTimeoutFn: () => { },
+            ...options
+        });
+    } finally {
+        if (previousWindow === undefined) {
+            delete globalThis.window;
+        } else {
+            globalThis.window = previousWindow;
+        }
+    }
     const socket = new root.WebSocket('wss://example.test');
     return { transport, socket, timers, advance: (milliseconds) => {
-        time += milliseconds; 
+        time += milliseconds;
     } };
 }
 
@@ -86,7 +107,7 @@ test('attaches response diagnostics to server rejection errors', async () => {
         assert.equal(error.code, 'SERVER_REJECTED');
         assert.deepEqual(error.diagnostics.response, {
             requestId: 'request-1', success: false, errorCode: 'DUPLICATE',
-            className: 'UserService', method: 'Create', elapsedMs: 5,
+            className: 'UserService', method: null, elapsedMs: 5,
             serverMessage: 'Already exists'
         });
         return true;

--- a/src/popup/components/popup-app.test.js
+++ b/src/popup/components/popup-app.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, test } from 'node:test';
 
-import { POPUP_COMMANDS } from '#src/shared/messaging/protocol.js';
+import { POPUP_COMMANDS } from '#src/shared/messaging/index.js';
 
 function createChromeApi() {
     const listeners = new Set();

--- a/src/shared/message-protocol.test.js
+++ b/src/shared/message-protocol.test.js
@@ -20,7 +20,7 @@ import {
     isRuntimeExportStatusMessage,
     isStorageRequestMessage,
     isStorageResponseMessage
-} from '#src/shared/messaging/protocol.js';
+} from '#src/shared/messaging/index.js';
 
 describe('popup to MAIN command protocol', () => {
     test('every supported popup command maps to a valid MAIN message', () => {

--- a/src/shared/messaging/protocol.js
+++ b/src/shared/messaging/protocol.js
@@ -1,4 +1,4 @@
-import { COMMAND_ROUTES, WINDOW_MESSAGE_TYPES, RUNTIME_MESSAGE_ACTIONS, STORAGE_ACTIONS, MAIN_COMMAND_TYPES, EXPORT_STATE_VALUES, STORAGE_KEY_VALUES } from '#src/shared/messaging/model.js';
+import { COMMAND_ROUTES, WINDOW_MESSAGE_TYPES, RUNTIME_MESSAGE_ACTIONS, STORAGE_ACTIONS, MAIN_COMMAND_TYPES, EXPORT_STATE_VALUES, STORAGE_ACTION_VALUES, STORAGE_KEY_VALUES } from '#src/shared/messaging/model.js';
 import { isRecord, hasOnlyKeys, isNonEmptyString } from '#src/shared/utils.js';
 
 export function getCommandRoute(action) {


### PR DESCRIPTION
## Summary

- fix the video attachment runtime adapter so it creates dialogs through the feature's factory contract
- align the WebSocket transport test fixture with the current logger and browser-runtime assumptions without weakening production dependencies
- add direct behavioral coverage for `FeatureDispatcher` registration, message validation, dispatch, and synchronous/asynchronous failure isolation
- add a composition smoke test that constructs every registered MAIN feature definition with a representative fake runtime and opens it far enough to cross its browser adapter boundary
- add a focused regression test proving the video attachment runtime creates a fresh dialog when reopened
- align the new and deliberately revised tests with the `writing-tests` skill: behavior-shaped names, exactly one `Given`/`When`/`Then` structure per test, focused expectations, and deterministic async synchronization
- repair two pre-existing messaging migration tears exposed by the restored validation path: restore the missing `STORAGE_ACTION_VALUES` model import and point stale tests at the canonical `shared/messaging` barrel

## Scope

This intentionally does not move runtime construction out of `FeatureDispatcher`, standardize feature lifecycle handling, or refactor execution-history integration. Those remain owned by the sibling follow-up issues in #147.

## Validation

GitHub Actions CI #272 passes:
- `npm run lint`
- `npm run test:ci`
- `npm run build`
- `npm run check:build-output`

Closes #148