### PR TITLE
Polish Telegram group browser sorting and actions

### DIFF
--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -5,6 +5,7 @@ import { telegramOwnedGroupsDialogStyles } from '#src/content/main/features/tele
 import {
     createOwnedTelegramGroupsView,
     getSelectedOwnedGroups,
+    TELEGRAM_GROUP_SORT_ORDERS,
     toggleOwnedGroupSelection
 } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import {
@@ -75,6 +76,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         viewState: { state: true },
         message: { state: true },
         filterQuery: { state: true },
+        sortOrder: { state: true },
         actionStage: { state: true },
         selectionAction: { state: true },
         selectedPeerIds: { state: true },
@@ -89,6 +91,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.viewState = 'loading';
         this.message = 'Загружаем группы текущего аккаунта…';
         this.filterQuery = '';
+        this.sortOrder = TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST;
         this.actionStage = 'browse';
         this.selectionAction = null;
         this.selectedPeerIds = [];
@@ -194,6 +197,12 @@ class TelegramOwnedGroupsDialog extends LitElement {
 
     handleFilterInput(event) {
         this.filterQuery = event.currentTarget?.value || '';
+    }
+
+    toggleSortOrder() {
+        this.sortOrder = this.sortOrder === TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST
+            ? TELEGRAM_GROUP_SORT_ORDERS.OLDEST_FIRST
+            : TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST;
     }
 
     startSelection(action) {
@@ -333,18 +342,30 @@ class TelegramOwnedGroupsDialog extends LitElement {
         const summary = this.actionStage === 'select'
             ? `Выбрано: ${selectedCount} · ${resultSummary}`
             : resultSummary;
+        const sortLabel = this.sortOrder === TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST
+            ? 'Новые → старые'
+            : 'Старые → новые';
 
         return html`
             <div class="toolbar">
-                <label data-field>
-                    <span>Фильтр по названию</span>
-                    <input
-                        type="search"
-                        placeholder="Начните вводить название…"
-                        .value=${this.filterQuery}
-                        @input=${this.handleFilterInput}
-                    >
-                </label>
+                <div class="toolbar-controls">
+                    <label class="filter-field" data-field>
+                        <span>Фильтр по названию</span>
+                        <input
+                            type="search"
+                            placeholder="Начните вводить название…"
+                            .value=${this.filterQuery}
+                            @input=${this.handleFilterInput}
+                        >
+                    </label>
+                    <button
+                        class="sort-button"
+                        type="button"
+                        data-control="secondary"
+                        aria-label="Изменить порядок сортировки по последней активности"
+                        @click=${this.toggleSortOrder}
+                    >${sortLabel}</button>
+                </div>
                 <p class="summary" aria-live="polite">${summary}</p>
             </div>
         `;
@@ -352,20 +373,20 @@ class TelegramOwnedGroupsDialog extends LitElement {
 
     renderBrowseActions() {
         return html`
-            <div class="group-actions" data-part="actions">
+            <footer class="group-actions" data-part="actions">
                 <button
                     type="button"
                     data-control="danger"
                     @click=${() => this.startSelection('delete')}
                 >Удалить группы</button>
-            </div>
+            </footer>
         `;
     }
 
     renderSelectionActions() {
         const selectedCount = this.selectedPeerIds.length;
         return html`
-            <div class="selection-actions" data-part="actions">
+            <footer class="selection-actions" data-part="actions">
                 <button type="button" data-control="secondary" @click=${this.cancelSelection}>Отмена</button>
                 <button
                     type="button"
@@ -373,7 +394,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
                     ?disabled=${selectedCount === 0}
                     @click=${this.requestDeleteConfirmation}
                 >Проверить удаление (${selectedCount})</button>
-            </div>
+            </footer>
         `;
     }
 
@@ -462,16 +483,24 @@ class TelegramOwnedGroupsDialog extends LitElement {
     }
 
     renderGroupList() {
-        const view = createOwnedTelegramGroupsView(this.groups, this.filterQuery);
+        const view = createOwnedTelegramGroupsView(
+            this.groups,
+            this.filterQuery,
+            this.sortOrder
+        );
         const selecting = this.actionStage === 'select';
         return html`
-            ${this.renderFilterToolbar(view)}
-            ${view.state === 'filtered-empty' ? this.renderFilterEmptyState() : html`
-                <ul class="group-list">
-                    ${view.groups.map((group) => this.renderGroup(group, { selectable: selecting }))}
-                </ul>
-            `}
-            ${selecting ? this.renderSelectionActions() : this.renderBrowseActions()}
+            <div class="group-browser">
+                ${this.renderFilterToolbar(view)}
+                <div class="group-list-region">
+                    ${view.state === 'filtered-empty' ? this.renderFilterEmptyState() : html`
+                        <ul class="group-list">
+                            ${view.groups.map((group) => this.renderGroup(group, { selectable: selecting }))}
+                        </ul>
+                    `}
+                </div>
+                ${selecting ? this.renderSelectionActions() : this.renderBrowseActions()}
+            </div>
         `;
     }
 

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -79,10 +79,31 @@ export const telegramOwnedGroupsDialogStyles = css`
         min-height: 140px;
     }
 
+    .group-browser {
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        gap: 12px;
+        min-height: 220px;
+    }
+
     .toolbar {
         display: grid;
         gap: 8px;
-        margin-bottom: 12px;
+    }
+
+    .toolbar-controls {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: end;
+        gap: 10px;
+    }
+
+    .sort-button {
+        white-space: nowrap;
+    }
+
+    .group-list-region {
+        min-height: 0;
     }
 
     .group-list,
@@ -172,7 +193,17 @@ export const telegramOwnedGroupsDialogStyles = css`
 
     .group-actions,
     .selection-actions {
-        margin-top: 14px;
+        margin-top: 0;
+        padding-top: 14px;
+        border-top: 1px solid var(--toolfox-border-subtle);
+    }
+
+    .group-actions {
+        justify-content: flex-end;
+    }
+
+    .selection-actions {
+        justify-content: space-between;
     }
 
     .operation-panel {
@@ -246,6 +277,14 @@ export const telegramOwnedGroupsDialogStyles = css`
 
         .content {
             max-height: none;
+        }
+
+        .toolbar-controls {
+            grid-template-columns: 1fr;
+        }
+
+        .sort-button {
+            width: 100%;
         }
     }
 `;

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js
@@ -1,5 +1,9 @@
 const SUPPORTED_STATE = 'supported';
 const GROUP_TYPES = new Set(['group', 'supergroup']);
+const TELEGRAM_GROUP_SORT_ORDERS = Object.freeze({
+    NEWEST_FIRST: 'newest-first',
+    OLDEST_FIRST: 'oldest-first'
+});
 
 function normalizeActivityTimestamp(value) {
     if (!value) {
@@ -31,7 +35,7 @@ function normalizeOwnedGroup(candidate) {
     });
 }
 
-function compareOwnedTelegramGroups(left, right) {
+function compareOwnedTelegramGroups(left, right, sortOrder = TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST) {
     const leftActivity = normalizeActivityTimestamp(left?.lastActivityAt);
     const rightActivity = normalizeActivityTimestamp(right?.lastActivityAt);
 
@@ -42,7 +46,9 @@ function compareOwnedTelegramGroups(left, right) {
         if (rightActivity === null) {
             return -1;
         }
-        return rightActivity - leftActivity;
+        return sortOrder === TELEGRAM_GROUP_SORT_ORDERS.OLDEST_FIRST
+            ? leftActivity - rightActivity
+            : rightActivity - leftActivity;
     }
 
     const leftTitle = String(left?.title || '').toLowerCase();
@@ -54,8 +60,9 @@ function compareOwnedTelegramGroups(left, right) {
     return Number(left?.peerId) - Number(right?.peerId);
 }
 
-function sortOwnedTelegramGroups(groups) {
-    return Object.freeze(Array.from(groups || []).sort(compareOwnedTelegramGroups));
+function sortOwnedTelegramGroups(groups, sortOrder = TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST) {
+    return Object.freeze(Array.from(groups || [])
+        .sort((left, right) => compareOwnedTelegramGroups(left, right, sortOrder)));
 }
 
 function filterOwnedTelegramGroups(groups, query = '') {
@@ -100,7 +107,11 @@ function getSelectedOwnedGroups(groups, selectedPeerIds) {
         .filter(({ peerId }) => selected.has(Number(peerId))));
 }
 
-function createOwnedTelegramGroupsView(groups, query = '') {
+function createOwnedTelegramGroupsView(
+    groups,
+    query = '',
+    sortOrder = TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST
+) {
     const source = Array.from(groups || []);
     if (source.length === 0) {
         return Object.freeze({
@@ -109,7 +120,10 @@ function createOwnedTelegramGroupsView(groups, query = '') {
         });
     }
 
-    const visibleGroups = filterOwnedTelegramGroups(source, query);
+    const visibleGroups = sortOwnedTelegramGroups(
+        filterOwnedTelegramGroups(source, query),
+        sortOrder
+    );
     return Object.freeze({
         groups: visibleGroups,
         state: visibleGroups.length === 0 ? 'filtered-empty' : 'ready'
@@ -176,5 +190,6 @@ export {
     loadOwnedTelegramGroups,
     normalizeOwnedGroup,
     sortOwnedTelegramGroups,
+    TELEGRAM_GROUP_SORT_ORDERS,
     toggleOwnedGroupSelection
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.test.js
@@ -8,6 +8,7 @@ import {
     loadOwnedTelegramGroups,
     normalizeOwnedGroup,
     sortOwnedTelegramGroups,
+    TELEGRAM_GROUP_SORT_ORDERS,
     toggleOwnedGroupSelection
 } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 
@@ -98,6 +99,34 @@ describe('owned Telegram group list presentation', () => {
         assert.deepEqual(source.map(({ peerId }) => peerId), [-10, -30, -20]);
     });
 
+    test('should sort oldest activity first while keeping missing activity last', () => {
+        const source = Object.freeze([
+            Object.freeze({
+                lastActivityAt: '2026-09-03T08:00:00.000Z',
+                peerId: -20,
+                title: 'Newest'
+            }),
+            Object.freeze({
+                lastActivityAt: null,
+                peerId: -30,
+                title: 'No activity'
+            }),
+            Object.freeze({
+                lastActivityAt: '2026-09-01T08:00:00.000Z',
+                peerId: -10,
+                title: 'Oldest'
+            })
+        ]);
+
+        const sorted = sortOwnedTelegramGroups(
+            source,
+            TELEGRAM_GROUP_SORT_ORDERS.OLDEST_FIRST
+        );
+
+        assert.deepEqual(sorted.map(({ peerId }) => peerId), [-10, -20, -30]);
+        assert.deepEqual(source.map(({ peerId }) => peerId), [-20, -30, -10]);
+    });
+
     test('should use deterministic title and peer-id fallbacks for equal or missing activity', () => {
         const equalActivity = '2026-09-03T08:00:00.000Z';
         const groups = [
@@ -128,6 +157,23 @@ describe('owned Telegram group list presentation', () => {
         assert.deepEqual(filtered.map(({ peerId }) => peerId), [-1, -3]);
         assert.deepEqual(restored.map(({ peerId }) => peerId), [-1, -2, -3]);
         assert.equal(groups.length, 3);
+    });
+
+    test('should apply the requested sort order to the filtered local view', () => {
+        const groups = [
+            { lastActivityAt: '2026-09-03T08:00:00.000Z', peerId: -1, title: 'Alpha newer' },
+            { lastActivityAt: '2026-09-01T08:00:00.000Z', peerId: -2, title: 'Alpha older' },
+            { lastActivityAt: '2026-08-01T08:00:00.000Z', peerId: -3, title: 'Beta' }
+        ];
+
+        const view = createOwnedTelegramGroupsView(
+            groups,
+            'alpha',
+            TELEGRAM_GROUP_SORT_ORDERS.OLDEST_FIRST
+        );
+
+        assert.deepEqual(view.groups.map(({ peerId }) => peerId), [-2, -1]);
+        assert.deepEqual(groups.map(({ peerId }) => peerId), [-1, -2, -3]);
     });
 
     test('should distinguish an empty filter result from an account with no owned groups', () => {


### PR DESCRIPTION
## Summary

- add a local activity-sort toggle for owned Telegram groups: newest → oldest and oldest → newest
- keep groups with missing activity timestamps at the bottom in both directions
- preserve filtering and selection while changing sort order without refetching Telegram data
- move destructive group actions into a dedicated footer below the group list
- keep selection-mode actions in the same lower action area for a stable workflow

## Validation

- extend service tests for both sort directions, missing-activity ordering, filtered sorting, and source immutability
- run the repository CI suite for lint, TypeScript, tests, production build, and bundle validation