### PR TITLE
Sort and filter owned Telegram groups

### DIFF
--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -1,24 +1,26 @@
 import { LitElement, html, nothing } from 'lit';
 
 import { telegramOwnedGroupsDialogStyles } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js';
+import { createOwnedTelegramGroupsView } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import {
     componentFoundationStyles,
     dialogFoundationStyles
 } from '#src/content/main/styles/foundations.js';
 import {
     controlStyles,
-    dialogShellStyles
+    dialogShellStyles,
+    fieldStyles
 } from '#src/content/main/styles/primitives.js';
 
 const TELEGRAM_OWNED_GROUPS_DIALOG_TAG = 'toolfox-telegram-owned-groups-dialog';
 
 function formatActivity(value) {
     if (!value) {
-        return 'Нет данных об активности';
+        return 'нет данных';
     }
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) {
-        return 'Нет данных об активности';
+        return 'нет данных';
     }
     return new Intl.DateTimeFormat(undefined, {
         dateStyle: 'medium',
@@ -46,6 +48,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         dialogFoundationStyles,
         dialogShellStyles,
         controlStyles,
+        fieldStyles,
         telegramOwnedGroupsDialogStyles
     ];
 
@@ -53,7 +56,8 @@ class TelegramOwnedGroupsDialog extends LitElement {
         options: { state: true },
         groups: { state: true },
         viewState: { state: true },
-        message: { state: true }
+        message: { state: true },
+        filterQuery: { state: true }
     };
 
     constructor() {
@@ -62,6 +66,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.groups = [];
         this.viewState = 'loading';
         this.message = 'Загружаем группы текущего аккаунта…';
+        this.filterQuery = '';
         this.loadPromise = null;
         this.handleKeydownBound = (event) => {
             if (event.key === 'Escape') {
@@ -133,6 +138,10 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.options?.onClose?.();
     }
 
+    handleFilterInput(event) {
+        this.filterQuery = event.currentTarget?.value || '';
+    }
+
     renderState() {
         const isError = this.viewState === 'error';
         const canRetry = isError || this.viewState === 'unsupported';
@@ -155,6 +164,15 @@ class TelegramOwnedGroupsDialog extends LitElement {
         `;
     }
 
+    renderFilterEmptyState() {
+        return html`
+            <div class="state-card filter-empty-state" data-part="filter-empty-state" aria-live="polite">
+                <h3>Ничего не найдено</h3>
+                <p>Измените фильтр, чтобы снова увидеть подходящие группы.</p>
+            </div>
+        `;
+    }
+
     renderGroup(group) {
         return html`
             <li class="group-card" data-peer-id=${String(group.peerId)}>
@@ -163,10 +181,38 @@ class TelegramOwnedGroupsDialog extends LitElement {
                     <span class="kind">${formatGroupKind(group.kind)}</span>
                 </div>
                 <div class="metadata">
-                    <span>${formatActivity(group.lastActivityAt)}</span>
+                    <span>Последняя активность: ${formatActivity(group.lastActivityAt)}</span>
                     <span>${formatSendability(group.canSendText)}</span>
                 </div>
             </li>
+        `;
+    }
+
+    renderReady() {
+        const view = createOwnedTelegramGroupsView(this.groups, this.filterQuery);
+        const isFiltered = this.filterQuery.trim() !== '';
+        const summary = isFiltered
+            ? `Показано: ${view.groups.length} из ${this.groups.length}`
+            : `Найдено групп: ${this.groups.length}`;
+
+        return html`
+            <div class="toolbar">
+                <label data-field>
+                    <span>Фильтр по названию</span>
+                    <input
+                        type="search"
+                        placeholder="Начните вводить название…"
+                        .value=${this.filterQuery}
+                        @input=${this.handleFilterInput}
+                    >
+                </label>
+                <p class="summary" aria-live="polite">${summary}</p>
+            </div>
+            ${view.state === 'filtered-empty' ? this.renderFilterEmptyState() : html`
+                <ul class="group-list">
+                    ${view.groups.map((group) => this.renderGroup(group))}
+                </ul>
+            `}
         `;
     }
 
@@ -184,12 +230,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
                         <button class="icon-button" data-control="secondary" type="button" data-action="close" aria-label="Закрыть" @click=${this.close}>×</button>
                     </header>
                     <div class="content">
-                        ${isReady ? html`
-                            <p class="summary">Найдено групп: ${this.groups.length}</p>
-                            <ul class="group-list">
-                                ${this.groups.map((group) => this.renderGroup(group))}
-                            </ul>
-                        ` : this.renderState()}
+                        ${isReady ? this.renderReady() : this.renderState()}
                     </div>
                 </section>
             </div>

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -75,6 +75,16 @@ export const telegramOwnedGroupsDialogStyles = css`
         background: var(--toolfox-danger-surface);
     }
 
+    .filter-empty-state {
+        min-height: 140px;
+    }
+
+    .toolbar {
+        display: grid;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+
     .group-list {
         display: grid;
         gap: 10px;
@@ -121,7 +131,7 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .summary {
-        margin: 0 0 12px;
+        margin: 0;
         color: var(--toolfox-text-muted);
         font-size: 12px;
     }

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
@@ -1,6 +1,15 @@
 const SUPPORTED_STATE = 'supported';
 const GROUP_TYPES = new Set(['group', 'supergroup']);
 
+function normalizeActivityTimestamp(value) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp = Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
 function normalizeOwnedGroup(candidate) {
     if (
         !candidate
@@ -20,6 +29,61 @@ function normalizeOwnedGroup(candidate) {
         lastActivityAt: candidate.lastActivityAt || null,
         peerId: Number(candidate.peerId),
         title: String(candidate.title || '').trim() || 'Без названия'
+    });
+}
+
+function compareOwnedTelegramGroups(left, right) {
+    const leftActivity = normalizeActivityTimestamp(left?.lastActivityAt);
+    const rightActivity = normalizeActivityTimestamp(right?.lastActivityAt);
+
+    if (leftActivity !== rightActivity) {
+        if (leftActivity === null) {
+            return 1;
+        }
+        if (rightActivity === null) {
+            return -1;
+        }
+        return rightActivity - leftActivity;
+    }
+
+    const leftTitle = String(left?.title || '').toLowerCase();
+    const rightTitle = String(right?.title || '').toLowerCase();
+    if (leftTitle !== rightTitle) {
+        return leftTitle < rightTitle ? -1 : 1;
+    }
+
+    return Number(left?.peerId) - Number(right?.peerId);
+}
+
+function sortOwnedTelegramGroups(groups) {
+    return Object.freeze(Array.from(groups || []).sort(compareOwnedTelegramGroups));
+}
+
+function filterOwnedTelegramGroups(groups, query = '') {
+    const source = Array.from(groups || []);
+    const normalizedQuery = String(query || '').trim().toLowerCase();
+    if (!normalizedQuery) {
+        return Object.freeze(source);
+    }
+
+    return Object.freeze(source.filter((group) => String(group?.title || '')
+        .toLowerCase()
+        .includes(normalizedQuery)));
+}
+
+function createOwnedTelegramGroupsView(groups, query = '') {
+    const source = Array.from(groups || []);
+    if (source.length === 0) {
+        return Object.freeze({
+            groups: Object.freeze([]),
+            state: 'empty'
+        });
+    }
+
+    const visibleGroups = filterOwnedTelegramGroups(source, query);
+    return Object.freeze({
+        groups: visibleGroups,
+        state: visibleGroups.length === 0 ? 'filtered-empty' : 'ready'
     });
 }
 
@@ -67,7 +131,7 @@ async function loadOwnedTelegramGroups(adapter, { pageSize = 100 } = {}) {
         offset = page.nextOffset;
     }
 
-    const groups = Object.freeze([...groupsByPeerId.values()]);
+    const groups = sortOwnedTelegramGroups(groupsByPeerId.values());
     return Object.freeze({
         groups,
         reason: null,
@@ -76,6 +140,10 @@ async function loadOwnedTelegramGroups(adapter, { pageSize = 100 } = {}) {
 }
 
 export {
+    compareOwnedTelegramGroups,
+    createOwnedTelegramGroupsView,
+    filterOwnedTelegramGroups,
     loadOwnedTelegramGroups,
-    normalizeOwnedGroup
+    normalizeOwnedGroup,
+    sortOwnedTelegramGroups
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import {
+    createOwnedTelegramGroupsView,
+    filterOwnedTelegramGroups,
     loadOwnedTelegramGroups,
-    normalizeOwnedGroup
+    normalizeOwnedGroup,
+    sortOwnedTelegramGroups
 } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 
 describe('normalizeOwnedGroup', () => {
@@ -53,6 +56,76 @@ describe('normalizeOwnedGroup', () => {
     });
 });
 
+describe('owned Telegram group list presentation', () => {
+    test('should sort newest activity first without treating pinned order as activity', () => {
+        const source = Object.freeze([
+            Object.freeze({
+                lastActivityAt: '2026-09-01T08:00:00.000Z',
+                peerId: -10,
+                pinned: true,
+                title: 'Pinned but older'
+            }),
+            Object.freeze({
+                lastActivityAt: null,
+                peerId: -30,
+                title: 'No activity'
+            }),
+            Object.freeze({
+                lastActivityAt: '2026-09-03T08:00:00.000Z',
+                peerId: -20,
+                title: 'Newest'
+            })
+        ]);
+
+        const sorted = sortOwnedTelegramGroups(source);
+
+        assert.deepEqual(sorted.map(({ peerId }) => peerId), [-20, -10, -30]);
+        assert.deepEqual(source.map(({ peerId }) => peerId), [-10, -30, -20]);
+    });
+
+    test('should use deterministic title and peer-id fallbacks for equal or missing activity', () => {
+        const equalActivity = '2026-09-03T08:00:00.000Z';
+        const groups = [
+            { lastActivityAt: null, peerId: -4, title: 'Zulu' },
+            { lastActivityAt: equalActivity, peerId: -2, title: 'Beta' },
+            { lastActivityAt: null, peerId: -3, title: 'Alpha' },
+            { lastActivityAt: equalActivity, peerId: -1, title: 'alpha' },
+            { lastActivityAt: equalActivity, peerId: -5, title: 'Alpha' }
+        ];
+
+        const forward = sortOwnedTelegramGroups(groups);
+        const reverse = sortOwnedTelegramGroups([...groups].reverse());
+
+        assert.deepEqual(forward.map(({ peerId }) => peerId), [-5, -1, -2, -3, -4]);
+        assert.deepEqual(reverse.map(({ peerId }) => peerId), [-5, -1, -2, -3, -4]);
+    });
+
+    test('should filter titles case-insensitively after trimming the query', () => {
+        const groups = Object.freeze([
+            Object.freeze({ peerId: -1, title: 'Alpha Team' }),
+            Object.freeze({ peerId: -2, title: 'Beta group' }),
+            Object.freeze({ peerId: -3, title: 'ALPHABET' })
+        ]);
+
+        const filtered = filterOwnedTelegramGroups(groups, '  alpha  ');
+        const restored = filterOwnedTelegramGroups(groups, '   ');
+
+        assert.deepEqual(filtered.map(({ peerId }) => peerId), [-1, -3]);
+        assert.deepEqual(restored.map(({ peerId }) => peerId), [-1, -2, -3]);
+        assert.equal(groups.length, 3);
+    });
+
+    test('should distinguish an empty filter result from an account with no owned groups', () => {
+        const filteredEmpty = createOwnedTelegramGroupsView([
+            { peerId: -1, title: 'Alpha Team' }
+        ], 'missing');
+        const accountEmpty = createOwnedTelegramGroupsView([], 'missing');
+
+        assert.deepEqual(filteredEmpty, { groups: [], state: 'filtered-empty' });
+        assert.deepEqual(accountEmpty, { groups: [], state: 'empty' });
+    });
+});
+
 describe('loadOwnedTelegramGroups', () => {
     test('should paginate all dialogs and retain only owned active groups', async () => {
         const calls = [];
@@ -69,12 +142,12 @@ describe('loadOwnedTelegramGroups', () => {
                 calls.push(['listDialogs', limit, offset]);
                 if (offset === 0) {
                     return {
-                        items: [{ peerId: 101 }, { peerId: -10 }, { peerId: -30 }],
+                        items: [{ peerId: 101 }, { peerId: -20 }, { peerId: -30 }],
                         nextOffset: 3
                     };
                 }
                 return {
-                    items: [{ peerId: -20 }, { peerId: -40 }, { peerId: -50 }],
+                    items: [{ peerId: -10 }, { peerId: -40 }, { peerId: -50 }],
                     nextOffset: null
                 };
             },


### PR DESCRIPTION
## Summary

- sort creator-owned Telegram groups by normalized last activity, newest first, with deterministic title/peer fallbacks
- keep Telegram sidebar/pinned presentation out of application ordering
- add a local case-insensitive title filter without refetching dialogs
- distinguish a filtered-empty result from an account with no owned groups
- show concise last-activity metadata and filtered result counts in the Telegram group browser
- add behavioral coverage for ordering, pinned-order independence, equal/missing activity, filtering, whitespace normalization, and empty filter results

Closes #170