### PR TITLE
Harden MAIN-world WebSocket interception and socket selection

### DIFF
--- a/src/content/main/infrastructure/websocket-transport.js
+++ b/src/content/main/infrastructure/websocket-transport.js
@@ -177,11 +177,9 @@ function createWebSocketTransport({
     }
 
     function qualifySocket(record, data) {
-        if (!isEdvibeRequestFrame(data)) {
-            return;
+        if (isEdvibeRequestFrame(data)) {
+            selectSocket(record);
         }
-        record.isQualified = true;
-        selectSocket(record);
     }
 
     function handleMessage(event, record) {
@@ -264,12 +262,12 @@ function createWebSocketTransport({
         }
     }
 
-    function observeSocket(socket, url) {
+    function observeSocket(nativeSocket, url) {
         logger.log('Intercepting WebSocket targeting:', url);
+        const socket = nativeSocket;
         const record = {
             socket,
-            socketId: nextSocketId,
-            isQualified: false
+            socketId: nextSocketId
         };
         nextSocketId += 1;
         const nativeSend = socket.send;
@@ -288,11 +286,6 @@ function createWebSocketTransport({
             }
             return result;
         };
-        socket.addEventListener('open', () => {
-            if (record.isQualified && record.socketId === latestQualifiedSocketId) {
-                selectSocket(record);
-            }
-        });
         socket.addEventListener('message', (event) => {
             handleMessage(event, record);
         });

--- a/src/content/main/infrastructure/websocket-transport.js
+++ b/src/content/main/infrastructure/websocket-transport.js
@@ -18,6 +18,31 @@ function createTransportError(code, message, details = {}) {
     return error;
 }
 
+function parseProtocolEnvelope(data) {
+    if (typeof data !== 'string') {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(data);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? parsed
+            : null;
+    } catch (_) {
+        return null;
+    }
+}
+
+function isEdvibeRequestFrame(data) {
+    const envelope = parseProtocolEnvelope(data);
+    if (!envelope || envelope.RequestId === undefined || envelope.RequestId === null) {
+        return false;
+    }
+
+    return typeof envelope.Controller === 'string'
+        && typeof envelope.Method === 'string'
+        && typeof envelope.ProjectName === 'string';
+}
+
 function createWebSocketTransport({
     WebSocketClass = window.WebSocket,
     cryptoApi = window.crypto,
@@ -28,9 +53,10 @@ function createWebSocketTransport({
     logger: parentLogger,
 }) {
     const logger = parentLogger.createChildLogger('Transport');
-    let activeSocket = null;
+    let activeSocketRecord = null;
+    let latestQualifiedSocketId = 0;
     let nextSocketId = 1;
-    let internalSendDepth = 0;
+    const toolboxSendingSockets = new WeakSet();
     const pendingRequests = new Map();
     const responseDiagnostics = new WeakMap();
     const frameObservers = new Set();
@@ -135,7 +161,30 @@ function createWebSocketTransport({
         return candidate;
     }
 
-    function handleMessage(event, socketId) {
+    function selectSocket(record) {
+        if (record.socketId < latestQualifiedSocketId) {
+            return;
+        }
+
+        latestQualifiedSocketId = record.socketId;
+        if (record.socket.readyState !== WebSocketClass.OPEN) {
+            return;
+        }
+        if (activeSocketRecord?.socket !== record.socket) {
+            logger.log(`Edvibe WebSocket selected: #${record.socketId}`);
+        }
+        activeSocketRecord = record;
+    }
+
+    function qualifySocket(record, data) {
+        if (!isEdvibeRequestFrame(data)) {
+            return;
+        }
+        record.isQualified = true;
+        selectSocket(record);
+    }
+
+    function handleMessage(event, record) {
         let data = null;
         if (typeof event.data === 'string') {
             try {
@@ -145,12 +194,15 @@ function createWebSocketTransport({
             }
         }
 
+        const pending = data?.RequestId
+            ? pendingRequests.get(data.RequestId)
+            : null;
         const isToolboxResponse = Boolean(
-            data?.RequestId && pendingRequests.has(data.RequestId)
+            pending && pending.socketId === record.socketId
         );
         emitFrame({
             direction: 'inbound',
-            socketId,
+            socketId: record.socketId,
             data: event.data,
             origin: isToolboxResponse ? 'toolbox' : 'page'
         });
@@ -159,14 +211,10 @@ function createWebSocketTransport({
             return;
         }
         try {
-            if (!data) {
-                return;
-            }
-            if (!data.RequestId || !pendingRequests.has(data.RequestId)) {
+            if (!data || !pending || pending.socketId !== record.socketId) {
                 return;
             }
 
-            const pending = pendingRequests.get(data.RequestId);
             pendingRequests.delete(data.RequestId);
             clearTimeoutFn(pending.timeoutId);
             const elapsedMs = now() - pending.startedAt;
@@ -216,63 +264,89 @@ function createWebSocketTransport({
         }
     }
 
-    function install(rootObject) {
-        function InterceptedWebSocket(url, protocols) {
-            logger.log('Intercepting WebSocket targeting:', url);
-            const socket = protocols === undefined
-                ? new WebSocketClass(url)
-                : new WebSocketClass(url, protocols);
-            const socketId = nextSocketId;
-            nextSocketId += 1;
-            activeSocket = socket;
-            const nativeSend = socket.send;
+    function observeSocket(socket, url) {
+        logger.log('Intercepting WebSocket targeting:', url);
+        const record = {
+            socket,
+            socketId: nextSocketId,
+            isQualified: false
+        };
+        nextSocketId += 1;
+        const nativeSend = socket.send;
 
-            socket.send = function observedSend(data) {
-                emitFrame({
-                    direction: 'outbound',
-                    socketId,
-                    data,
-                    origin: internalSendDepth > 0 ? 'toolbox' : 'page'
-                });
-                return nativeSend.call(socket, data);
-            };
-            socket.addEventListener('message', (event) => {
-                handleMessage(event, socketId);
+        socket.send = function observedSend(data) {
+            const origin = toolboxSendingSockets.has(socket) ? 'toolbox' : 'page';
+            emitFrame({
+                direction: 'outbound',
+                socketId: record.socketId,
+                data,
+                origin
             });
-            return socket;
-        }
+            const result = nativeSend.call(socket, data);
+            if (origin === 'page') {
+                qualifySocket(record, data);
+            }
+            return result;
+        };
+        socket.addEventListener('open', () => {
+            if (record.isQualified && record.socketId === latestQualifiedSocketId) {
+                selectSocket(record);
+            }
+        });
+        socket.addEventListener('message', (event) => {
+            handleMessage(event, record);
+        });
+        socket.addEventListener('close', () => {
+            if (activeSocketRecord?.socket === socket) {
+                activeSocketRecord = null;
+                logger.log(`Edvibe WebSocket closed: #${record.socketId}`);
+            }
+        });
+        return socket;
+    }
 
-        InterceptedWebSocket.prototype = WebSocketClass.prototype;
+    const InterceptedWebSocket = new Proxy(WebSocketClass, {
+        construct(target, args, newTarget) {
+            const socket = Reflect.construct(target, args, newTarget);
+            return observeSocket(socket, args[0]);
+        }
+    });
+
+    function install(rootObject) {
         rootObject.WebSocket = InterceptedWebSocket;
     }
 
     function requireOpenSocket(controller, method) {
-        if (!activeSocket || activeSocket.readyState !== WebSocketClass.OPEN) {
+        if (
+            !activeSocketRecord
+            || activeSocketRecord.socket.readyState !== WebSocketClass.OPEN
+        ) {
             throw createTransportError(
                 'WS_UNAVAILABLE',
-                'Active WebSocket connection is missing. Please reload the Edvibe tab context.',
+                'Active Edvibe WebSocket connection is missing. Please reload the Edvibe tab context.',
                 { controller, method }
             );
         }
 
-        return activeSocket;
+        return activeSocketRecord;
     }
 
     function getConnectionState() {
         return {
             isOpen: Boolean(
-                activeSocket && activeSocket.readyState === WebSocketClass.OPEN
+                activeSocketRecord
+                && activeSocketRecord.socket.readyState === WebSocketClass.OPEN
             )
         };
     }
 
     function sendRequest(controller, method, projectName, valueObject) {
         return new Promise((resolve, reject) => {
-            let socket;
+            let socketRecord;
             try {
-                socket = requireOpenSocket(controller, method);
+                socketRecord = requireOpenSocket(controller, method);
             } catch (error) {
-                logger.log('No active WebSocket connection.');
+                logger.log('No active Edvibe WebSocket connection.');
                 reject(error);
                 return;
             }
@@ -303,6 +377,7 @@ function createWebSocketTransport({
                 method,
                 projectName,
                 requestId: packet.RequestId,
+                socketId: socketRecord.socketId,
                 startedAt,
                 requestValue: diagnostics.value,
                 diagnostics
@@ -310,11 +385,11 @@ function createWebSocketTransport({
             logger.log(`→ ${controller}.${method} [${packet.RequestId}]`);
 
             try {
-                internalSendDepth += 1;
+                toolboxSendingSockets.add(socketRecord.socket);
                 try {
-                    socket.send(JSON.stringify(packet));
+                    socketRecord.socket.send(JSON.stringify(packet));
                 } finally {
-                    internalSendDepth -= 1;
+                    toolboxSendingSockets.delete(socketRecord.socket);
                 }
             } catch (error) {
                 clearTimeoutFn(timeoutId);
@@ -338,14 +413,14 @@ function createWebSocketTransport({
     }
 
     function sendWithoutResponse(controller, method, projectName, valueObject) {
-        const socket = requireOpenSocket(controller, method);
+        const socketRecord = requireOpenSocket(controller, method);
         const packet = createPacket(controller, method, projectName, valueObject);
         logger.log(`→ ${controller}.${method} [${packet.RequestId}] (no response expected)`);
-        internalSendDepth += 1;
+        toolboxSendingSockets.add(socketRecord.socket);
         try {
-            socket.send(JSON.stringify(packet));
+            socketRecord.socket.send(JSON.stringify(packet));
         } finally {
-            internalSendDepth -= 1;
+            toolboxSendingSockets.delete(socketRecord.socket);
         }
     }
 

--- a/src/content/main/infrastructure/websocket-transport.test.js
+++ b/src/content/main/infrastructure/websocket-transport.test.js
@@ -4,28 +4,55 @@ import test from 'node:test';
 import { createWebSocketTransport } from '#src/content/main/infrastructure/websocket-transport.js';
 
 class FakeWebSocket {
+    static CONNECTING = 0;
     static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static customStatic = 'preserved';
+    static instances = [];
 
-    constructor() {
+    constructor(url, protocols) {
+        this.url = url;
+        this.protocols = protocols;
         this.readyState = FakeWebSocket.OPEN;
         this.listeners = new Map();
         this.sent = [];
-        FakeWebSocket.instance = this;
+        FakeWebSocket.instances.push(this);
     }
 
     addEventListener(type, listener) {
-        this.listeners.set(type, listener);
+        const listeners = this.listeners.get(type) || [];
+        listeners.push(listener);
+        this.listeners.set(type, listeners);
+    }
+
+    dispatch(type, event = {}) {
+        for (const listener of this.listeners.get(type) || []) {
+            listener(event);
+        }
     }
 
     send(data) {
         if (this.sendError) {
             throw this.sendError;
         }
+        if (this.readyState !== FakeWebSocket.OPEN) {
+            throw new Error('socket closed');
+        }
         this.sent.push(data);
     }
 
     respond(data) {
-        this.listeners.get('message')({ data: JSON.stringify(data) });
+        this.dispatch('message', { data: JSON.stringify(data) });
+    }
+
+    receive(data) {
+        this.dispatch('message', { data });
+    }
+
+    close() {
+        this.readyState = FakeWebSocket.CLOSED;
+        this.dispatch('close');
     }
 }
 
@@ -39,11 +66,26 @@ function createLogger() {
     return logger;
 }
 
+function pageRequest(requestId = 'page-request') {
+    return JSON.stringify({
+        Controller: 'Lessons',
+        Method: 'Get',
+        ProjectName: 'Books',
+        RequestId: requestId,
+        Value: '{}'
+    });
+}
+
+function qualify(socket, requestId) {
+    socket.send(pageRequest(requestId));
+}
+
 function setup(options = {}) {
     let time = 100;
     const timers = [];
     const root = {};
     const previousWindow = globalThis.window;
+    FakeWebSocket.instances = [];
     globalThis.window = root;
     let transport;
     try {
@@ -67,9 +109,16 @@ function setup(options = {}) {
         }
     }
     const socket = new root.WebSocket('wss://example.test');
-    return { transport, socket, timers, advance: (milliseconds) => {
-        time += milliseconds;
-    } };
+    qualify(socket, 'bootstrap-request');
+    return {
+        transport,
+        root,
+        socket,
+        timers,
+        advance: (milliseconds) => {
+            time += milliseconds;
+        }
+    };
 }
 
 test('createWebSocketTransport should preserve successful response when diagnostics are recorded', async () => {
@@ -204,4 +253,122 @@ test('createWebSocketTransport should preserve malformed server payload when rej
         ]);
         return true;
     });
+});
+
+test('createWebSocketTransport should preserve native constructor and static semantics', () => {
+    // Given
+    const { root } = setup();
+
+    // When
+    const socket = new root.WebSocket('wss://compat.test', ['json']);
+
+    // Then
+    assert.equal(root.WebSocket.OPEN, FakeWebSocket.OPEN);
+    assert.equal(root.WebSocket.CLOSED, FakeWebSocket.CLOSED);
+    assert.equal(root.WebSocket.customStatic, 'preserved');
+    assert.equal(root.WebSocket.prototype, FakeWebSocket.prototype);
+    assert.equal(socket.url, 'wss://compat.test');
+    assert.deepEqual(socket.protocols, ['json']);
+    assert.ok(socket instanceof root.WebSocket);
+    assert.ok(socket instanceof FakeWebSocket);
+    assert.throws(() => root.WebSocket('wss://compat.test'), TypeError);
+});
+
+test('createWebSocketTransport should not let an unrelated newer socket steal Toolbox traffic', () => {
+    // Given
+    const { transport, root, socket: edvibeSocket } = setup();
+    edvibeSocket.sent = [];
+    const unrelatedSocket = new root.WebSocket('wss://unrelated.test');
+    unrelatedSocket.send(JSON.stringify({ type: 'presence', RequestId: 'other' }));
+
+    // When
+    transport.sendWithoutResponse('Lessons', 'Save', 'Books', { LessonId: 7 });
+
+    // Then
+    assert.equal(edvibeSocket.sent.length, 1);
+    assert.equal(unrelatedSocket.sent.length, 1);
+    assert.equal(JSON.parse(edvibeSocket.sent[0]).Controller, 'Lessons');
+});
+
+test('createWebSocketTransport should switch only to a qualified replacement and not fall back to a stale socket', async () => {
+    // Given
+    const { transport, root, socket: firstSocket } = setup();
+    firstSocket.sent = [];
+    const replacementSocket = new root.WebSocket('wss://replacement.test');
+    qualify(replacementSocket, 'replacement-bootstrap');
+    replacementSocket.sent = [];
+
+    // When
+    transport.sendWithoutResponse('Lessons', 'Save', 'Books', { LessonId: 8 });
+    replacementSocket.close();
+
+    // Then
+    assert.equal(firstSocket.sent.length, 0);
+    assert.equal(replacementSocket.sent.length, 1);
+    assert.deepEqual(transport.getConnectionState(), { isOpen: false });
+    await assert.rejects(
+        transport.sendRequest('Lessons', 'Get', 'Books', { LessonId: 8 }),
+        (error) => error.code === 'WS_UNAVAILABLE'
+    );
+
+    // When a reconnect appears
+    const reconnectedSocket = new root.WebSocket('wss://reconnected.test');
+    qualify(reconnectedSocket, 'reconnected-bootstrap');
+    reconnectedSocket.sent = [];
+    transport.sendWithoutResponse('Lessons', 'Save', 'Books', { LessonId: 9 });
+
+    // Then the reconnect becomes authoritative
+    assert.equal(reconnectedSocket.sent.length, 1);
+    assert.deepEqual(transport.getConnectionState(), { isOpen: true });
+});
+
+test('createWebSocketTransport should ignore matching request IDs received on another socket', async () => {
+    // Given
+    const { transport, root, socket: edvibeSocket } = setup();
+    const unrelatedSocket = new root.WebSocket('wss://unrelated.test');
+
+    // When
+    const promise = transport.sendRequest('Users', 'Get', 'School', { Page: 1 });
+    unrelatedSocket.respond({ RequestId: 'request-1', IsSuccess: true, Value: { wrong: true } });
+    edvibeSocket.respond({ RequestId: 'request-1', IsSuccess: true, Value: { right: true } });
+    const response = await promise;
+    edvibeSocket.sent = [];
+    unrelatedSocket.sent = [];
+    transport.sendWithoutResponse('Lessons', 'Save', 'Books', { LessonId: 11 });
+
+    // Then
+    assert.deepEqual(response, {
+        RequestId: 'request-1', IsSuccess: true, Value: { right: true }
+    });
+    assert.equal(edvibeSocket.sent.length, 1);
+    assert.equal(unrelatedSocket.sent.length, 0);
+});
+
+test('createWebSocketTransport should keep frame observation and Toolbox origin tagging across sockets', () => {
+    // Given
+    const { transport, root, socket: edvibeSocket } = setup();
+    const frames = [];
+    transport.subscribeFrames((frame) => frames.push(frame));
+    edvibeSocket.sent = [];
+    const unrelatedSocket = new root.WebSocket('wss://unrelated.test');
+
+    // When
+    unrelatedSocket.send('plain-page-frame');
+    transport.sendWithoutResponse('Lessons', 'Save', 'Books', { LessonId: 10 });
+
+    // Then
+    assert.equal(frames.length, 2);
+    assert.deepEqual(
+        frames.map(({ direction, socketId, origin, data }) => ({ direction, socketId, origin, data })),
+        [
+            {
+                direction: 'outbound', socketId: 2, origin: 'page',
+                data: 'plain-page-frame'
+            },
+            {
+                direction: 'outbound', socketId: 1, origin: 'toolbox',
+                data: edvibeSocket.sent[0]
+            }
+        ]
+    );
 });


### PR DESCRIPTION
## Summary

- preserve native WebSocket constructor/static/prototype semantics with a constructor proxy
- qualify the Edvibe transport socket from observed Edvibe request envelopes instead of treating the newest socket as authoritative
- handle replacement, close, and reconnect transitions without falling back to stale sockets
- bind pending responses to the socket that sent the Toolbox request and preserve frame observation/origin tagging across all sockets
- add behavioral coverage for simultaneous sockets, constructor compatibility, closed/replaced sockets, reconnects, cross-socket request IDs, and recorder-facing frame metadata

## Validation

- targeted WebSocket transport suite: 11 tests passed
- GitHub Actions: ESLint, full test suite, production build, and build-output validation passed
- branch diff is limited to the transport and its colocated tests; generated `dist/` is untouched

Closes #150