### PR TITLE
refactor: standardize MAIN feature session lifecycle

### DIFF
--- a/src/content/main/application/feature-session.js
+++ b/src/content/main/application/feature-session.js
@@ -1,0 +1,76 @@
+export function createFeatureSession({ operationGuard, operationName }) {
+    if (
+        typeof operationGuard?.activate !== 'function'
+        || typeof operationGuard?.release !== 'function'
+    ) {
+        throw new TypeError('operationGuard with activate/release is required');
+    }
+
+    const name = String(operationName || '').trim();
+    if (!name) {
+        throw new TypeError('operationName is required');
+    }
+
+    let active = false;
+    let dialog = null;
+
+    function isOpen() {
+        return active || dialog !== null;
+    }
+
+    function activate() {
+        if (isOpen() || !operationGuard.activate(name)) {
+            return false;
+        }
+        active = true;
+        return true;
+    }
+
+    function ownDialog(nextDialog) {
+        if (!active) {
+            throw new Error('Feature session must be active before owning a dialog.');
+        }
+        if (!nextDialog) {
+            throw new TypeError('dialog is required');
+        }
+        if (dialog && dialog !== nextDialog) {
+            throw new Error('Feature session already owns a dialog.');
+        }
+        dialog = nextDialog;
+        return nextDialog;
+    }
+
+    function release() {
+        if (!active) {
+            return false;
+        }
+        active = false;
+        if (!operationGuard.release(name)) {
+            throw new Error(`Operation guard ownership for "${name}" was lost.`);
+        }
+        return true;
+    }
+
+    function close({ removeDialog = true } = {}) {
+        const currentDialog = dialog;
+        dialog = null;
+        try {
+            if (removeDialog) {
+                currentDialog?.remove?.();
+            }
+        } finally {
+            release();
+        }
+        return currentDialog;
+    }
+
+    return Object.freeze({
+        activate,
+        ownDialog,
+        release,
+        close,
+        isActive: () => active,
+        isOpen,
+        getDialog: () => dialog
+    });
+}

--- a/src/content/main/application/feature-session.test.js
+++ b/src/content/main/application/feature-session.test.js
@@ -2,7 +2,35 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { createFeatureSession } from '#src/content/main/application/feature-session.js';
-import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
+
+function createOperationGuard() {
+    let activeOperation = null;
+    const activations = [];
+    const releases = [];
+    return {
+        activations,
+        releases,
+        activate(operationName) {
+            activations.push(operationName);
+            if (activeOperation !== null) {
+                return false;
+            }
+            activeOperation = operationName;
+            return true;
+        },
+        release(operationName) {
+            releases.push(operationName);
+            if (activeOperation !== operationName) {
+                return false;
+            }
+            activeOperation = null;
+            return true;
+        },
+        canStart() {
+            return activeOperation === null;
+        }
+    };
+}
 
 function createDialog({ remove = () => {} } = {}) {
     return { remove };
@@ -10,7 +38,7 @@ function createDialog({ remove = () => {} } = {}) {
 
 test('feature session should acquire the operation guard once and block duplicate activation', () => {
     // Given
-    const operationGuard = new OperationGuard();
+    const operationGuard = createOperationGuard();
     const session = createFeatureSession({ operationGuard, operationName: 'example' });
 
     // When
@@ -22,11 +50,12 @@ test('feature session should acquire the operation guard once and block duplicat
     assert.equal(duplicateActivation, false);
     assert.equal(session.isActive(), true);
     assert.equal(operationGuard.canStart(), false);
+    assert.deepEqual(operationGuard.activations, ['example']);
 });
 
 test('feature session should release guard ownership exactly once on normal close', () => {
     // Given
-    const operationGuard = new OperationGuard();
+    const operationGuard = createOperationGuard();
     let removeCount = 0;
     const dialog = createDialog({ remove: () => { removeCount += 1; } });
     const session = createFeatureSession({ operationGuard, operationName: 'example' });
@@ -42,11 +71,12 @@ test('feature session should release guard ownership exactly once on normal clos
     assert.equal(duplicateRelease, false);
     assert.equal(session.isOpen(), false);
     assert.equal(operationGuard.canStart(), true);
+    assert.deepEqual(operationGuard.releases, ['example']);
 });
 
 test('feature session should release the guard while retaining an initialization error dialog', () => {
     // Given
-    const operationGuard = new OperationGuard();
+    const operationGuard = createOperationGuard();
     let removeCount = 0;
     const dialog = createDialog({ remove: () => { removeCount += 1; } });
     const session = createFeatureSession({ operationGuard, operationName: 'example' });
@@ -71,11 +101,12 @@ test('feature session should release the guard while retaining an initialization
     assert.equal(removeCount, 1);
     assert.equal(session.isOpen(), false);
     assert.equal(operationGuard.canStart(), true);
+    assert.deepEqual(operationGuard.releases, ['example']);
 });
 
 test('feature session should release the guard even when dialog removal fails', () => {
     // Given
-    const operationGuard = new OperationGuard();
+    const operationGuard = createOperationGuard();
     const session = createFeatureSession({ operationGuard, operationName: 'example' });
     session.activate();
     session.ownDialog(createDialog({
@@ -88,11 +119,12 @@ test('feature session should release the guard even when dialog removal fails', 
     assert.throws(() => session.close(), /remove failed/);
     assert.equal(session.isOpen(), false);
     assert.equal(operationGuard.canStart(), true);
+    assert.deepEqual(operationGuard.releases, ['example']);
 });
 
 test('feature session should allow a fresh dialog after close and reopen', () => {
     // Given
-    const operationGuard = new OperationGuard();
+    const operationGuard = createOperationGuard();
     const session = createFeatureSession({ operationGuard, operationName: 'example' });
     const firstDialog = createDialog();
     const secondDialog = createDialog();

--- a/src/content/main/application/feature-session.test.js
+++ b/src/content/main/application/feature-session.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
+import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
+
+function createDialog({ remove = () => {} } = {}) {
+    return { remove };
+}
+
+test('feature session should acquire the operation guard once and block duplicate activation', () => {
+    // Given
+    const operationGuard = new OperationGuard();
+    const session = createFeatureSession({ operationGuard, operationName: 'example' });
+
+    // When
+    const firstActivation = session.activate();
+    const duplicateActivation = session.activate();
+
+    // Then
+    assert.equal(firstActivation, true);
+    assert.equal(duplicateActivation, false);
+    assert.equal(session.isActive(), true);
+    assert.equal(operationGuard.canStart(), false);
+});
+
+test('feature session should release guard ownership exactly once on normal close', () => {
+    // Given
+    const operationGuard = new OperationGuard();
+    let removeCount = 0;
+    const dialog = createDialog({ remove: () => { removeCount += 1; } });
+    const session = createFeatureSession({ operationGuard, operationName: 'example' });
+    session.activate();
+    session.ownDialog(dialog);
+
+    // When
+    session.close();
+    const duplicateRelease = session.release();
+
+    // Then
+    assert.equal(removeCount, 1);
+    assert.equal(duplicateRelease, false);
+    assert.equal(session.isOpen(), false);
+    assert.equal(operationGuard.canStart(), true);
+});
+
+test('feature session should release the guard while retaining an initialization error dialog', () => {
+    // Given
+    const operationGuard = new OperationGuard();
+    let removeCount = 0;
+    const dialog = createDialog({ remove: () => { removeCount += 1; } });
+    const session = createFeatureSession({ operationGuard, operationName: 'example' });
+    session.activate();
+    session.ownDialog(dialog);
+
+    // When
+    session.release();
+
+    // Then
+    assert.equal(session.isActive(), false);
+    assert.equal(session.isOpen(), true);
+    assert.equal(session.getDialog(), dialog);
+    assert.equal(removeCount, 0);
+    assert.equal(operationGuard.canStart(), true);
+    assert.equal(session.activate(), false);
+
+    // When the visible error dialog is later closed
+    session.close();
+
+    // Then
+    assert.equal(removeCount, 1);
+    assert.equal(session.isOpen(), false);
+    assert.equal(operationGuard.canStart(), true);
+});
+
+test('feature session should release the guard even when dialog removal fails', () => {
+    // Given
+    const operationGuard = new OperationGuard();
+    const session = createFeatureSession({ operationGuard, operationName: 'example' });
+    session.activate();
+    session.ownDialog(createDialog({
+        remove() {
+            throw new Error('remove failed');
+        }
+    }));
+
+    // When / Then
+    assert.throws(() => session.close(), /remove failed/);
+    assert.equal(session.isOpen(), false);
+    assert.equal(operationGuard.canStart(), true);
+});
+
+test('feature session should allow a fresh dialog after close and reopen', () => {
+    // Given
+    const operationGuard = new OperationGuard();
+    const session = createFeatureSession({ operationGuard, operationName: 'example' });
+    const firstDialog = createDialog();
+    const secondDialog = createDialog();
+    session.activate();
+    session.ownDialog(firstDialog);
+    session.close();
+
+    // When
+    const reopened = session.activate();
+    session.ownDialog(secondDialog);
+
+    // Then
+    assert.equal(reopened, true);
+    assert.equal(session.getDialog(), secondDialog);
+    assert.equal(operationGuard.canStart(), false);
+});

--- a/src/content/main/features/action-recorder/action-recorder.js
+++ b/src/content/main/features/action-recorder/action-recorder.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { RECORDER_DIALOG_TAG } from '#src/content/main/features/action-recorder/action-recorder-dialog.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
 
@@ -116,12 +117,12 @@ export function createActionRecorderFeatureV2({
     operationGuard,
     logger,
 }) {
-    let recorderOpen = false;
+    const session = createFeatureSession({ operationGuard, operationName: 'recording' });
 
     const actionRecorderFeature = createActionRecorderFeature({
         subscribeFrames: transport.subscribeFrames,
         createPanel() {
-            const panel = document.createElement(RECORDER_DIALOG_TAG);
+            const panel = session.ownDialog(document.createElement(RECORDER_DIALOG_TAG));
             const configure = panel.configure.bind(panel);
             panel.configure = (options = {}) => configure({
                 ...options,
@@ -129,12 +130,10 @@ export function createActionRecorderFeatureV2({
                     try {
                         options.onClose?.();
                     } finally {
-                        recorderOpen = false;
-                        operationGuard.release('recording');
+                        session.close({ removeDialog: false });
                     }
                 }
             });
-            recorderOpen = true;
             return panel;
         },
         logger: logger.createChildLogger('Recorder')
@@ -143,13 +142,13 @@ export function createActionRecorderFeatureV2({
     return {
         ...actionRecorderFeature,
         openActionRecorder() {
-            if (recorderOpen) {
+            if (session.isOpen()) {
                 actionRecorderFeature.open();
-            } else if (operationGuard.activate('recording')) {
+            } else if (session.activate()) {
                 try {
                     actionRecorderFeature.open();
                 } catch (error) {
-                    operationGuard.release('recording');
+                    session.close();
                     throw error;
                 }
             } else {

--- a/src/content/main/features/batch-lesson-access/batch-lesson-access-history.js
+++ b/src/content/main/features/batch-lesson-access/batch-lesson-access-history.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { BATCH_ACCESS_DIALOG_TAG } from '#src/content/main/features/batch-lesson-access/batch-lesson-access-dialog.js';
 import * as modelApi from '#src/content/main/features/batch-lesson-access/batch-lesson-access-history-model.js';
 import * as recordApi from '#src/content/main/features/batch-lesson-access/batch-lesson-access-history-record.js';
@@ -46,8 +47,7 @@ export function createHistoryAwareFeatureV2({
         createFeature: batchAccessApi.createBatchLessonAccessFeature,
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('batch-access'),
+        session: createFeatureSession({ operationGuard, operationName: 'batch-access' }),
         createDialog: () => document.createElement(BATCH_ACCESS_DIALOG_TAG),
         copyText: (text) => navigator.clipboard.writeText(text),
         persistExecution: executionHistoryService.persistTerminal,

--- a/src/content/main/features/batch-lesson-access/batch-lesson-access.js
+++ b/src/content/main/features/batch-lesson-access/batch-lesson-access.js
@@ -332,13 +332,11 @@ function freezePlan({
 function createBatchLessonAccessFeature({
     sendRequest,
     getConnectionState,
-    canStart,
-    onActiveChange,
+    session,
     createDialog = () => document.createElement(BATCH_ACCESS_DIALOG_TAG),
     copyText = async () => {},
     logger = { log() {} }
 }) {
-    let active = false;
     let running = false;
     let pupils = [];
     let lessonCatalogue = [];
@@ -346,14 +344,6 @@ function createBatchLessonAccessFeature({
     let completedResult = null;
     let marathonId = null;
     let dialog = null;
-
-    function releaseOperation() {
-        if (!active) {
-            return;
-        }
-        active = false;
-        onActiveChange(false);
-    }
 
     function handleClose() {
         running = false;
@@ -363,7 +353,7 @@ function createBatchLessonAccessFeature({
         completedResult = null;
         marathonId = null;
         dialog = null;
-        releaseOperation();
+        session.close();
     }
 
     function getErrorCode(error) {
@@ -603,27 +593,25 @@ function createBatchLessonAccessFeature({
 
     async function open() {
         if (
-            active
+            session.isOpen()
             || document.getElementById(BATCH_ACCESS_OVERLAY_ID)
         ) {
             return;
         }
-        if (!canStart()) {
+        if (!session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
 
         marathonId = parseMarathonId(window.location.href);
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page before opening batch lesson access.');
             return;
         }
 
-        active = true;
-        onActiveChange(true);
-
         try {
-            dialog = createDialog();
+            dialog = session.ownDialog(createDialog());
             dialog.addEventListener('edvibe-dialog-close', handleClose);
             dialog.addEventListener('edvibe-batch-access-input-change', (event) => {
                 const parsed = parseEmailInput(event?.detail?.emailInput);
@@ -677,7 +665,7 @@ function createBatchLessonAccessFeature({
                     throw error;
                 }
             } finally {
-                releaseOperation();
+                session.release();
             }
         }
     }

--- a/src/content/main/features/batch-section-creation/batch-section-creation.js
+++ b/src/content/main/features/batch-section-creation/batch-section-creation.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { BATCH_SECTION_DIALOG_TAG } from '#src/content/main/features/batch-section-creation/batch-section-creation-dialog.js';
 import { createHistoryAwareDialog } from '#src/content/main/features/batch-section-creation/batch-section-creation-history.js';
 import { createImageUploadCreationAdapter, dynamicImageRecipe } from '#src/content/main/features/batch-section-creation/batch-section-image-upload.js';
@@ -567,8 +568,10 @@ export function createBatchSectionCreationFeatureV2({
     return createBatchSectionCreationFeature({
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('batch-section-creation'),
+        session: createFeatureSession({
+            operationGuard,
+            operationName: 'batch-section-creation'
+        }),
         adapter: batchSectionCreationAdapter,
         createDialog: createBatchSectionCreationDialog,
         copyText: (text) => navigator.clipboard.writeText(text),
@@ -587,14 +590,12 @@ const batchSectionCreationFeatureDefinition = Object.freeze({
 function createBatchSectionCreationFeature({
     sendRequest,
     getConnectionState,
-    canStart,
-    onActiveChange,
+    session,
     adapter,
     createDialog = () => document.createElement(DIALOG_TAG),
     copyText = async () => { },
     logger = { log() {} }
 }) {
-    let active = false;
     let running = false;
     let dialog = null;
     let marathonId = null;
@@ -602,20 +603,13 @@ function createBatchSectionCreationFeature({
     let pendingPlan = null;
     let completedResult = null;
 
-    function release() {
-        if (active) {
-            active = false;
-            onActiveChange(false);
-        }
-    }
-
     function close() {
         running = false;
         dialog = null;
         lessons = [];
         pendingPlan = null;
         completedResult = null;
-        release();
+        session.close();
     }
 
     async function preflight(event) {
@@ -701,23 +695,22 @@ function createBatchSectionCreationFeature({
     }
 
     async function open() {
-        if (active || document.getElementById(OVERLAY_ID)) {
+        if (session.isOpen() || document.getElementById(OVERLAY_ID)) {
             return;
         }
-        if (!canStart()) {
+        if (!session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
         marathonId = parseMarathonId(window.location.href);
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page before creating sections.');
             return;
         }
 
-        active = true;
-        onActiveChange(true);
         try {
-            dialog = createDialog();
+            dialog = session.ownDialog(createDialog());
             dialog.addEventListener('edvibe-dialog-close', close);
             dialog.addEventListener('edvibe-batch-section-preflight', preflight);
             dialog.addEventListener('edvibe-batch-section-confirm', confirm);
@@ -741,7 +734,7 @@ function createBatchSectionCreationFeature({
             try {
                 dialog?.showFatalError?.(error);
             } finally {
-                release();
+                session.release();
             }
         }
     }

--- a/src/content/main/features/batch-section-deletion/batch-section-deletion-history.js
+++ b/src/content/main/features/batch-section-deletion/batch-section-deletion-history.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { BATCH_SECTION_DELETION_DIALOG_TAG } from '#src/content/main/features/batch-section-deletion/batch-section-deletion-dialog.js';
 import * as coreApi from '#src/content/main/features/batch-section-deletion/batch-section-deletion.js';
 import { historyDiagnostics } from '#src/content/main/infrastructure/history-diagnostics.js';
@@ -443,8 +444,10 @@ export function createBatchSectionDeletionFeatureV2({
     return createBatchSectionDeletionFeature({
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('batch-section-deletion'),
+        session: createFeatureSession({
+            operationGuard,
+            operationName: 'batch-section-deletion'
+        }),
         createDialog: () => document.createElement(BATCH_SECTION_DELETION_DIALOG_TAG),
         copyText: (text) => navigator.clipboard.writeText(text),
         persistExecution: executionHistoryService.persistTerminal,

--- a/src/content/main/features/batch-section-deletion/batch-section-deletion.js
+++ b/src/content/main/features/batch-section-deletion/batch-section-deletion.js
@@ -223,34 +223,33 @@ function buildExecutionHistoryInput({ marathonId, startedAt, completedAt, result
 function createBatchSectionDeletionFeature({
     sendRequest,
     getConnectionState,
-    canStart,
-    onActiveChange,
+    session,
     createDialog,
     copyText,
     persistExecution = async () => Object.freeze({ stored: false }),
     openHistory = () => {},
     logger = { log() {} }
 }) {
-    let active = false;
     async function open() {
-        if (active || !canStart()) {
+        if (session.isOpen() || !session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
         const marathonId = parseMarathonId(window.location.href);
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page first.');
             return;
         }
         if (getConnectionState?.()?.ready === false) {
+            session.release();
             window.alert('Edvibe WebSocket connection is not ready.');
             return;
         }
-        active = true;
-        onActiveChange(true);
-        const dialog = createDialog();
-        document.body.append(dialog);
+
         try {
+            const dialog = session.ownDialog(createDialog());
+            document.body.append(dialog);
             const lessons = await loadLessonCatalogue({ sendRequest, marathonId });
             dialog.configure({
                 marathonId,
@@ -280,22 +279,16 @@ function createBatchSectionDeletionFeature({
                 },
                 onCopy: copyText,
                 onOpenHistory(executionId) {
-                    dialog.remove();
-                    active = false;
-                    onActiveChange(false);
+                    session.close();
                     openHistory(executionId);
                 },
                 onClose() {
-                    dialog.remove();
-                    active = false;
-                    onActiveChange(false);
+                    session.close();
                 }
             });
         } catch (error) {
             logger.log('Failed to open batch section deletion:', error);
-            dialog.remove();
-            active = false;
-            onActiveChange(false);
+            session.close();
             window.alert(error.message || 'Failed to load lessons.');
         }
     }

--- a/src/content/main/features/batch-user-management/batch-user-management.js
+++ b/src/content/main/features/batch-user-management/batch-user-management.js
@@ -1,4 +1,5 @@
 /* eslint-disable perfectionist/sort-imports */
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import {
     appendPage,
     createFeatureError,
@@ -334,8 +335,10 @@ export function createBatchUserManagementFeatureV2({
     return createBatchUserManagementFeature({
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('batch-user-management'),
+        session: createFeatureSession({
+            operationGuard,
+            operationName: 'batch-user-management'
+        }),
         createDialog: createBatchUserManagementDialog,
         logger: logger.createChildLogger('BatchUserManagement')
     });
@@ -352,25 +355,15 @@ const batchUserManagementFeatureDefinition = Object.freeze({
 function createBatchUserManagementFeature({
     sendRequest,
     getConnectionState,
-    canStart,
-    onActiveChange,
+    session,
     createDialog = () => document.createElement(USER_MANAGEMENT_DIALOG_TAG),
     logger = { log() {} }
 }) {
-    let active = false;
     let running = false;
     let pupils = [];
     let currentRows = [];
     let marathonId = null;
     let dialog = null;
-
-    function releaseOperation() {
-        if (!active) {
-            return;
-        }
-        active = false;
-        onActiveChange(false);
-    }
 
     function handleClose() {
         running = false;
@@ -378,7 +371,7 @@ function createBatchUserManagementFeature({
         currentRows = [];
         marathonId = null;
         dialog = null;
-        releaseOperation();
+        session.close();
     }
 
     function getErrorCode(error) {
@@ -512,23 +505,22 @@ function createBatchUserManagementFeature({
     }
 
     async function open() {
-        if (active || document.getElementById(USER_MANAGEMENT_OVERLAY_ID)) {
+        if (session.isOpen() || document.getElementById(USER_MANAGEMENT_OVERLAY_ID)) {
             return;
         }
-        if (!canStart()) {
+        if (!session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
         marathonId = parseMarathonId(window.location.href);
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page before managing users.');
             return;
         }
-        active = true;
-        onActiveChange(true);
 
         try {
-            dialog = createDialog();
+            dialog = session.ownDialog(createDialog());
             dialog.addEventListener('edvibe-dialog-close', handleClose);
             dialog.addEventListener('edvibe-batch-user-management-input-change', handleInput);
             dialog.addEventListener('edvibe-batch-user-management-check', handleCheck);
@@ -555,7 +547,7 @@ function createBatchUserManagementFeature({
             } catch (renderError) {
                 logger.log(`Batch user management error rendering failed (${getErrorCode(renderError)}).`);
             } finally {
-                releaseOperation();
+                session.release();
             }
         }
     }

--- a/src/content/main/features/batch-user-onboarding/batch-user-onboarding-runtime.test.js
+++ b/src/content/main/features/batch-user-onboarding/batch-user-onboarding-runtime.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { createBatchUserOnboardingFeatureV2 } from '#src/content/main/features/batch-user-onboarding/batch-user-onboarding.js';
+import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
 
 function createDialog() {
     return {
@@ -69,7 +70,7 @@ test('createBatchUserOnboardingFeatureV2 should use runtime page context and Edv
     t.after(browser.restore);
     const pupilRequests = [];
     const transportRequests = [];
-    const activeChanges = [];
+    const operationGuard = new OperationGuard();
     const logger = {
         createChildLogger() {
             return { log() { } };
@@ -83,10 +84,7 @@ test('createBatchUserOnboardingFeatureV2 should use runtime page context and Edv
             },
             getConnectionState: () => ({ isOpen: true })
         },
-        operationGuard: {
-            canStart: () => true,
-            guardedActiveChange: () => (active) => activeChanges.push(active)
-        },
+        operationGuard,
         logger,
         executionHistoryService: {
             persistTerminal: async () => ({ stored: true })
@@ -117,8 +115,14 @@ test('createBatchUserOnboardingFeatureV2 should use runtime page context and Edv
         projectName: 'Marathons',
         value: { MarathonId: 777 }
     });
-    assert.deepEqual(activeChanges, [true]);
+    assert.equal(operationGuard.canStart(), false);
     assert.deepEqual(browser.appended, [dialog]);
     assert.deepEqual(browser.alerts, []);
     assert.ok(dialog.configuration);
+
+    // When
+    dialog.configuration.onClose();
+
+    // Then
+    assert.equal(operationGuard.canStart(), true);
 });

--- a/src/content/main/features/batch-user-onboarding/batch-user-onboarding.js
+++ b/src/content/main/features/batch-user-onboarding/batch-user-onboarding.js
@@ -1,4 +1,5 @@
 /* eslint-disable perfectionist/sort-imports */
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import {
     loadModerators,
     normalizeModeratorCatalogue,
@@ -50,8 +51,10 @@ export function createBatchUserOnboardingFeatureV2({
     return createBatchUserOnboardingFeature({
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('batch-user-onboarding'),
+        session: createFeatureSession({
+            operationGuard,
+            operationName: 'batch-user-onboarding'
+        }),
         createDialog: () => document.createElement(BATCH_USER_ONBOARDING_DIALOG_TAG),
         copyText: (text) => navigator.clipboard.writeText(text),
         persistExecution: executionHistoryService.persistTerminal,
@@ -78,8 +81,7 @@ const batchUserOnboardingFeatureDefinition = Object.freeze({
 function createBatchUserOnboardingFeature({
     sendRequest,
     getConnectionState,
-    canStart,
-    onActiveChange,
+    session,
     createDialog = () => document.createElement(DIALOG_TAG),
     copyText = (text) => navigator.clipboard.writeText(text),
     persistExecution = async () => Object.freeze({ stored: false }),
@@ -92,31 +94,22 @@ function createBatchUserOnboardingFeature({
     now = () => new Date(),
     logger = { log() {} }
 }) {
-    let active = false;
-    function release() {
-        if (!active) {
-            return;
-        }
-        active = false;
-        onActiveChange(false);
-    }
-
     async function open() {
-        if (active || !canStart()) {
+        if (session.isOpen() || !session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
         const marathonId = getMarathonId();
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page before adding users.');
             return;
         }
 
-        active = true;
-        onActiveChange(true);
-        const dialog = createDialog();
-        (document.body || document.documentElement).appendChild(dialog);
+        let dialog;
         try {
+            dialog = session.ownDialog(createDialog());
+            (document.body || document.documentElement).appendChild(dialog);
             dialog.showLoading?.('Loading marathon users and curators…');
             const [pupils, moderators] = await Promise.all([
                 loadPupils({ marathonId }),
@@ -193,21 +186,18 @@ function createBatchUserOnboardingFeature({
                 },
                 onCopy: copyText,
                 onOpenHistory(executionId) {
-                    dialog.remove();
-                    release();
+                    session.close();
                     openHistory(executionId);
                 },
                 onClose() {
-                    dialog.remove();
-                    release();
+                    session.close();
                 }
             });
             dialog.showConfigure?.();
             logger.log(`Batch user onboarding initialized for MarathonId ${marathonId}.`);
         } catch (error) {
             logger.log(`Batch user onboarding initialization failed (${error.code || 'UNKNOWN_ERROR'}).`);
-            dialog.remove();
-            release();
+            session.close();
             window.alert(error.message || 'Could not initialize batch user onboarding.');
         }
     }

--- a/src/content/main/features/execution-history/execution-history.js
+++ b/src/content/main/features/execution-history/execution-history.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { EXECUTION_HISTORY_DIALOG_TAG } from '#src/content/main/features/execution-history/execution-history-dialog.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
 
@@ -10,8 +11,7 @@ export function createExecutionHistoryFeatureV2({
 }) {
     return createExecutionHistoryFeature({
         service: executionHistoryService,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('history'),
+        session: createFeatureSession({ operationGuard, operationName: 'history' }),
         createDialog: () => document.createElement(EXECUTION_HISTORY_DIALOG_TAG),
         logger: logger.createChildLogger('History')
     });
@@ -19,38 +19,31 @@ export function createExecutionHistoryFeatureV2({
 
 function createExecutionHistoryFeature({
     service,
-    canStart,
-    onActiveChange,
+    session,
     createDialog,
     logger = { log() {} },
 }) {
-    let active = false;
     function open({ executionId = null } = {}) {
-        if (active || document.getElementById(HISTORY_OVERLAY_ID)) {
+        if (session.isOpen() || document.getElementById(HISTORY_OVERLAY_ID)) {
             return;
         }
-        if (!canStart()) {
+        if (!session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
-        active = true;
-        onActiveChange(true);
         try {
-            const dialog = createDialog();
+            const dialog = session.ownDialog(createDialog());
             dialog.id = HISTORY_OVERLAY_ID;
             dialog.configure({
                 service,
                 initialExecutionId: executionId,
                 onClose() {
-                    dialog.remove();
-                    active = false;
-                    onActiveChange(false);
+                    session.close();
                 }
             });
             (document.body || document.documentElement).append(dialog);
         } catch (error) {
-            active = false;
-            onActiveChange(false);
+            session.close();
             logger.log('Failed to open execution history:', error);
             window.alert(error.message || 'Could not open execution history.');
         }

--- a/src/content/main/features/reset-lessons/reset-lessons-runtime.test.js
+++ b/src/content/main/features/reset-lessons/reset-lessons-runtime.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createResetLessonsFeatureV2 } from '#src/content/main/features/reset-lessons/reset-lessons.js';
+import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
+
+function installBrowserGlobals(dialog) {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        writable: true,
+        value: { alert() {}, confirm: () => true }
+    });
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        writable: true,
+        value: {
+            body: { appendChild() {} },
+            createElement: () => dialog,
+            getElementById: () => null
+        }
+    });
+    return () => {
+        if (previousWindow) {
+            Object.defineProperty(globalThis, 'window', previousWindow);
+        } else {
+            delete globalThis.window;
+        }
+        if (previousDocument) {
+            Object.defineProperty(globalThis, 'document', previousDocument);
+        } else {
+            delete globalThis.document;
+        }
+    };
+}
+
+test('reset initialization failure should release the guard while keeping the error dialog closable', async (t) => {
+    // Given
+    const listeners = new Map();
+    let shownError = null;
+    let removeCount = 0;
+    const dialog = {
+        addEventListener(type, listener) {
+            listeners.set(type, listener);
+        },
+        configure() {},
+        remove() {
+            removeCount += 1;
+        },
+        setLoading() {},
+        showError(message) {
+            shownError = message;
+        }
+    };
+    t.after(installBrowserGlobals(dialog));
+    const operationGuard = new OperationGuard();
+    const feature = createResetLessonsFeatureV2({
+        transport: {
+            sendRequest: async () => {
+                throw new Error('initial load failed');
+            },
+            sendWithoutResponse() {}
+        },
+        operationGuard,
+        pageContext: { marathonId: 123 },
+        logger: { createChildLogger: () => ({ log() {} }) }
+    });
+
+    // When
+    await feature.open();
+
+    // Then
+    assert.equal(shownError, 'initial load failed');
+    assert.equal(operationGuard.canStart(), true);
+    assert.equal(removeCount, 0);
+
+    // When the retained error dialog closes
+    listeners.get('edvibe-dialog-close')();
+
+    // Then
+    assert.equal(removeCount, 1);
+    assert.equal(operationGuard.canStart(), true);
+});

--- a/src/content/main/features/reset-lessons/reset-lessons.js
+++ b/src/content/main/features/reset-lessons/reset-lessons.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { RESET_DIALOG_TAG } from '#src/content/main/features/reset-lessons/reset-lessons-dialog.js';
 import { parseMarathonId } from '#src/content/main/page-context.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
@@ -303,8 +304,7 @@ export function createResetLessonsFeatureV2({
     return createResetLessonsFeature({
         sendRequest: transport.sendRequest,
         sendWithoutResponse: transport.sendWithoutResponse,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('reset'),
+        session: createFeatureSession({ operationGuard, operationName: 'reset' }),
         getMarathonId: () => pageContext.marathonId,
         logger: logger.createChildLogger('Reset')
     });
@@ -321,99 +321,88 @@ const resetLessonsFeatureDefinition = Object.freeze({
 function createResetLessonsFeature({
     sendRequest,
     sendWithoutResponse,
-    canStart,
-    onActiveChange,
+    session,
     createDialog = () => document.createElement(RESET_DIALOG_TAG),
     getMarathonId = () => parseMarathonId(window.location.href),
     logger = { log() {} }
 }) {
     let running = false;
-    let active = false;
-
-    function releaseOperation() {
-        if (!active) {
-            return;
-        }
-        active = false;
-        onActiveChange(false);
-    }
 
     async function open() {
-        if (document.getElementById(RESET_OVERLAY_ID)) {
+        if (session.isOpen() || document.getElementById(RESET_OVERLAY_ID)) {
             return;
         }
-        if (!canStart()) {
+        if (!session.activate()) {
             window.alert('Another Edvibe Toolbox operation is already running.');
             return;
         }
 
         const marathonId = getMarathonId();
         if (!marathonId) {
+            session.release();
             window.alert('Open an Edvibe marathon page before resetting lessons.');
             return;
         }
 
-        active = true;
-        onActiveChange(true);
-
-        const dialog = createDialog();
-        dialog.addEventListener('edvibe-dialog-close', releaseOperation);
-        dialog.addEventListener('edvibe-reset-request', async (event) => {
-            const { pupil, lessons } = event.detail;
-            const confirmed = window.confirm(
-                `Reset ${lessons.length} lesson(s) for ${pupil.Email}?`
-            );
-            if (!confirmed) {
-                return;
-            }
-
-            running = true;
-            dialog.lock();
-            let completed = false;
-
-            try {
-                dialog.showDiscovery('Discovering exercises...');
-                const work = await discoverResetWork({
-                    sendRequest,
-                    wait,
-                    marathonId,
-                    pupilId: pupil.PupilId,
-                    lessons,
-                    onDiscovery: (message) => dialog.showDiscovery(message),
-                    logger
-                });
-                await executeResetWork({
-                    sendRequest,
-                    sendWithoutResponse,
-                    wait,
-                    marathonId,
-                    pupilId: pupil.PupilId,
-                    work,
-                    onProgress: (progress) => dialog.showProgress(progress),
-                    logger
-                });
-                dialog.showComplete('Selected lesson progress was reset successfully.');
-                completed = true;
-            } catch (error) {
-                const lessonIds = lessons
-                    .map((lesson) => lesson.MarathonLessonId)
-                    .join(', ');
-                logger.log(
-                    `Reset stopped for PupilId ${pupil.PupilId}; `
-                    + `MarathonLessonIds: ${lessonIds} (${getErrorType(error)}).`
-                );
-                dialog.showError(error.message);
-            } finally {
-                running = false;
-                if (completed) {
-                    dialog.completeRun();
-                } else {
-                    dialog.unlockAfterRun();
-                }
-            }
-        });
-
+        let dialog;
         try {
+            dialog = session.ownDialog(createDialog());
+            dialog.addEventListener('edvibe-dialog-close', () => session.close());
+            dialog.addEventListener('edvibe-reset-request', async (event) => {
+                const { pupil, lessons } = event.detail;
+                const confirmed = window.confirm(
+                    `Reset ${lessons.length} lesson(s) for ${pupil.Email}?`
+                );
+                if (!confirmed) {
+                    return;
+                }
+
+                running = true;
+                dialog.lock();
+                let completed = false;
+
+                try {
+                    dialog.showDiscovery('Discovering exercises...');
+                    const work = await discoverResetWork({
+                        sendRequest,
+                        wait,
+                        marathonId,
+                        pupilId: pupil.PupilId,
+                        lessons,
+                        onDiscovery: (message) => dialog.showDiscovery(message),
+                        logger
+                    });
+                    await executeResetWork({
+                        sendRequest,
+                        sendWithoutResponse,
+                        wait,
+                        marathonId,
+                        pupilId: pupil.PupilId,
+                        work,
+                        onProgress: (progress) => dialog.showProgress(progress),
+                        logger
+                    });
+                    dialog.showComplete('Selected lesson progress was reset successfully.');
+                    completed = true;
+                } catch (error) {
+                    const lessonIds = lessons
+                        .map((lesson) => lesson.MarathonLessonId)
+                        .join(', ');
+                    logger.log(
+                        `Reset stopped for PupilId ${pupil.PupilId}; `
+                        + `MarathonLessonIds: ${lessonIds} (${getErrorType(error)}).`
+                    );
+                    dialog.showError(error.message);
+                } finally {
+                    running = false;
+                    if (completed) {
+                        dialog.completeRun();
+                    } else {
+                        dialog.unlockAfterRun();
+                    }
+                }
+            });
+
             const pupilPager = createPupilPager(sendRequest, marathonId);
             dialog.configure({
                 loadNextPupils: () => pupilPager.loadNext(),
@@ -459,10 +448,14 @@ function createResetLessonsFeature({
                 `Failed to initialize reset workflow for MarathonId ${marathonId} `
                 + `(${getErrorType(error)}).`
             );
-            if (typeof dialog.showError === 'function') {
-                dialog.showError(error.message);
+            if (typeof dialog?.showError === 'function') {
+                try {
+                    dialog.showError(error.message);
+                } finally {
+                    session.release();
+                }
             } else {
-                releaseOperation();
+                session.close();
                 throw error;
             }
         }

--- a/src/content/main/features/video-attachment/video-attachment-runtime.test.js
+++ b/src/content/main/features/video-attachment/video-attachment-runtime.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { createVideoAttachmentFeatureV2 } from '#src/content/main/features/video-attachment/video-attachment.js';
+import { OperationGuard } from '#src/content/main/infrastructure/operation-guard.js';
 
 function createDialog() {
     return {
@@ -74,10 +75,7 @@ test('createVideoAttachmentFeatureV2 should create fresh dialog when feature is 
             sendRequest: () => new Promise(() => { }),
             getConnectionState: () => ({ isOpen: true })
         },
-        operationGuard: {
-            canStart: () => true,
-            guardedActiveChange: () => () => { }
-        },
+        operationGuard: new OperationGuard(),
         logger: {
             createChildLogger: () => ({ log() { } })
         }

--- a/src/content/main/features/video-attachment/video-attachment.js
+++ b/src/content/main/features/video-attachment/video-attachment.js
@@ -1,3 +1,4 @@
+import { createFeatureSession } from '#src/content/main/application/feature-session.js';
 import { createFeatureError, parseMarathonId } from '#src/content/main/features/batch-workflow-primitives.js';
 import { VIDEO_ATTACHMENT_DIALOG_TAG } from '#src/content/main/features/video-attachment/video-attachment-dialog.js';
 import { getLessonById, loadAllMarathonLessons } from '#src/content/main/infrastructure/edvibe-marathon-api.js';
@@ -310,9 +311,7 @@ export function createVideoAttachmentFeatureV2({
     return createVideoAttachmentFeature({
         sendRequest: transport.sendRequest,
         getConnectionState: transport.getConnectionState,
-        canStart: operationGuard.canStart,
-        onActiveChange: operationGuard.guardedActiveChange('video-attachment'),
-
+        session: createFeatureSession({ operationGuard, operationName: 'video-attachment' }),
         createDialog: () => document.createElement(VIDEO_ATTACHMENT_DIALOG_TAG),
         getLocationHref: () => window.location.href,
         appendDialog: (dialog) => document.body.append(dialog),
@@ -332,42 +331,29 @@ const videoAttachmentFeatureDefinition = Object.freeze({
 function createVideoAttachmentFeature({
     sendRequest,
     getConnectionState,
-    canStart = () => true,
-    onActiveChange = () => { },
+    session,
     createDialog,
     getLocationHref = () => globalThis.location?.href || '',
     appendDialog = (dialog) => globalThis.document?.body?.append(dialog),
     alertUser = (message) => globalThis.alert?.(message),
     logger = { log() {} }
 }) {
-    let active = false;
-
-    function release(dialog) {
-        dialog?.remove?.();
-        if (!active) {
-            return;
-        }
-        active = false;
-        onActiveChange(false);
-    }
-
     function open() {
-        if (active || !canStart()) {
+        if (session.isOpen() || !session.activate()) {
             alertUser('Another Edvibe Toolbox operation is already running.');
             return;
         }
 
         const marathonId = parseMarathonId(getLocationHref());
         if (!marathonId) {
+            session.release();
             alertUser('Open an Edvibe marathon page first.');
             return;
         }
 
-        active = true;
-        onActiveChange(true);
         let dialog;
         try {
-            dialog = createDialog();
+            dialog = session.ownDialog(createDialog());
             dialog.configure({
                 marathonId,
                 lessons: [],
@@ -388,24 +374,24 @@ function createVideoAttachmentFeature({
                     return result;
                 },
                 onClose() {
-                    release(dialog);
+                    session.close();
                 }
             });
             appendDialog(dialog);
 
             void loadLessonCatalogue({ sendRequest, marathonId })
                 .then((lessons) => {
-                    if (active) {
+                    if (session.isActive()) {
                         dialog.setLessons(lessons);
                     }
                 })
                 .catch((error) => {
-                    if (active) {
+                    if (session.isActive()) {
                         dialog.setLoadError(error);
                     }
                 });
         } catch (error) {
-            release(dialog);
+            session.close();
             throw error;
         }
     }


### PR DESCRIPTION
## Summary

- add a small `FeatureSession` application primitive for operation-guard and dialog ownership
- migrate equivalent MAIN dialog/session lifecycle bookkeeping to the shared contract
- keep feature-local workflow, execution, and execution-history semantics unchanged
- release operation ownership on initialization failures without forcing visible fatal-error dialogs to disappear
- add regression coverage for duplicate activation, normal close, initialization failure, double release, and reopen behavior

## Scope boundary

- execution-attempt and history semantics remain feature-local and are intentionally left for #154
- marathon export remains a run-scoped direct guard user because it does not have dialog-session ownership semantics
- no base feature class, inheritance hierarchy, DI framework, or generic workflow engine was introduced

## Testing

CI is green on Node 22:

- ESLint
- full test suite
- production extension build
- production bundle output check

Dedicated lifecycle tests cover duplicate activation, normal close, initialization-error release, double release, removal failure, and reopen behavior. Runtime regression coverage was added/updated for reset lessons, video attachment, and batch user onboarding.

Closes #153