### PR TITLE
Delete multiple selected Telegram groups

### DIFF
--- a/docs/telegram-web-k-runtime-adapter.md
+++ b/docs/telegram-web-k-runtime-adapter.md
@@ -25,6 +25,8 @@ Reviewed against the current Telegram Web K source on 2026-09-03 (`morethanwords
 - `appMessagesManager.getMessageByPeer(peerId, topMessageId)` resolves the dialog's top message; its `date` field is Unix seconds and is normalized by Toolfox to an ISO timestamp.
 - For chat peers, Telegram's own peer-id helpers derive the chat id as `Math.abs(peerId)`. `appChatsManager.hasRights(chatId, 'send_plain')` provides the text-send permission check used by the adapter.
 - `appMessagesManager.sendText({ peerId, text })` is the current text-send path.
+- Creator-owned basic groups are deleted through `appChatsManager.deleteChat(chatId)`, which invokes MTProto `messages.deleteChat` rather than leaving or locally hiding the group.
+- Creator-owned supergroups are deleted through `appChatsManager.deleteChannel(chatId)`, which invokes MTProto `channels.deleteChannel`.
 
 The adapter is intentionally the only Toolfox module that knows these names and shapes.
 
@@ -38,8 +40,9 @@ The adapter is intentionally the only Toolfox module that knows these names and 
 - `getLastActivity(dialog)` — returns an ISO timestamp or `null`;
 - `canSendText(peerId)` — checks the current runtime's plain-text permission for a chat peer;
 - `resolveGroupCandidate(dialog)` — combines normalized group metadata, ownership, last activity, and send capability;
+- `deleteGroup(peerId, kind)` — deletes a creator-owned basic group or supergroup through the matching authenticated Web K manager operation;
 - `sendText(peerId, text)` — sends plain text through the already-authenticated Telegram Web session;
-- `probe()` — non-mutating runtime validation for discovery, peer resolution, and last-activity calls. It never sends a message; the mutating `sendText` path is validated manually as described below.
+- `probe()` — non-mutating runtime validation for discovery, peer resolution, and last-activity calls. It never deletes a group or sends a message; the mutating `deleteGroup` and `sendText` paths require dedicated live validation.
 
 Normalized objects deliberately omit Telegram manager references and raw flags.
 
@@ -47,11 +50,11 @@ Normalized objects deliberately omit Telegram manager references and raw flags.
 
 The content script starts at `document_start`, before Telegram necessarily mounts its runtime globals. A missing manager factory is therefore not cached as a permanent failure. The adapter checks compatibility lazily when an operation is requested and can become supported later in the same page lifecycle.
 
-When the expected boundary is absent or rejects the expected call shape, Toolfox raises `TelegramWebKRuntimeError` with a Toolfox-owned error code. The host page is not modified to emulate missing Telegram APIs, and Toolfox does not fall back to DOM automation or direct IndexedDB reads.
+When the expected boundary is absent or rejects the expected call shape, Toolfox raises `TelegramWebKRuntimeError` with a Toolfox-owned error code. Telegram RPC error identifiers exposed by the runtime (for example `CHAT_ADMIN_REQUIRED` or `FLOOD_WAIT_30`) are preserved when available so feature workflows can distinguish target-local failures from conditions that should interrupt a batch. The host page is not modified to emulate missing Telegram APIs, and Toolfox does not fall back to DOM automation or direct IndexedDB reads.
 
 ## Production field validation
 
-Status: **verified on live production Telegram Web K on 2026-09-03**.
+Status: **discovery and text-send paths verified on live production Telegram Web K on 2026-09-03; destructive deletion path source-verified and intentionally requires a disposable-group validation**.
 
 A logged-in Web K session was used with a dedicated test group. No credentials, cookies, session/auth keys, message contents, peer identifiers, or group titles were retained.
 
@@ -65,7 +68,9 @@ The live runtime confirmed that:
 - a group created by the active account exposes `pFlags.creator === true`;
 - `appMessagesManager.sendText({ peerId, text })` successfully delivered one test text message to that dedicated group through the already-authenticated Web K session.
 
-This field validation confirms the adapter's current production boundary without requiring a second login, Bot API credentials, DOM automation, or direct storage access. If production later differs from this contract, compatibility changes belong inside the Telegram adapter rather than feature code.
+The deletion implementation follows Telegram Web K's own current source paths (`appChatsManager.deleteChat` / `deleteChannel`) and deliberately does not substitute leave/history-removal semantics. Because deletion is irreversible, it should be production-validated only against an explicitly disposable group before relying on it for real cleanup batches.
+
+This boundary does not require a second login, Bot API credentials, DOM automation, or direct storage access. If production later differs from this contract, compatibility changes belong inside the Telegram adapter rather than feature code.
 
 ## Upstream references
 

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js
@@ -1,0 +1,133 @@
+const DELETE_STATUSES = Object.freeze({
+    DELETED: 'deleted',
+    DELETING: 'deleting',
+    FAILED: 'failed',
+    NOT_ATTEMPTED: 'not-attempted',
+    PENDING: 'pending'
+});
+
+const FATAL_DELETE_ERROR_CODES = new Set([
+    'AUTH_KEY_UNREGISTERED',
+    'SESSION_EXPIRED',
+    'SESSION_REVOKED',
+    'TELEGRAM_WEB_K_OPERATION_UNAVAILABLE',
+    'TELEGRAM_WEB_K_UNSUPPORTED_RUNTIME'
+]);
+
+function normalizeError(error) {
+    return Object.freeze({
+        code: typeof error?.code === 'string' ? error.code : 'TELEGRAM_DELETE_FAILED',
+        message: error instanceof Error
+            ? error.message
+            : typeof error?.message === 'string'
+                ? error.message
+                : 'Не удалось удалить группу.'
+    });
+}
+
+function isFatalTelegramGroupDeleteError(error) {
+    const code = typeof error?.code === 'string' ? error.code : '';
+    return FATAL_DELETE_ERROR_CODES.has(code)
+        || code === 'AUTH_KEY_DUPLICATED'
+        || code.startsWith('FLOOD_WAIT_');
+}
+
+function createDeleteResult(group, status, error = null) {
+    const normalizedError = error ? normalizeError(error) : null;
+    return Object.freeze({
+        errorCode: normalizedError?.code || null,
+        errorMessage: normalizedError?.message || null,
+        kind: group.kind,
+        peerId: group.peerId,
+        status,
+        title: group.title
+    });
+}
+
+function summarizeDeleteResults(results) {
+    const snapshot = Object.freeze(Array.from(results || []));
+    const counts = Object.freeze({
+        deleted: snapshot.filter(({ status }) => status === DELETE_STATUSES.DELETED).length,
+        failed: snapshot.filter(({ status }) => status === DELETE_STATUSES.FAILED).length,
+        notAttempted: snapshot.filter(({ status }) => status === DELETE_STATUSES.NOT_ATTEMPTED).length,
+        pending: snapshot.filter(({ status }) => (
+            status === DELETE_STATUSES.PENDING || status === DELETE_STATUSES.DELETING
+        )).length,
+        total: snapshot.length
+    });
+    return Object.freeze({ counts, results: snapshot });
+}
+
+function emitProgress(onProgress, results) {
+    if (typeof onProgress !== 'function') {
+        return;
+    }
+    try {
+        onProgress(summarizeDeleteResults(results));
+    } catch {
+        // Progress rendering must never change external deletion semantics.
+    }
+}
+
+async function deleteOwnedTelegramGroups(adapter, groups, { onProgress } = {}) {
+    if (!adapter || typeof adapter.deleteGroup !== 'function') {
+        throw new TypeError('Telegram adapter with deleteGroup() is required.');
+    }
+
+    const targets = Array.from(groups || []);
+    if (targets.length === 0) {
+        throw new TypeError('At least one Telegram group must be selected for deletion.');
+    }
+
+    const results = targets.map((group) => createDeleteResult(group, DELETE_STATUSES.PENDING));
+    emitProgress(onProgress, results);
+
+    for (let index = 0; index < targets.length; index += 1) {
+        const group = targets[index];
+        results[index] = createDeleteResult(group, DELETE_STATUSES.DELETING);
+        emitProgress(onProgress, results);
+
+        try {
+            await adapter.deleteGroup(group.peerId, group.kind);
+            results[index] = createDeleteResult(group, DELETE_STATUSES.DELETED);
+            emitProgress(onProgress, results);
+        } catch (error) {
+            results[index] = createDeleteResult(group, DELETE_STATUSES.FAILED, error);
+            if (isFatalTelegramGroupDeleteError(error)) {
+                for (let remaining = index + 1; remaining < targets.length; remaining += 1) {
+                    results[remaining] = createDeleteResult(
+                        targets[remaining],
+                        DELETE_STATUSES.NOT_ATTEMPTED,
+                        {
+                            code: error.code || 'TELEGRAM_DELETE_INTERRUPTED',
+                            message: 'Не выполнено: очередь остановлена после общей ошибки Telegram.'
+                        }
+                    );
+                }
+                emitProgress(onProgress, results);
+                break;
+            }
+            emitProgress(onProgress, results);
+        }
+    }
+
+    return summarizeDeleteResults(results);
+}
+
+function reconcileDeletedOwnedGroups(groups, results) {
+    const deletedPeerIds = new Set(
+        Array.from(results || [])
+            .filter(({ status }) => status === DELETE_STATUSES.DELETED)
+            .map(({ peerId }) => Number(peerId))
+    );
+    return Object.freeze(Array.from(groups || [])
+        .filter(({ peerId }) => !deletedPeerIds.has(Number(peerId))));
+}
+
+export {
+    DELETE_STATUSES,
+    deleteOwnedTelegramGroups,
+    isFatalTelegramGroupDeleteError,
+    reconcileDeletedOwnedGroups,
+    summarizeDeleteResults
+};

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js
@@ -69,7 +69,10 @@ function emitProgress(onProgress, results) {
     }
 }
 
-async function deleteOwnedTelegramGroups(adapter, groups, { onProgress } = {}) {
+async function deleteOwnedTelegramGroups(adapter, groups, {
+    confirmed = false,
+    onProgress
+} = {}) {
     if (!adapter || typeof adapter.deleteGroup !== 'function') {
         throw new TypeError('Telegram adapter with deleteGroup() is required.');
     }
@@ -77,6 +80,9 @@ async function deleteOwnedTelegramGroups(adapter, groups, { onProgress } = {}) {
     const targets = Array.from(groups || []);
     if (targets.length === 0) {
         throw new TypeError('At least one Telegram group must be selected for deletion.');
+    }
+    if (confirmed !== true) {
+        throw new TypeError('Explicit confirmation is required before deleting Telegram groups.');
     }
 
     const results = targets.map((group) => createDeleteResult(group, DELETE_STATUSES.PENDING));

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.test.js
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+    deleteOwnedTelegramGroups,
+    isFatalTelegramGroupDeleteError,
+    reconcileDeletedOwnedGroups
+} from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js';
+
+function group(peerId, title, kind = 'group') {
+    return Object.freeze({ kind, peerId, title });
+}
+
+describe('deleteOwnedTelegramGroups', () => {
+    test('should reject execution without selected targets', async () => {
+        await assert.rejects(
+            () => deleteOwnedTelegramGroups({ deleteGroup() {} }, []),
+            /At least one Telegram group/
+        );
+    });
+
+    test('should delete groups sequentially and preserve mixed results', async () => {
+        const calls = [];
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+        const adapter = {
+            async deleteGroup(peerId, kind) {
+                activeCalls += 1;
+                maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+                calls.push([peerId, kind]);
+                await Promise.resolve();
+                activeCalls -= 1;
+                if (peerId === -20) {
+                    const error = new Error('Creator permission was lost.');
+                    error.code = 'CHAT_ADMIN_REQUIRED';
+                    throw error;
+                }
+            }
+        };
+        const targets = [
+            group(-10, 'First'),
+            group(-20, 'Second', 'supergroup'),
+            group(-30, 'Third')
+        ];
+
+        const summary = await deleteOwnedTelegramGroups(adapter, targets);
+
+        assert.equal(maxActiveCalls, 1);
+        assert.deepEqual(calls, [
+            [-10, 'group'],
+            [-20, 'supergroup'],
+            [-30, 'group']
+        ]);
+        assert.deepEqual(summary.results.map(({ status }) => status), [
+            'deleted',
+            'failed',
+            'deleted'
+        ]);
+        assert.deepEqual(summary.counts, {
+            deleted: 2,
+            failed: 1,
+            notAttempted: 0,
+            pending: 0,
+            total: 3
+        });
+        assert.equal(summary.results[1].errorCode, 'CHAT_ADMIN_REQUIRED');
+    });
+
+    test('should stop after a platform-wide failure and mark remaining targets not attempted', async () => {
+        const calls = [];
+        const adapter = {
+            async deleteGroup(peerId) {
+                calls.push(peerId);
+                if (peerId === -20) {
+                    const error = new Error('Flood wait.');
+                    error.code = 'FLOOD_WAIT_30';
+                    throw error;
+                }
+            }
+        };
+        const targets = [
+            group(-10, 'First'),
+            group(-20, 'Second'),
+            group(-30, 'Third'),
+            group(-40, 'Fourth')
+        ];
+
+        const summary = await deleteOwnedTelegramGroups(adapter, targets);
+
+        assert.deepEqual(calls, [-10, -20]);
+        assert.deepEqual(summary.results.map(({ status }) => status), [
+            'deleted',
+            'failed',
+            'not-attempted',
+            'not-attempted'
+        ]);
+        assert.equal(summary.counts.notAttempted, 2);
+        assert.equal(summary.results[2].errorCode, 'FLOOD_WAIT_30');
+    });
+
+    test('should expose progress snapshots without allowing observer failures to interrupt deletion', async () => {
+        const snapshots = [];
+        const adapter = {
+            async deleteGroup() {}
+        };
+        let progressCalls = 0;
+
+        const summary = await deleteOwnedTelegramGroups(adapter, [group(-10, 'One')], {
+            onProgress(snapshot) {
+                snapshots.push(snapshot.results.map(({ status }) => status));
+                progressCalls += 1;
+                if (progressCalls === 2) {
+                    throw new Error('render failed');
+                }
+            }
+        });
+
+        assert.deepEqual(snapshots, [
+            ['pending'],
+            ['deleting'],
+            ['deleted']
+        ]);
+        assert.equal(summary.results[0].status, 'deleted');
+    });
+});
+
+describe('Telegram group deletion result helpers', () => {
+    test('should treat only platform-wide error families as fatal', () => {
+        assert.equal(isFatalTelegramGroupDeleteError({ code: 'FLOOD_WAIT_10' }), true);
+        assert.equal(isFatalTelegramGroupDeleteError({ code: 'SESSION_REVOKED' }), true);
+        assert.equal(isFatalTelegramGroupDeleteError({ code: 'TELEGRAM_WEB_K_UNSUPPORTED_RUNTIME' }), true);
+        assert.equal(isFatalTelegramGroupDeleteError({ code: 'CHAT_ADMIN_REQUIRED' }), false);
+    });
+
+    test('should remove only successfully deleted groups from the loaded collection', () => {
+        const groups = [
+            group(-10, 'Deleted'),
+            group(-20, 'Failed'),
+            group(-30, 'Not attempted')
+        ];
+        const reconciled = reconcileDeletedOwnedGroups(groups, [
+            { peerId: -10, status: 'deleted' },
+            { peerId: -20, status: 'failed' },
+            { peerId: -30, status: 'not-attempted' }
+        ]);
+
+        assert.deepEqual(reconciled.map(({ peerId }) => peerId), [-20, -30]);
+        assert.deepEqual(groups.map(({ peerId }) => peerId), [-10, -20, -30]);
+    });
+});

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.test.js
@@ -14,9 +14,24 @@ function group(peerId, title, kind = 'group') {
 describe('deleteOwnedTelegramGroups', () => {
     test('should reject execution without selected targets', async () => {
         await assert.rejects(
-            () => deleteOwnedTelegramGroups({ deleteGroup() {} }, []),
+            () => deleteOwnedTelegramGroups({ deleteGroup() {} }, [], { confirmed: true }),
             /At least one Telegram group/
         );
+    });
+
+    test('should perform zero deletion calls without explicit confirmation', async () => {
+        const calls = [];
+        const adapter = {
+            async deleteGroup(peerId) {
+                calls.push(peerId);
+            }
+        };
+
+        await assert.rejects(
+            () => deleteOwnedTelegramGroups(adapter, [group(-10, 'One')]),
+            /Explicit confirmation is required/
+        );
+        assert.deepEqual(calls, []);
     });
 
     test('should delete groups sequentially and preserve mixed results', async () => {
@@ -43,7 +58,7 @@ describe('deleteOwnedTelegramGroups', () => {
             group(-30, 'Third')
         ];
 
-        const summary = await deleteOwnedTelegramGroups(adapter, targets);
+        const summary = await deleteOwnedTelegramGroups(adapter, targets, { confirmed: true });
 
         assert.equal(maxActiveCalls, 1);
         assert.deepEqual(calls, [
@@ -85,7 +100,7 @@ describe('deleteOwnedTelegramGroups', () => {
             group(-40, 'Fourth')
         ];
 
-        const summary = await deleteOwnedTelegramGroups(adapter, targets);
+        const summary = await deleteOwnedTelegramGroups(adapter, targets, { confirmed: true });
 
         assert.deepEqual(calls, [-10, -20]);
         assert.deepEqual(summary.results.map(({ status }) => status), [
@@ -106,6 +121,7 @@ describe('deleteOwnedTelegramGroups', () => {
         let progressCalls = 0;
 
         const summary = await deleteOwnedTelegramGroups(adapter, [group(-10, 'One')], {
+            confirmed: true,
             onProgress(snapshot) {
                 snapshots.push(snapshot.results.map(({ status }) => status));
                 progressCalls += 1;

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -240,6 +240,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.operationError = '';
         try {
             const result = await this.options.onDelete(selectedGroups, {
+                confirmed: true,
                 onProgress: (progress) => {
                     this.deleteProgress = progress;
                 }

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -1,7 +1,12 @@
 import { LitElement, html, nothing } from 'lit';
 
+import { reconcileDeletedOwnedGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js';
 import { telegramOwnedGroupsDialogStyles } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js';
-import { createOwnedTelegramGroupsView } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
+import {
+    createOwnedTelegramGroupsView,
+    getSelectedOwnedGroups,
+    toggleOwnedGroupSelection
+} from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import {
     componentFoundationStyles,
     dialogFoundationStyles
@@ -9,7 +14,8 @@ import {
 import {
     controlStyles,
     dialogShellStyles,
-    fieldStyles
+    fieldStyles,
+    noticeStyles
 } from '#src/content/main/styles/primitives.js';
 
 const TELEGRAM_OWNED_GROUPS_DIALOG_TAG = 'toolfox-telegram-owned-groups-dialog';
@@ -42,6 +48,16 @@ function formatSendability(canSendText) {
     return 'Возможность отправки неизвестна';
 }
 
+function formatDeleteStatus(status) {
+    switch (status) {
+        case 'deleted': return 'Удалена';
+        case 'deleting': return 'Удаляется…';
+        case 'failed': return 'Ошибка';
+        case 'not-attempted': return 'Не выполнено';
+        default: return 'Ожидает';
+    }
+}
+
 class TelegramOwnedGroupsDialog extends LitElement {
     static styles = [
         componentFoundationStyles,
@@ -49,6 +65,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         dialogShellStyles,
         controlStyles,
         fieldStyles,
+        noticeStyles,
         telegramOwnedGroupsDialogStyles
     ];
 
@@ -57,7 +74,12 @@ class TelegramOwnedGroupsDialog extends LitElement {
         groups: { state: true },
         viewState: { state: true },
         message: { state: true },
-        filterQuery: { state: true }
+        filterQuery: { state: true },
+        actionStage: { state: true },
+        selectionAction: { state: true },
+        selectedPeerIds: { state: true },
+        deleteProgress: { state: true },
+        operationError: { state: true }
     };
 
     constructor() {
@@ -67,11 +89,32 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.viewState = 'loading';
         this.message = 'Загружаем группы текущего аккаунта…';
         this.filterQuery = '';
+        this.actionStage = 'browse';
+        this.selectionAction = null;
+        this.selectedPeerIds = [];
+        this.deleteProgress = null;
+        this.operationError = '';
         this.loadPromise = null;
         this.handleKeydownBound = (event) => {
-            if (event.key === 'Escape') {
-                this.close();
+            if (event.key !== 'Escape') {
+                return;
             }
+            if (this.actionStage === 'running') {
+                return;
+            }
+            if (this.actionStage === 'confirm') {
+                this.cancelConfirmation();
+                return;
+            }
+            if (this.actionStage === 'select') {
+                this.cancelSelection();
+                return;
+            }
+            if (this.actionStage === 'results') {
+                this.finishDeleteResults();
+                return;
+            }
+            this.close();
         };
     }
 
@@ -94,6 +137,14 @@ class TelegramOwnedGroupsDialog extends LitElement {
         super.disconnectedCallback();
     }
 
+    resetActionState() {
+        this.actionStage = 'browse';
+        this.selectionAction = null;
+        this.selectedPeerIds = [];
+        this.deleteProgress = null;
+        this.operationError = '';
+    }
+
     async load() {
         if (!this.options?.onLoad || this.loadPromise) {
             return this.loadPromise;
@@ -102,6 +153,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.viewState = 'loading';
         this.groups = [];
         this.message = 'Загружаем группы текущего аккаунта…';
+        this.resetActionState();
         this.loadPromise = (async () => {
             try {
                 const result = await this.options.onLoad();
@@ -135,11 +187,81 @@ class TelegramOwnedGroupsDialog extends LitElement {
     }
 
     close() {
-        this.options?.onClose?.();
+        if (this.actionStage !== 'running') {
+            this.options?.onClose?.();
+        }
     }
 
     handleFilterInput(event) {
         this.filterQuery = event.currentTarget?.value || '';
+    }
+
+    startSelection(action) {
+        this.selectionAction = action;
+        this.selectedPeerIds = [];
+        this.actionStage = 'select';
+        this.deleteProgress = null;
+        this.operationError = '';
+    }
+
+    cancelSelection() {
+        this.resetActionState();
+    }
+
+    handleSelectionChange(event, peerId) {
+        this.selectedPeerIds = toggleOwnedGroupSelection(
+            this.selectedPeerIds,
+            peerId,
+            Boolean(event.currentTarget?.checked)
+        );
+    }
+
+    requestDeleteConfirmation() {
+        if (
+            this.selectionAction !== 'delete'
+            || getSelectedOwnedGroups(this.groups, this.selectedPeerIds).length === 0
+        ) {
+            return;
+        }
+        this.actionStage = 'confirm';
+    }
+
+    cancelConfirmation() {
+        this.actionStage = 'select';
+    }
+
+    async confirmDelete() {
+        const selectedGroups = getSelectedOwnedGroups(this.groups, this.selectedPeerIds);
+        if (selectedGroups.length === 0 || typeof this.options?.onDelete !== 'function') {
+            return;
+        }
+
+        this.actionStage = 'running';
+        this.operationError = '';
+        try {
+            const result = await this.options.onDelete(selectedGroups, {
+                onProgress: (progress) => {
+                    this.deleteProgress = progress;
+                }
+            });
+            this.deleteProgress = result;
+            this.groups = [...reconcileDeletedOwnedGroups(this.groups, result.results)];
+        } catch (error) {
+            this.operationError = error instanceof Error
+                ? error.message
+                : 'Не удалось выполнить удаление групп.';
+        } finally {
+            this.selectedPeerIds = [];
+            this.actionStage = 'results';
+        }
+    }
+
+    finishDeleteResults() {
+        this.resetActionState();
+        this.viewState = this.groups.length > 0 ? 'ready' : 'empty';
+        if (this.viewState === 'empty') {
+            this.message = 'У текущего аккаунта не найдено созданных им активных групп.';
+        }
     }
 
     renderState() {
@@ -173,27 +295,43 @@ class TelegramOwnedGroupsDialog extends LitElement {
         `;
     }
 
-    renderGroup(group) {
+    renderGroup(group, { selectable = false } = {}) {
+        const selected = this.selectedPeerIds.includes(group.peerId);
         return html`
-            <li class="group-card" data-peer-id=${String(group.peerId)}>
-                <div class="group-heading">
-                    <strong>${group.title}</strong>
-                    <span class="kind">${formatGroupKind(group.kind)}</span>
-                </div>
-                <div class="metadata">
-                    <span>Последняя активность: ${formatActivity(group.lastActivityAt)}</span>
-                    <span>${formatSendability(group.canSendText)}</span>
+            <li class="group-card ${selected ? 'is-selected' : ''}" data-peer-id=${String(group.peerId)}>
+                ${selectable ? html`
+                    <label class="selection-control">
+                        <input
+                            type="checkbox"
+                            .checked=${selected}
+                            aria-label=${`Выбрать ${group.title}`}
+                            @change=${(event) => this.handleSelectionChange(event, group.peerId)}
+                        >
+                    </label>
+                ` : nothing}
+                <div class="group-body">
+                    <div class="group-heading">
+                        <strong>${group.title}</strong>
+                        <span class="kind">${formatGroupKind(group.kind)}</span>
+                    </div>
+                    <div class="metadata">
+                        <span>Последняя активность: ${formatActivity(group.lastActivityAt)}</span>
+                        <span>${formatSendability(group.canSendText)}</span>
+                    </div>
                 </div>
             </li>
         `;
     }
 
-    renderReady() {
-        const view = createOwnedTelegramGroupsView(this.groups, this.filterQuery);
+    renderFilterToolbar(view) {
         const isFiltered = this.filterQuery.trim() !== '';
-        const summary = isFiltered
+        const selectedCount = this.selectedPeerIds.length;
+        const resultSummary = isFiltered
             ? `Показано: ${view.groups.length} из ${this.groups.length}`
             : `Найдено групп: ${this.groups.length}`;
+        const summary = this.actionStage === 'select'
+            ? `Выбрано: ${selectedCount} · ${resultSummary}`
+            : resultSummary;
 
         return html`
             <div class="toolbar">
@@ -208,16 +346,147 @@ class TelegramOwnedGroupsDialog extends LitElement {
                 </label>
                 <p class="summary" aria-live="polite">${summary}</p>
             </div>
+        `;
+    }
+
+    renderBrowseActions() {
+        return html`
+            <div class="group-actions" data-part="actions">
+                <button
+                    type="button"
+                    data-control="danger"
+                    @click=${() => this.startSelection('delete')}
+                >Удалить группы</button>
+            </div>
+        `;
+    }
+
+    renderSelectionActions() {
+        const selectedCount = this.selectedPeerIds.length;
+        return html`
+            <div class="selection-actions" data-part="actions">
+                <button type="button" data-control="secondary" @click=${this.cancelSelection}>Отмена</button>
+                <button
+                    type="button"
+                    data-control="danger"
+                    ?disabled=${selectedCount === 0}
+                    @click=${this.requestDeleteConfirmation}
+                >Проверить удаление (${selectedCount})</button>
+            </div>
+        `;
+    }
+
+    renderDeleteConfirmation() {
+        const selectedGroups = getSelectedOwnedGroups(this.groups, this.selectedPeerIds);
+        return html`
+            <div class="operation-panel confirmation-panel">
+                <div data-notice="danger">
+                    <strong>Необратимое действие.</strong>
+                    Эти группы будут удалены для всех участников. Уже удалённую группу нельзя восстановить через Toolfox.
+                </div>
+                <div>
+                    <h3>Удалить групп: ${selectedGroups.length}?</h3>
+                    <p class="operation-copy">Проверьте список перед подтверждением.</p>
+                </div>
+                <ul class="review-list">
+                    ${selectedGroups.map((group) => html`
+                        <li>
+                            <strong>${group.title}</strong>
+                            <span>${formatGroupKind(group.kind)}</span>
+                        </li>
+                    `)}
+                </ul>
+                <div data-part="actions">
+                    <button type="button" data-control="secondary" @click=${this.cancelConfirmation}>Назад</button>
+                    <button type="button" data-control="danger" @click=${this.confirmDelete}>
+                        Да, удалить ${selectedGroups.length}
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    renderDeleteResultItem(result) {
+        const hasError = result.status === 'failed' || result.status === 'not-attempted';
+        return html`
+            <li class="result-card result-${result.status}">
+                <div class="result-heading">
+                    <strong>${result.title}</strong>
+                    <span>${formatDeleteStatus(result.status)}</span>
+                </div>
+                ${hasError ? html`
+                    <p class="result-error">
+                        ${result.errorCode ? `${result.errorCode}: ` : ''}${result.errorMessage || 'Неизвестная ошибка.'}
+                    </p>
+                ` : nothing}
+            </li>
+        `;
+    }
+
+    renderDeleteProgress() {
+        const progress = this.deleteProgress;
+        const isRunning = this.actionStage === 'running';
+        const counts = progress?.counts || {
+            deleted: 0,
+            failed: 0,
+            notAttempted: 0,
+            pending: 0,
+            total: 0
+        };
+        const title = isRunning ? 'Удаляем группы…' : 'Удаление завершено';
+
+        return html`
+            <div class="operation-panel" aria-live="polite">
+                <div>
+                    <h3>${title}</h3>
+                    <p class="operation-copy">
+                        Удалено: ${counts.deleted} · Ошибок: ${counts.failed} · Не выполнено: ${counts.notAttempted} · Всего: ${counts.total}
+                    </p>
+                </div>
+                ${this.operationError ? html`
+                    <div data-notice="danger">${this.operationError}</div>
+                ` : nothing}
+                ${progress?.results?.length ? html`
+                    <ul class="result-list">
+                        ${progress.results.map((result) => this.renderDeleteResultItem(result))}
+                    </ul>
+                ` : nothing}
+                ${!isRunning ? html`
+                    <div data-part="actions">
+                        <button type="button" data-control @click=${this.finishDeleteResults}>Вернуться к группам</button>
+                    </div>
+                ` : nothing}
+            </div>
+        `;
+    }
+
+    renderGroupList() {
+        const view = createOwnedTelegramGroupsView(this.groups, this.filterQuery);
+        const selecting = this.actionStage === 'select';
+        return html`
+            ${this.renderFilterToolbar(view)}
             ${view.state === 'filtered-empty' ? this.renderFilterEmptyState() : html`
                 <ul class="group-list">
-                    ${view.groups.map((group) => this.renderGroup(group))}
+                    ${view.groups.map((group) => this.renderGroup(group, { selectable: selecting }))}
                 </ul>
             `}
+            ${selecting ? this.renderSelectionActions() : this.renderBrowseActions()}
         `;
+    }
+
+    renderReady() {
+        if (this.actionStage === 'confirm') {
+            return this.renderDeleteConfirmation();
+        }
+        if (this.actionStage === 'running' || this.actionStage === 'results') {
+            return this.renderDeleteProgress();
+        }
+        return this.renderGroupList();
     }
 
     render() {
         const isReady = this.viewState === 'ready';
+        const isRunning = this.actionStage === 'running';
         return html`
             <div class="overlay" data-part="overlay">
                 <section class="dialog" data-part="dialog" role="dialog" aria-modal="true" aria-labelledby="telegram-groups-title">
@@ -227,7 +496,15 @@ class TelegramOwnedGroupsDialog extends LitElement {
                             <h2 id="telegram-groups-title">Мои группы</h2>
                             <p class="header-copy">Только активные группы, создателем которых является текущий Telegram-аккаунт.</p>
                         </div>
-                        <button class="icon-button" data-control="secondary" type="button" data-action="close" aria-label="Закрыть" @click=${this.close}>×</button>
+                        <button
+                            class="icon-button"
+                            data-control="secondary"
+                            type="button"
+                            data-action="close"
+                            aria-label="Закрыть"
+                            ?disabled=${isRunning}
+                            @click=${this.close}
+                        >×</button>
                     </header>
                     <div class="content">
                         ${isReady ? this.renderReady() : this.renderState()}
@@ -244,6 +521,7 @@ export {
     TELEGRAM_OWNED_GROUPS_DIALOG_TAG,
     TelegramOwnedGroupsDialog,
     formatActivity,
+    formatDeleteStatus,
     formatGroupKind,
     formatSendability
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -85,7 +85,9 @@ export const telegramOwnedGroupsDialogStyles = css`
         margin-bottom: 12px;
     }
 
-    .group-list {
+    .group-list,
+    .result-list,
+    .review-list {
         display: grid;
         gap: 10px;
         margin: 0;
@@ -94,22 +96,54 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .group-card {
-        display: grid;
-        gap: 9px;
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
         padding: 14px 16px;
         border: 1px solid var(--toolfox-border-subtle);
         border-radius: var(--toolfox-radius-panel);
         background: var(--toolfox-surface-subtle);
     }
 
-    .group-heading {
+    .group-card.is-selected {
+        border-color: var(--toolfox-primary);
+        background: var(--toolfox-primary-surface, var(--toolfox-surface-subtle));
+    }
+
+    .selection-control {
+        display: grid;
+        place-items: center;
+        flex: 0 0 auto;
+        min-width: 24px;
+        min-height: 24px;
+        cursor: pointer;
+    }
+
+    .selection-control input {
+        width: 18px;
+        height: 18px;
+        margin: 0;
+        accent-color: var(--toolfox-primary);
+        cursor: pointer;
+    }
+
+    .group-body {
+        display: grid;
+        flex: 1 1 auto;
+        gap: 9px;
+        min-width: 0;
+    }
+
+    .group-heading,
+    .result-heading {
         display: flex;
         align-items: baseline;
         justify-content: space-between;
         gap: 12px;
     }
 
-    .group-heading strong {
+    .group-heading strong,
+    .result-heading strong {
         min-width: 0;
         overflow-wrap: anywhere;
         font-size: 14px;
@@ -134,6 +168,74 @@ export const telegramOwnedGroupsDialogStyles = css`
         margin: 0;
         color: var(--toolfox-text-muted);
         font-size: 12px;
+    }
+
+    .group-actions,
+    .selection-actions {
+        margin-top: 14px;
+    }
+
+    .operation-panel {
+        display: grid;
+        gap: 16px;
+    }
+
+    .operation-panel h3,
+    .operation-copy {
+        margin: 0;
+    }
+
+    .operation-copy {
+        margin-top: 5px;
+        color: var(--toolfox-text-muted);
+        font-size: 12px;
+        line-height: 1.45;
+    }
+
+    .review-list li,
+    .result-card {
+        display: grid;
+        gap: 5px;
+        padding: 11px 13px;
+        border: 1px solid var(--toolfox-border-subtle);
+        border-radius: var(--toolfox-radius-control);
+        background: var(--toolfox-surface-subtle);
+    }
+
+    .review-list li {
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: baseline;
+    }
+
+    .review-list span,
+    .result-heading span {
+        color: var(--toolfox-text-muted);
+        font-size: 11px;
+        font-weight: 700;
+    }
+
+    .result-deleted {
+        border-color: var(--toolfox-success-border);
+    }
+
+    .result-failed {
+        border-color: var(--toolfox-danger-border);
+    }
+
+    .result-not-attempted {
+        border-color: var(--toolfox-warning-border);
+    }
+
+    .result-deleting {
+        border-color: var(--toolfox-primary);
+    }
+
+    .result-error {
+        margin: 0;
+        color: var(--toolfox-text-muted);
+        font-size: 11px;
+        line-height: 1.4;
+        overflow-wrap: anywhere;
     }
 
     @media (max-width: 640px) {

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
@@ -71,6 +71,36 @@ function filterOwnedTelegramGroups(groups, query = '') {
         .includes(normalizedQuery)));
 }
 
+function normalizeSelectedPeerIds(selectedPeerIds) {
+    return new Set(Array.from(selectedPeerIds || [])
+        .map((peerId) => Number(peerId))
+        .filter(Number.isFinite));
+}
+
+function toggleOwnedGroupSelection(selectedPeerIds, peerId, selected) {
+    const normalizedPeerId = Number(peerId);
+    const next = normalizeSelectedPeerIds(selectedPeerIds);
+    if (!Number.isFinite(normalizedPeerId)) {
+        return Object.freeze([...next]);
+    }
+
+    const shouldSelect = typeof selected === 'boolean'
+        ? selected
+        : !next.has(normalizedPeerId);
+    if (shouldSelect) {
+        next.add(normalizedPeerId);
+    } else {
+        next.delete(normalizedPeerId);
+    }
+    return Object.freeze([...next]);
+}
+
+function getSelectedOwnedGroups(groups, selectedPeerIds) {
+    const selected = normalizeSelectedPeerIds(selectedPeerIds);
+    return Object.freeze(Array.from(groups || [])
+        .filter(({ peerId }) => selected.has(Number(peerId))));
+}
+
 function createOwnedTelegramGroupsView(groups, query = '') {
     const source = Array.from(groups || []);
     if (source.length === 0) {
@@ -143,7 +173,9 @@ export {
     compareOwnedTelegramGroups,
     createOwnedTelegramGroupsView,
     filterOwnedTelegramGroups,
+    getSelectedOwnedGroups,
     loadOwnedTelegramGroups,
     normalizeOwnedGroup,
-    sortOwnedTelegramGroups
+    sortOwnedTelegramGroups,
+    toggleOwnedGroupSelection
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
@@ -15,7 +15,6 @@ function normalizeOwnedGroup(candidate) {
         !candidate
         || !candidate.isActive
         || !candidate.isCreator
-        || candidate.canSendText === false
         || !GROUP_TYPES.has(candidate.groupType)
         || !Number.isFinite(Number(candidate.peerId))
     ) {

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
@@ -44,17 +44,30 @@ describe('normalizeOwnedGroup', () => {
         assert.equal(supergroup.canSendText, true);
     });
 
-    test('should exclude non-creator, inactive, non-sendable, channel, and direct-chat shapes', () => {
+    test('should keep non-sendable owned groups available for non-send actions', () => {
+        const group = normalizeOwnedGroup({
+            canSendText: false,
+            groupType: 'group',
+            isActive: true,
+            isCreator: true,
+            peerId: -30,
+            title: 'Read-only right now'
+        });
+
+        assert.equal(group.peerId, -30);
+        assert.equal(group.canSendText, false);
+    });
+
+    test('should exclude non-creator, inactive, channel, and direct-chat shapes', () => {
         const cases = [
             { groupType: 'group', isActive: true, isCreator: false, canSendText: true, peerId: -1 },
             { groupType: 'group', isActive: false, isCreator: true, canSendText: true, peerId: -2 },
-            { groupType: 'group', isActive: true, isCreator: true, canSendText: false, peerId: -3 },
             { groupType: 'channel', isActive: true, isCreator: true, canSendText: true, peerId: -4 },
             { groupType: 'user', isActive: true, isCreator: true, canSendText: true, peerId: 5 },
             null
         ];
 
-        assert.deepEqual(cases.map(normalizeOwnedGroup), [null, null, null, null, null, null]);
+        assert.deepEqual(cases.map(normalizeOwnedGroup), [null, null, null, null, null]);
     });
 });
 

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
@@ -4,9 +4,11 @@ import { describe, test } from 'node:test';
 import {
     createOwnedTelegramGroupsView,
     filterOwnedTelegramGroups,
+    getSelectedOwnedGroups,
     loadOwnedTelegramGroups,
     normalizeOwnedGroup,
-    sortOwnedTelegramGroups
+    sortOwnedTelegramGroups,
+    toggleOwnedGroupSelection
 } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 
 describe('normalizeOwnedGroup', () => {
@@ -123,6 +125,35 @@ describe('owned Telegram group list presentation', () => {
 
         assert.deepEqual(filteredEmpty, { groups: [], state: 'filtered-empty' });
         assert.deepEqual(accountEmpty, { groups: [], state: 'empty' });
+    });
+});
+
+describe('owned Telegram group selection', () => {
+    test('should keep selected peer ids independent from the filtered visible collection', () => {
+        const groups = [
+            { peerId: -10, title: 'Alpha' },
+            { peerId: -20, title: 'Beta' },
+            { peerId: -30, title: 'Gamma' }
+        ];
+        let selected = toggleOwnedGroupSelection([], -10, true);
+        selected = toggleOwnedGroupSelection(selected, -30, true);
+
+        const filtered = createOwnedTelegramGroupsView(groups, 'alpha');
+        const targets = getSelectedOwnedGroups(groups, selected);
+
+        assert.deepEqual(filtered.groups.map(({ peerId }) => peerId), [-10]);
+        assert.deepEqual(selected, [-10, -30]);
+        assert.deepEqual(targets.map(({ peerId }) => peerId), [-10, -30]);
+    });
+
+    test('should select and deselect without mutating the previous selection', () => {
+        const initial = Object.freeze([-10]);
+        const added = toggleOwnedGroupSelection(initial, -20, true);
+        const removed = toggleOwnedGroupSelection(added, -10, false);
+
+        assert.deepEqual(initial, [-10]);
+        assert.deepEqual(added, [-10, -20]);
+        assert.deepEqual(removed, [-20]);
     });
 });
 

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
@@ -1,3 +1,4 @@
+import { deleteOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js';
 import { TELEGRAM_OWNED_GROUPS_DIALOG_TAG } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js';
 import { loadOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
@@ -30,6 +31,7 @@ function createTelegramOwnedGroupsFeature({
         dialog = documentApi.createElement(TELEGRAM_OWNED_GROUPS_DIALOG_TAG);
         dialog.configure({
             onClose: close,
+            onDelete: (groups, options) => deleteOwnedTelegramGroups(adapter, groups, options),
             onLoad: () => loadOwnedTelegramGroups(adapter)
         });
         (documentApi.body || documentApi.documentElement).append(dialog);

--- a/src/content/main/infrastructure/telegram-web-k-adapter.js
+++ b/src/content/main/infrastructure/telegram-web-k-adapter.js
@@ -176,12 +176,31 @@ function normalizeLastActivity(message) {
     return new Date(unixSeconds * 1000).toISOString();
 }
 
+function extractTelegramErrorCode(cause) {
+    for (const value of [cause?.type, cause?.error_message, cause?.code]) {
+        if (typeof value === 'string' && /^[A-Z][A-Z0-9_]*(?:_\d+)?$/.test(value)) {
+            return value;
+        }
+    }
+    return null;
+}
+
 function createRuntimeCallError(operation, cause) {
     return new TelegramWebKRuntimeError(
         `Telegram Web K operation "${operation}" failed.`,
         {
             cause,
-            code: 'TELEGRAM_WEB_K_RUNTIME_CALL_FAILED',
+            code: extractTelegramErrorCode(cause) || 'TELEGRAM_WEB_K_RUNTIME_CALL_FAILED',
+            operation
+        }
+    );
+}
+
+function createOperationUnavailableError(operation) {
+    return new TelegramWebKRuntimeError(
+        `Telegram Web K operation "${operation}" is unavailable in the current runtime.`,
+        {
+            code: 'TELEGRAM_WEB_K_OPERATION_UNAVAILABLE',
             operation
         }
     );
@@ -368,6 +387,34 @@ export class TelegramWebKAdapter {
         });
     }
 
+    async deleteGroup(peerId, kind) {
+        const normalizedPeerId = toFiniteNumber(peerId);
+        if (normalizedPeerId === null || normalizedPeerId >= 0) {
+            throw new TypeError('peerId must identify a Telegram group');
+        }
+        if (kind !== 'group' && kind !== 'supergroup') {
+            throw new TypeError('kind must be "group" or "supergroup"');
+        }
+
+        const operation = kind === 'supergroup' ? 'delete-supergroup' : 'delete-group';
+        try {
+            const managers = this.getManagers();
+            const chatsManager = managers.appChatsManager;
+            const methodName = kind === 'supergroup' ? 'deleteChannel' : 'deleteChat';
+            if (typeof chatsManager?.[methodName] !== 'function') {
+                throw createOperationUnavailableError(operation);
+            }
+
+            await chatsManager[methodName](Math.abs(normalizedPeerId));
+            return Object.freeze({ ok: true });
+        } catch (cause) {
+            if (cause instanceof TelegramWebKRuntimeError) {
+                throw cause;
+            }
+            throw createRuntimeCallError(operation, cause);
+        }
+    }
+
     async sendText(peerId, text) {
         const normalizedPeerId = toFiniteNumber(peerId);
         if (normalizedPeerId === null) {
@@ -412,7 +459,7 @@ export class TelegramWebKAdapter {
                     lastActivity: true,
                     peerResolution: true
                 }),
-                requiresLiveValidation: Object.freeze(['sendText'])
+                requiresLiveValidation: Object.freeze(['deleteGroup', 'sendText'])
             });
         } catch (cause) {
             return Object.freeze({

--- a/src/content/main/infrastructure/telegram-web-k-adapter.test.js
+++ b/src/content/main/infrastructure/telegram-web-k-adapter.test.js
@@ -14,11 +14,24 @@ function createRuntime({
     dialogs = [],
     peers = {},
     messages = {},
-    canSend = true
+    canSend = true,
+    deleteFailures = {}
 } = {}) {
     const calls = [];
     const managers = {
         appChatsManager: {
+            async deleteChannel(chatId) {
+                calls.push(['deleteChannel', chatId]);
+                if (deleteFailures.supergroup) {
+                    throw deleteFailures.supergroup;
+                }
+            },
+            async deleteChat(chatId) {
+                calls.push(['deleteChat', chatId]);
+                if (deleteFailures.group) {
+                    throw deleteFailures.group;
+                }
+            },
             async hasRights(chatId, right) {
                 calls.push(['hasRights', chatId, right]);
                 return canSend;
@@ -55,7 +68,7 @@ function createRuntime({
             return managers;
         }
     };
-    return { calls, globalObject };
+    return { calls, globalObject, managers };
 }
 
 describe('Telegram Web K runtime detection', () => {
@@ -262,6 +275,41 @@ describe('TelegramWebKAdapter', () => {
         assert.equal(candidate.lastActivityAt, null);
         assert.equal(runtime.calls.some(([name]) => name === 'getMessageByPeer'), false);
         assert.equal(runtime.calls.some(([name]) => name === 'hasRights'), false);
+    });
+
+    test('should delete basic groups and supergroups through the matching Telegram manager operations', async () => {
+        const runtime = createRuntime();
+        const adapter = createTelegramWebKAdapter({
+            globalObject: runtime.globalObject,
+            location: new URL('https://web.telegram.org/k/')
+        });
+
+        assert.deepEqual(await adapter.deleteGroup(-10, 'group'), { ok: true });
+        assert.deepEqual(await adapter.deleteGroup(-20, 'supergroup'), { ok: true });
+        assert.ok(runtime.calls.some((call) => call[0] === 'deleteChat' && call[1] === 10));
+        assert.ok(runtime.calls.some((call) => call[0] === 'deleteChannel' && call[1] === 20));
+    });
+
+    test('should preserve Telegram error codes from destructive runtime calls', async () => {
+        const runtime = createRuntime({
+            deleteFailures: {
+                group: { type: 'CHAT_ADMIN_REQUIRED' },
+                supergroup: { type: 'FLOOD_WAIT_30' }
+            }
+        });
+        const adapter = createTelegramWebKAdapter({
+            globalObject: runtime.globalObject,
+            location: new URL('https://web.telegram.org/k/')
+        });
+
+        await assert.rejects(
+            () => adapter.deleteGroup(-10, 'group'),
+            (error) => error.code === 'CHAT_ADMIN_REQUIRED' && error.operation === 'delete-group'
+        );
+        await assert.rejects(
+            () => adapter.deleteGroup(-20, 'supergroup'),
+            (error) => error.code === 'FLOOD_WAIT_30' && error.operation === 'delete-supergroup'
+        );
     });
 
     test('should send text through the existing Telegram manager facade', async () => {


### PR DESCRIPTION
## Summary

- add source-verified Telegram Web K deletion operations for creator-owned basic groups and supergroups
- preserve Telegram RPC error identifiers when available and distinguish batch-fatal runtime/rate-limit failures
- keep active creator-owned groups visible even when text sending is unavailable, so sendability does not incorrectly remove valid deletion targets
- add a reusable checkbox-based group selection model that survives title filtering
- require explicit confirmation both in the UI and again at the deletion workflow boundary before any destructive call can run
- execute deletions sequentially with per-group pending/deleting/deleted/failed/not-attempted results
- stop remaining work on platform-wide failures while preserving already completed deletions
- reconcile successfully deleted groups out of the loaded collection without hiding failed targets
- add destructive confirmation, progress, and final result states to the existing owned-group browser
- document the Web K `deleteChat` / `deleteChannel` boundary and destructive live-validation requirement

## Validation

Automated coverage includes selection/filter interaction, zero-selection validation, explicit confirmation enforcement, non-sendable group retention, basic-group vs supergroup adapter calls, sequential ordering, mixed success/failure, fatal queue interruption, progress observer isolation, and post-delete reconciliation.

CI passes ESLint, TypeScript, the full test suite, production build, and build-output validation.

A final destructive live check should use an explicitly disposable Telegram group because the operation is irreversible.

Closes #175