### PR TITLE
feat: send one message to multiple Telegram groups

### DIFF
--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -449,19 +449,20 @@ class TelegramOwnedGroupsDialog extends LitElement {
         `;
     }
 
-    renderBrowseActions() {
+    renderBrowseActions(disabled = false) {
         const canStartSend = this.groups.some((group) => group.canSendText !== false);
         return html`
             <footer class="group-actions" data-part="actions">
                 <button
                     type="button"
                     data-control
-                    ?disabled=${!canStartSend}
+                    ?disabled=${disabled || !canStartSend}
                     @click=${() => this.startSelection('send')}
                 >Отправить сообщение</button>
                 <button
                     type="button"
                     data-control="danger"
+                    ?disabled=${disabled}
                     @click=${() => this.startSelection('delete')}
                 >Удалить группы</button>
             </footer>
@@ -671,6 +672,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
         const selecting = this.actionStage === 'select';
         return html`
             <div class="group-browser">
+                ${this.renderBrowseActions(selecting)}
                 ${this.renderFilterToolbar(view)}
                 <div class="group-list-region">
                     ${view.state === 'filtered-empty' ? this.renderFilterEmptyState() : html`
@@ -679,7 +681,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
                         </ul>
                     `}
                 </div>
-                ${selecting ? this.renderSelectionActions() : this.renderBrowseActions()}
+                ${selecting ? this.renderSelectionActions() : nothing}
             </div>
         `;
     }

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js
@@ -59,6 +59,16 @@ function formatDeleteStatus(status) {
     }
 }
 
+function formatSendStatus(status) {
+    switch (status) {
+        case 'sent': return 'Отправлено';
+        case 'sending': return 'Отправляется…';
+        case 'failed': return 'Ошибка';
+        case 'not-attempted': return 'Не выполнено';
+        default: return 'Ожидает';
+    }
+}
+
 class TelegramOwnedGroupsDialog extends LitElement {
     static styles = [
         componentFoundationStyles,
@@ -80,7 +90,9 @@ class TelegramOwnedGroupsDialog extends LitElement {
         actionStage: { state: true },
         selectionAction: { state: true },
         selectedPeerIds: { state: true },
+        messageDraft: { state: true },
         deleteProgress: { state: true },
+        sendProgress: { state: true },
         operationError: { state: true }
     };
 
@@ -95,7 +107,9 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.actionStage = 'browse';
         this.selectionAction = null;
         this.selectedPeerIds = [];
+        this.messageDraft = '';
         this.deleteProgress = null;
+        this.sendProgress = null;
         this.operationError = '';
         this.loadPromise = null;
         this.handleKeydownBound = (event) => {
@@ -114,7 +128,7 @@ class TelegramOwnedGroupsDialog extends LitElement {
                 return;
             }
             if (this.actionStage === 'results') {
-                this.finishDeleteResults();
+                this.finishOperationResults();
                 return;
             }
             this.close();
@@ -144,7 +158,9 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.actionStage = 'browse';
         this.selectionAction = null;
         this.selectedPeerIds = [];
+        this.messageDraft = '';
         this.deleteProgress = null;
+        this.sendProgress = null;
         this.operationError = '';
     }
 
@@ -199,6 +215,10 @@ class TelegramOwnedGroupsDialog extends LitElement {
         this.filterQuery = event.currentTarget?.value || '';
     }
 
+    handleMessageInput(event) {
+        this.messageDraft = event.currentTarget?.value || '';
+    }
+
     toggleSortOrder() {
         this.sortOrder = this.sortOrder === TELEGRAM_GROUP_SORT_ORDERS.NEWEST_FIRST
             ? TELEGRAM_GROUP_SORT_ORDERS.OLDEST_FIRST
@@ -206,15 +226,24 @@ class TelegramOwnedGroupsDialog extends LitElement {
     }
 
     startSelection(action) {
+        if (action !== 'delete' && action !== 'send') {
+            return;
+        }
         this.selectionAction = action;
         this.selectedPeerIds = [];
+        this.messageDraft = '';
         this.actionStage = 'select';
         this.deleteProgress = null;
+        this.sendProgress = null;
         this.operationError = '';
     }
 
     cancelSelection() {
         this.resetActionState();
+    }
+
+    isGroupSelectable(group) {
+        return this.selectionAction !== 'send' || group?.canSendText !== false;
     }
 
     handleSelectionChange(event, peerId) {
@@ -228,6 +257,17 @@ class TelegramOwnedGroupsDialog extends LitElement {
     requestDeleteConfirmation() {
         if (
             this.selectionAction !== 'delete'
+            || getSelectedOwnedGroups(this.groups, this.selectedPeerIds).length === 0
+        ) {
+            return;
+        }
+        this.actionStage = 'confirm';
+    }
+
+    requestSendConfirmation() {
+        if (
+            this.selectionAction !== 'send'
+            || this.messageDraft.trim() === ''
             || getSelectedOwnedGroups(this.groups, this.selectedPeerIds).length === 0
         ) {
             return;
@@ -266,7 +306,38 @@ class TelegramOwnedGroupsDialog extends LitElement {
         }
     }
 
-    finishDeleteResults() {
+    async confirmSend() {
+        const selectedGroups = getSelectedOwnedGroups(this.groups, this.selectedPeerIds);
+        const text = this.messageDraft;
+        if (
+            selectedGroups.length === 0
+            || text.trim() === ''
+            || typeof this.options?.onSend !== 'function'
+        ) {
+            return;
+        }
+
+        this.actionStage = 'running';
+        this.operationError = '';
+        try {
+            const result = await this.options.onSend(selectedGroups, text, {
+                confirmed: true,
+                onProgress: (progress) => {
+                    this.sendProgress = progress;
+                }
+            });
+            this.sendProgress = result;
+        } catch (error) {
+            this.operationError = error instanceof Error
+                ? error.message
+                : 'Не удалось выполнить отправку сообщений.';
+        } finally {
+            this.selectedPeerIds = [];
+            this.actionStage = 'results';
+        }
+    }
+
+    finishOperationResults() {
         this.resetActionState();
         this.viewState = this.groups.length > 0 ? 'ready' : 'empty';
         if (this.viewState === 'empty') {
@@ -307,14 +378,21 @@ class TelegramOwnedGroupsDialog extends LitElement {
 
     renderGroup(group, { selectable = false } = {}) {
         const selected = this.selectedPeerIds.includes(group.peerId);
+        const selectionDisabled = selectable && !this.isGroupSelectable(group);
         return html`
-            <li class="group-card ${selected ? 'is-selected' : ''}" data-peer-id=${String(group.peerId)}>
+            <li
+                class="group-card ${selected ? 'is-selected' : ''} ${selectionDisabled ? 'is-unavailable' : ''}"
+                data-peer-id=${String(group.peerId)}
+            >
                 ${selectable ? html`
-                    <label class="selection-control">
+                    <label class="selection-control ${selectionDisabled ? 'is-disabled' : ''}">
                         <input
                             type="checkbox"
                             .checked=${selected}
-                            aria-label=${`Выбрать ${group.title}`}
+                            ?disabled=${selectionDisabled}
+                            aria-label=${selectionDisabled
+                                ? `${group.title}: отправка недоступна`
+                                : `Выбрать ${group.title}`}
                             @change=${(event) => this.handleSelectionChange(event, group.peerId)}
                         >
                     </label>
@@ -372,8 +450,15 @@ class TelegramOwnedGroupsDialog extends LitElement {
     }
 
     renderBrowseActions() {
+        const canStartSend = this.groups.some((group) => group.canSendText !== false);
         return html`
             <footer class="group-actions" data-part="actions">
+                <button
+                    type="button"
+                    data-control
+                    ?disabled=${!canStartSend}
+                    @click=${() => this.startSelection('send')}
+                >Отправить сообщение</button>
                 <button
                     type="button"
                     data-control="danger"
@@ -385,15 +470,33 @@ class TelegramOwnedGroupsDialog extends LitElement {
 
     renderSelectionActions() {
         const selectedCount = this.selectedPeerIds.length;
+        const isSend = this.selectionAction === 'send';
+        const canReview = selectedCount > 0 && (!isSend || this.messageDraft.trim() !== '');
         return html`
-            <footer class="selection-actions" data-part="actions">
-                <button type="button" data-control="secondary" @click=${this.cancelSelection}>Отмена</button>
-                <button
-                    type="button"
-                    data-control="danger"
-                    ?disabled=${selectedCount === 0}
-                    @click=${this.requestDeleteConfirmation}
-                >Проверить удаление (${selectedCount})</button>
+            <footer class="selection-actions ${isSend ? 'send-selection-actions' : ''}" data-part="actions">
+                ${isSend ? html`
+                    <label class="message-composer" data-field>
+                        <span>Сообщение</span>
+                        <textarea
+                            rows="5"
+                            placeholder="Введите текст, который будет отправлен во все выбранные группы…"
+                            .value=${this.messageDraft}
+                            @input=${this.handleMessageInput}
+                        ></textarea>
+                    </label>
+                    <p class="selection-note">
+                        Группы, для которых Telegram уже сообщает о запрете отправки, недоступны для выбора.
+                    </p>
+                ` : nothing}
+                <div class="selection-action-buttons">
+                    <button type="button" data-control="secondary" @click=${this.cancelSelection}>Отмена</button>
+                    <button
+                        type="button"
+                        data-control=${isSend ? '' : 'danger'}
+                        ?disabled=${!canReview}
+                        @click=${isSend ? this.requestSendConfirmation : this.requestDeleteConfirmation}
+                    >${isSend ? `Проверить отправку (${selectedCount})` : `Проверить удаление (${selectedCount})`}</button>
+                </div>
             </footer>
         `;
     }
@@ -428,13 +531,53 @@ class TelegramOwnedGroupsDialog extends LitElement {
         `;
     }
 
-    renderDeleteResultItem(result) {
+    renderSendConfirmation() {
+        const selectedGroups = getSelectedOwnedGroups(this.groups, this.selectedPeerIds);
+        const unknownSendability = selectedGroups.filter(({ canSendText }) => canSendText === null).length;
+        return html`
+            <div class="operation-panel confirmation-panel">
+                <div data-notice="warning">
+                    <strong>Проверьте массовую отправку.</strong>
+                    После подтверждения сообщения станут видимы участникам групп, а уже отправленные сообщения не будут откатываться при ошибке следующей группы.
+                </div>
+                <div>
+                    <h3>Отправить сообщение в групп: ${selectedGroups.length}?</h3>
+                    <p class="operation-copy">Получатели и исходный текст показаны ниже без изменений.</p>
+                </div>
+                ${unknownSendability > 0 ? html`
+                    <div data-notice="warning">
+                        Для групп с неизвестной доступностью отправки Toolfox попробует отправить сообщение и покажет результат отдельно.
+                    </div>
+                ` : nothing}
+                <ul class="review-list">
+                    ${selectedGroups.map((group) => html`
+                        <li>
+                            <strong>${group.title}</strong>
+                            <span>${formatGroupKind(group.kind)} · ID ${group.peerId}</span>
+                        </li>
+                    `)}
+                </ul>
+                <div class="message-review-section">
+                    <strong>Точное сообщение</strong>
+                    <pre class="message-review">${this.messageDraft}</pre>
+                </div>
+                <div data-part="actions">
+                    <button type="button" data-control="secondary" @click=${this.cancelConfirmation}>Назад</button>
+                    <button type="button" data-control @click=${this.confirmSend}>
+                        Да, отправить в ${selectedGroups.length}
+                    </button>
+                </div>
+            </div>
+        `;
+    }
+
+    renderResultItem(result, formatStatus) {
         const hasError = result.status === 'failed' || result.status === 'not-attempted';
         return html`
             <li class="result-card result-${result.status}">
                 <div class="result-heading">
                     <strong>${result.title}</strong>
-                    <span>${formatDeleteStatus(result.status)}</span>
+                    <span>${formatStatus(result.status)}</span>
                 </div>
                 ${hasError ? html`
                     <p class="result-error">
@@ -470,12 +613,49 @@ class TelegramOwnedGroupsDialog extends LitElement {
                 ` : nothing}
                 ${progress?.results?.length ? html`
                     <ul class="result-list">
-                        ${progress.results.map((result) => this.renderDeleteResultItem(result))}
+                        ${progress.results.map((result) => this.renderResultItem(result, formatDeleteStatus))}
                     </ul>
                 ` : nothing}
                 ${!isRunning ? html`
                     <div data-part="actions">
-                        <button type="button" data-control @click=${this.finishDeleteResults}>Вернуться к группам</button>
+                        <button type="button" data-control @click=${this.finishOperationResults}>Вернуться к группам</button>
+                    </div>
+                ` : nothing}
+            </div>
+        `;
+    }
+
+    renderSendProgress() {
+        const progress = this.sendProgress;
+        const isRunning = this.actionStage === 'running';
+        const counts = progress?.counts || {
+            failed: 0,
+            notAttempted: 0,
+            pending: 0,
+            sent: 0,
+            total: 0
+        };
+        const title = isRunning ? 'Отправляем сообщения…' : 'Отправка завершена';
+
+        return html`
+            <div class="operation-panel" aria-live="polite">
+                <div>
+                    <h3>${title}</h3>
+                    <p class="operation-copy">
+                        Отправлено: ${counts.sent} · Ошибок: ${counts.failed} · Не выполнено: ${counts.notAttempted} · Всего: ${counts.total}
+                    </p>
+                </div>
+                ${this.operationError ? html`
+                    <div data-notice="danger">${this.operationError}</div>
+                ` : nothing}
+                ${progress?.results?.length ? html`
+                    <ul class="result-list">
+                        ${progress.results.map((result) => this.renderResultItem(result, formatSendStatus))}
+                    </ul>
+                ` : nothing}
+                ${!isRunning ? html`
+                    <div data-part="actions">
+                        <button type="button" data-control @click=${this.finishOperationResults}>Вернуться к группам</button>
                     </div>
                 ` : nothing}
             </div>
@@ -506,10 +686,14 @@ class TelegramOwnedGroupsDialog extends LitElement {
 
     renderReady() {
         if (this.actionStage === 'confirm') {
-            return this.renderDeleteConfirmation();
+            return this.selectionAction === 'send'
+                ? this.renderSendConfirmation()
+                : this.renderDeleteConfirmation();
         }
         if (this.actionStage === 'running' || this.actionStage === 'results') {
-            return this.renderDeleteProgress();
+            return this.selectionAction === 'send'
+                ? this.renderSendProgress()
+                : this.renderDeleteProgress();
         }
         return this.renderGroupList();
     }
@@ -553,5 +737,6 @@ export {
     formatActivity,
     formatDeleteStatus,
     formatGroupKind,
-    formatSendability
+    formatSendability,
+    formatSendStatus
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -200,7 +200,7 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .group-actions {
-        order: -1;
+        order: -2;
         justify-content: space-between;
         gap: 10px;
         margin: 0;
@@ -212,6 +212,19 @@ export const telegramOwnedGroupsDialogStyles = css`
         display: grid;
         gap: 10px;
         margin-top: 0;
+        padding-top: 14px;
+        border-top: 1px solid var(--toolfox-border-subtle);
+    }
+
+    .send-selection-actions {
+        display: contents;
+    }
+
+    .send-selection-actions .message-composer {
+        order: -1;
+    }
+
+    .send-selection-actions .selection-note {
         padding-top: 14px;
         border-top: 1px solid var(--toolfox-border-subtle);
     }

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -131,6 +131,10 @@ export const telegramOwnedGroupsDialogStyles = css`
         background: var(--toolfox-primary-surface, var(--toolfox-surface-subtle));
     }
 
+    .group-card.is-unavailable {
+        opacity: .68;
+    }
+
     .selection-control {
         display: grid;
         place-items: center;
@@ -146,6 +150,11 @@ export const telegramOwnedGroupsDialogStyles = css`
         margin: 0;
         accent-color: var(--toolfox-primary);
         cursor: pointer;
+    }
+
+    .selection-control.is-disabled,
+    .selection-control.is-disabled input {
+        cursor: not-allowed;
     }
 
     .group-body {
@@ -199,11 +208,37 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .group-actions {
-        justify-content: flex-end;
+        justify-content: space-between;
+        gap: 10px;
     }
 
     .selection-actions {
+        display: grid;
+        gap: 10px;
+    }
+
+    .selection-action-buttons {
+        display: flex;
         justify-content: space-between;
+        gap: 10px;
+    }
+
+    .message-composer {
+        display: grid;
+        gap: 6px;
+        width: 100%;
+    }
+
+    .message-composer textarea {
+        min-height: 104px;
+        resize: vertical;
+    }
+
+    .selection-note {
+        margin: 0;
+        color: var(--toolfox-text-muted);
+        font-size: 11px;
+        line-height: 1.4;
     }
 
     .operation-panel {
@@ -245,7 +280,27 @@ export const telegramOwnedGroupsDialogStyles = css`
         font-weight: 700;
     }
 
-    .result-deleted {
+    .message-review-section {
+        display: grid;
+        gap: 7px;
+    }
+
+    .message-review {
+        margin: 0;
+        padding: 12px 14px;
+        overflow: auto;
+        border: 1px solid var(--toolfox-border-subtle);
+        border-radius: var(--toolfox-radius-control);
+        background: var(--toolfox-surface-subtle);
+        color: var(--toolfox-text);
+        font: inherit;
+        line-height: 1.5;
+        overflow-wrap: anywhere;
+        white-space: pre-wrap;
+    }
+
+    .result-deleted,
+    .result-sent {
         border-color: var(--toolfox-success-border);
     }
 
@@ -257,7 +312,8 @@ export const telegramOwnedGroupsDialogStyles = css`
         border-color: var(--toolfox-warning-border);
     }
 
-    .result-deleting {
+    .result-deleting,
+    .result-sending {
         border-color: var(--toolfox-primary);
     }
 
@@ -285,6 +341,12 @@ export const telegramOwnedGroupsDialogStyles = css`
 
         .sort-button {
             width: 100%;
+        }
+
+        .group-actions,
+        .selection-action-buttons {
+            align-items: stretch;
+            flex-direction: column;
         }
     }
 `;

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -81,7 +81,6 @@ export const telegramOwnedGroupsDialogStyles = css`
 
     .group-browser {
         display: grid;
-        grid-template-rows: auto minmax(0, 1fr) auto;
         gap: 12px;
         min-height: 220px;
     }
@@ -200,21 +199,21 @@ export const telegramOwnedGroupsDialogStyles = css`
         font-size: 12px;
     }
 
-    .group-actions,
-    .selection-actions {
-        margin-top: 0;
-        padding-top: 14px;
-        border-top: 1px solid var(--toolfox-border-subtle);
-    }
-
     .group-actions {
+        order: -1;
         justify-content: space-between;
         gap: 10px;
+        margin: 0;
+        padding-bottom: 14px;
+        border-bottom: 1px solid var(--toolfox-border-subtle);
     }
 
     .selection-actions {
         display: grid;
         gap: 10px;
+        margin-top: 0;
+        padding-top: 14px;
+        border-top: 1px solid var(--toolfox-border-subtle);
     }
 
     .selection-action-buttons {

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.styles.js
@@ -116,6 +116,7 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .group-card {
+        position: relative;
         display: flex;
         align-items: flex-start;
         gap: 12px;
@@ -135,20 +136,27 @@ export const telegramOwnedGroupsDialogStyles = css`
     }
 
     .selection-control {
-        display: grid;
-        place-items: center;
-        flex: 0 0 auto;
-        min-width: 24px;
-        min-height: 24px;
+        position: absolute;
+        inset: 0;
+        display: block;
+        min-width: 0;
+        min-height: 0;
         cursor: pointer;
     }
 
     .selection-control input {
+        position: absolute;
+        top: 14px;
+        left: 16px;
         width: 18px;
         height: 18px;
         margin: 0;
         accent-color: var(--toolfox-primary);
         cursor: pointer;
+    }
+
+    .selection-control + .group-body {
+        padding-left: 30px;
     }
 
     .selection-control.is-disabled,

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.test.js
@@ -47,6 +47,20 @@ describe('Telegram owned-group send interaction', () => {
         assert.equal(dialog.filterQuery, 'beta');
     });
 
+    test('should keep primary group actions rendered but disabled during selection', () => {
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.groups = [group(-10, 'Alpha')];
+        dialog.startSelection('send');
+
+        const groupList = dialog.renderGroupList();
+        const actions = groupList.values[0];
+
+        assert.match(templateText(actions), /Отправить сообщение/);
+        assert.match(templateText(actions), /Удалить группы/);
+        assert.equal(actions.values[0], true);
+        assert.equal(actions.values[2], true);
+    });
+
     test('should require both selected groups and non-whitespace text before review', () => {
         const dialog = new TelegramOwnedGroupsDialog();
         dialog.groups = [group(-10, 'Alpha')];

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.test.js
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+    formatSendStatus,
+    TelegramOwnedGroupsDialog
+} from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js';
+
+function group(peerId, title, overrides = {}) {
+    return Object.freeze({
+        canSendText: true,
+        kind: 'group',
+        lastActivityAt: null,
+        peerId,
+        title,
+        ...overrides
+    });
+}
+
+function templateText(value) {
+    if (value == null || value === false) {
+        return '';
+    }
+    if (Array.isArray(value)) {
+        return value.map(templateText).join('');
+    }
+    if (typeof value !== 'object' || !value.strings) {
+        return String(value);
+    }
+    return value.strings.reduce((output, string, index) =>
+        `${output}${string}${templateText(value.values[index])}`, '');
+}
+
+describe('Telegram owned-group send interaction', () => {
+    test('should keep selection stable while the title filter changes', () => {
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.groups = [
+            group(-10, 'Alpha'),
+            group(-20, 'Beta')
+        ];
+        dialog.startSelection('send');
+        dialog.handleSelectionChange({ currentTarget: { checked: true } }, -10);
+
+        dialog.handleFilterInput({ currentTarget: { value: 'beta' } });
+
+        assert.deepEqual(dialog.selectedPeerIds, [-10]);
+        assert.equal(dialog.filterQuery, 'beta');
+    });
+
+    test('should require both selected groups and non-whitespace text before review', () => {
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.groups = [group(-10, 'Alpha')];
+        dialog.startSelection('send');
+
+        dialog.messageDraft = 'Hello';
+        dialog.requestSendConfirmation();
+        assert.equal(dialog.actionStage, 'select');
+
+        dialog.selectedPeerIds = [-10];
+        dialog.messageDraft = '   ';
+        dialog.requestSendConfirmation();
+        assert.equal(dialog.actionStage, 'select');
+
+        dialog.messageDraft = 'Hello';
+        dialog.requestSendConfirmation();
+        assert.equal(dialog.actionStage, 'confirm');
+    });
+
+    test('should cancel confirmation without sending and preserve the draft workflow', () => {
+        let sendCalls = 0;
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.configure({
+            onSend() {
+                sendCalls += 1;
+            }
+        });
+        dialog.groups = [group(-10, 'Alpha')];
+        dialog.startSelection('send');
+        dialog.selectedPeerIds = [-10];
+        dialog.messageDraft = 'Do not send yet';
+        dialog.requestSendConfirmation();
+
+        dialog.cancelConfirmation();
+
+        assert.equal(sendCalls, 0);
+        assert.equal(dialog.actionStage, 'select');
+        assert.deepEqual(dialog.selectedPeerIds, [-10]);
+        assert.equal(dialog.messageDraft, 'Do not send yet');
+    });
+
+    test('should render recipient identity and the exact message in the review surface', () => {
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.groups = [
+            group(-10, 'Same title'),
+            group(-20, 'Same title', { kind: 'supergroup', canSendText: null })
+        ];
+        dialog.startSelection('send');
+        dialog.selectedPeerIds = [-10, -20];
+        dialog.messageDraft = '  First line\nSecond line  ';
+
+        const markup = templateText(dialog.renderSendConfirmation());
+
+        assert.match(markup, /Отправить сообщение в групп: 2/);
+        assert.match(markup, /Same title/);
+        assert.match(markup, /ID -10/);
+        assert.match(markup, /ID -20/);
+        assert.match(markup, /  First line\nSecond line  /);
+        assert.match(markup, /неизвестной доступностью отправки/);
+    });
+
+    test('should pass the original text and explicit confirmation to the send workflow', async () => {
+        const calls = [];
+        const progress = {
+            counts: { failed: 0, notAttempted: 0, pending: 0, sent: 1, total: 1 },
+            results: [{ peerId: -10, status: 'sent', title: 'Alpha' }]
+        };
+        const dialog = new TelegramOwnedGroupsDialog();
+        dialog.configure({
+            async onSend(groups, text, options) {
+                calls.push({ groups, text, confirmed: options.confirmed });
+                options.onProgress(progress);
+                return progress;
+            }
+        });
+        dialog.groups = [group(-10, 'Alpha')];
+        dialog.startSelection('send');
+        dialog.selectedPeerIds = [-10];
+        dialog.messageDraft = '  Keep my whitespace  ';
+        dialog.requestSendConfirmation();
+
+        await dialog.confirmSend();
+
+        assert.equal(calls.length, 1);
+        assert.deepEqual(calls[0].groups.map(({ peerId }) => peerId), [-10]);
+        assert.equal(calls[0].text, '  Keep my whitespace  ');
+        assert.equal(calls[0].confirmed, true);
+        assert.equal(dialog.sendProgress, progress);
+        assert.equal(dialog.actionStage, 'results');
+        assert.deepEqual(dialog.selectedPeerIds, []);
+    });
+
+    test('should prevent groups with known send restrictions from being selectable for send', () => {
+        const dialog = new TelegramOwnedGroupsDialog();
+        const blocked = group(-10, 'Blocked', { canSendText: false });
+
+        dialog.startSelection('send');
+        assert.equal(dialog.isGroupSelectable(blocked), false);
+
+        dialog.startSelection('delete');
+        assert.equal(dialog.isGroupSelectable(blocked), true);
+    });
+});
+
+test('formats Telegram send result states for progress and summary UI', () => {
+    assert.equal(formatSendStatus('pending'), 'Ожидает');
+    assert.equal(formatSendStatus('sending'), 'Отправляется…');
+    assert.equal(formatSendStatus('sent'), 'Отправлено');
+    assert.equal(formatSendStatus('failed'), 'Ошибка');
+    assert.equal(formatSendStatus('not-attempted'), 'Не выполнено');
+});

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.js
@@ -1,0 +1,151 @@
+const SEND_STATUSES = Object.freeze({
+    FAILED: 'failed',
+    NOT_ATTEMPTED: 'not-attempted',
+    PENDING: 'pending',
+    SENDING: 'sending',
+    SENT: 'sent'
+});
+
+const FATAL_SEND_ERROR_CODES = new Set([
+    'AUTH_KEY_DUPLICATED',
+    'AUTH_KEY_UNREGISTERED',
+    'PEER_FLOOD',
+    'SESSION_EXPIRED',
+    'SESSION_REVOKED',
+    'TELEGRAM_WEB_K_OPERATION_UNAVAILABLE',
+    'TELEGRAM_WEB_K_RUNTIME_CALL_FAILED',
+    'TELEGRAM_WEB_K_UNSUPPORTED_RUNTIME'
+]);
+
+function normalizeError(error) {
+    return Object.freeze({
+        code: typeof error?.code === 'string' ? error.code : 'TELEGRAM_SEND_FAILED',
+        message: error instanceof Error
+            ? error.message
+            : typeof error?.message === 'string'
+                ? error.message
+                : 'Не удалось отправить сообщение.'
+    });
+}
+
+function isFatalTelegramGroupSendError(error) {
+    const code = typeof error?.code === 'string' ? error.code : '';
+    return FATAL_SEND_ERROR_CODES.has(code)
+        || /^FLOOD(?:_[A-Z0-9]+)*_WAIT_\d+$/.test(code);
+}
+
+function createSendResult(group, status, error = null) {
+    const normalizedError = error ? normalizeError(error) : null;
+    return Object.freeze({
+        errorCode: normalizedError?.code || null,
+        errorMessage: normalizedError?.message || null,
+        kind: group.kind,
+        peerId: group.peerId,
+        status,
+        title: group.title
+    });
+}
+
+function summarizeSendResults(results) {
+    const snapshot = Object.freeze(Array.from(results || []));
+    const counts = Object.freeze({
+        failed: snapshot.filter(({ status }) => status === SEND_STATUSES.FAILED).length,
+        notAttempted: snapshot.filter(({ status }) => status === SEND_STATUSES.NOT_ATTEMPTED).length,
+        pending: snapshot.filter(({ status }) => (
+            status === SEND_STATUSES.PENDING || status === SEND_STATUSES.SENDING
+        )).length,
+        sent: snapshot.filter(({ status }) => status === SEND_STATUSES.SENT).length,
+        total: snapshot.length
+    });
+    return Object.freeze({ counts, results: snapshot });
+}
+
+function emitProgress(onProgress, results) {
+    if (typeof onProgress !== 'function') {
+        return;
+    }
+    try {
+        onProgress(summarizeSendResults(results));
+    } catch {
+        // Progress rendering must never change externally visible send semantics.
+    }
+}
+
+function createPreflightBlockedResult(group) {
+    return createSendResult(group, SEND_STATUSES.NOT_ATTEMPTED, {
+        code: 'TELEGRAM_SEND_PREFLIGHT_BLOCKED',
+        message: 'Не выполнено: Telegram сообщает, что отправка текста в эту группу сейчас недоступна.'
+    });
+}
+
+async function sendMessageToOwnedTelegramGroups(adapter, groups, text, {
+    confirmed = false,
+    onProgress
+} = {}) {
+    if (!adapter || typeof adapter.sendText !== 'function') {
+        throw new TypeError('Telegram adapter with sendText() is required.');
+    }
+
+    const targets = Array.from(groups || []);
+    if (targets.length === 0) {
+        throw new TypeError('At least one Telegram group must be selected for sending.');
+    }
+    if (typeof text !== 'string' || text.trim() === '') {
+        throw new TypeError('A non-empty text message is required before sending.');
+    }
+    if (confirmed !== true) {
+        throw new TypeError('Explicit confirmation is required before sending Telegram messages.');
+    }
+
+    const results = targets.map((group) => (
+        group?.canSendText === false
+            ? createPreflightBlockedResult(group)
+            : createSendResult(group, SEND_STATUSES.PENDING)
+    ));
+    emitProgress(onProgress, results);
+
+    for (let index = 0; index < targets.length; index += 1) {
+        if (results[index].status === SEND_STATUSES.NOT_ATTEMPTED) {
+            continue;
+        }
+
+        const group = targets[index];
+        results[index] = createSendResult(group, SEND_STATUSES.SENDING);
+        emitProgress(onProgress, results);
+
+        try {
+            await adapter.sendText(group.peerId, text);
+            results[index] = createSendResult(group, SEND_STATUSES.SENT);
+            emitProgress(onProgress, results);
+        } catch (error) {
+            results[index] = createSendResult(group, SEND_STATUSES.FAILED, error);
+            if (isFatalTelegramGroupSendError(error)) {
+                for (let remaining = index + 1; remaining < targets.length; remaining += 1) {
+                    if (results[remaining].status !== SEND_STATUSES.PENDING) {
+                        continue;
+                    }
+                    results[remaining] = createSendResult(
+                        targets[remaining],
+                        SEND_STATUSES.NOT_ATTEMPTED,
+                        {
+                            code: error.code || 'TELEGRAM_SEND_INTERRUPTED',
+                            message: 'Не выполнено: очередь остановлена после общей ошибки Telegram.'
+                        }
+                    );
+                }
+                emitProgress(onProgress, results);
+                break;
+            }
+            emitProgress(onProgress, results);
+        }
+    }
+
+    return summarizeSendResults(results);
+}
+
+export {
+    isFatalTelegramGroupSendError,
+    SEND_STATUSES,
+    sendMessageToOwnedTelegramGroups,
+    summarizeSendResults
+};

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.test.js
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+    isFatalTelegramGroupSendError,
+    sendMessageToOwnedTelegramGroups
+} from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.js';
+
+function group(peerId, title, overrides = {}) {
+    return Object.freeze({
+        canSendText: true,
+        kind: 'group',
+        peerId,
+        title,
+        ...overrides
+    });
+}
+
+describe('sendMessageToOwnedTelegramGroups', () => {
+    test('should reject execution without targets or a non-empty message', async () => {
+        const adapter = { sendText() {} };
+
+        await assert.rejects(
+            () => sendMessageToOwnedTelegramGroups(adapter, [], 'Hello', { confirmed: true }),
+            /At least one Telegram group/
+        );
+        await assert.rejects(
+            () => sendMessageToOwnedTelegramGroups(adapter, [group(-10, 'One')], '   ', { confirmed: true }),
+            /non-empty text message/
+        );
+    });
+
+    test('should perform zero send calls without explicit confirmation', async () => {
+        const calls = [];
+        const adapter = {
+            async sendText(peerId, text) {
+                calls.push([peerId, text]);
+            }
+        };
+
+        await assert.rejects(
+            () => sendMessageToOwnedTelegramGroups(adapter, [group(-10, 'One')], 'Hello'),
+            /Explicit confirmation is required/
+        );
+        assert.deepEqual(calls, []);
+    });
+
+    test('should send the original text sequentially and preserve mixed results', async () => {
+        const calls = [];
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+        const adapter = {
+            async sendText(peerId, text) {
+                activeCalls += 1;
+                maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+                calls.push([peerId, text]);
+                await Promise.resolve();
+                activeCalls -= 1;
+                if (peerId === -20) {
+                    const error = new Error('Writing is forbidden.');
+                    error.code = 'CHAT_WRITE_FORBIDDEN';
+                    throw error;
+                }
+            }
+        };
+        const text = '  Same message\nfor everyone  ';
+        const targets = [
+            group(-10, 'First'),
+            group(-20, 'Second'),
+            group(-30, 'Third')
+        ];
+
+        const summary = await sendMessageToOwnedTelegramGroups(adapter, targets, text, { confirmed: true });
+
+        assert.equal(maxActiveCalls, 1);
+        assert.deepEqual(calls, [
+            [-10, text],
+            [-20, text],
+            [-30, text]
+        ]);
+        assert.deepEqual(summary.results.map(({ status }) => status), [
+            'sent',
+            'failed',
+            'sent'
+        ]);
+        assert.deepEqual(summary.counts, {
+            failed: 1,
+            notAttempted: 0,
+            pending: 0,
+            sent: 2,
+            total: 3
+        });
+        assert.equal(summary.results[1].errorCode, 'CHAT_WRITE_FORBIDDEN');
+    });
+
+    test('should stop after a platform-wide flood wait and mark remaining targets not attempted', async () => {
+        const calls = [];
+        const adapter = {
+            async sendText(peerId) {
+                calls.push(peerId);
+                if (peerId === -20) {
+                    const error = new Error('Flood wait.');
+                    error.code = 'FLOOD_WAIT_30';
+                    throw error;
+                }
+            }
+        };
+        const targets = [
+            group(-10, 'First'),
+            group(-20, 'Second'),
+            group(-30, 'Third'),
+            group(-40, 'Fourth')
+        ];
+
+        const summary = await sendMessageToOwnedTelegramGroups(adapter, targets, 'Hello', { confirmed: true });
+
+        assert.deepEqual(calls, [-10, -20]);
+        assert.deepEqual(summary.results.map(({ status }) => status), [
+            'sent',
+            'failed',
+            'not-attempted',
+            'not-attempted'
+        ]);
+        assert.equal(summary.counts.notAttempted, 2);
+        assert.equal(summary.results[2].errorCode, 'FLOOD_WAIT_30');
+    });
+
+    test('should treat slow mode as target-specific and continue without retrying or bypassing it', async () => {
+        const calls = [];
+        const adapter = {
+            async sendText(peerId) {
+                calls.push(peerId);
+                if (peerId === -10) {
+                    const error = new Error('Slow mode wait.');
+                    error.code = 'SLOWMODE_WAIT_15';
+                    throw error;
+                }
+            }
+        };
+
+        const summary = await sendMessageToOwnedTelegramGroups(adapter, [
+            group(-10, 'Slow'),
+            group(-20, 'Next')
+        ], 'Hello', { confirmed: true });
+
+        assert.deepEqual(calls, [-10, -20]);
+        assert.deepEqual(summary.results.map(({ status }) => status), ['failed', 'sent']);
+        assert.equal(summary.results[0].errorCode, 'SLOWMODE_WAIT_15');
+    });
+
+    test('should skip groups blocked by the preflight sendability check', async () => {
+        const calls = [];
+        const adapter = {
+            async sendText(peerId) {
+                calls.push(peerId);
+            }
+        };
+
+        const summary = await sendMessageToOwnedTelegramGroups(adapter, [
+            group(-10, 'Blocked', { canSendText: false }),
+            group(-20, 'Allowed')
+        ], 'Hello', { confirmed: true });
+
+        assert.deepEqual(calls, [-20]);
+        assert.deepEqual(summary.results.map(({ status }) => status), ['not-attempted', 'sent']);
+        assert.equal(summary.results[0].errorCode, 'TELEGRAM_SEND_PREFLIGHT_BLOCKED');
+    });
+
+    test('should expose progress snapshots without allowing observer failures to interrupt sends', async () => {
+        const snapshots = [];
+        let progressCalls = 0;
+
+        const summary = await sendMessageToOwnedTelegramGroups({
+            async sendText() {}
+        }, [group(-10, 'One')], 'Hello', {
+            confirmed: true,
+            onProgress(snapshot) {
+                snapshots.push(snapshot.results.map(({ status }) => status));
+                progressCalls += 1;
+                if (progressCalls === 2) {
+                    throw new Error('render failed');
+                }
+            }
+        });
+
+        assert.deepEqual(snapshots, [
+            ['pending'],
+            ['sending'],
+            ['sent']
+        ]);
+        assert.equal(summary.results[0].status, 'sent');
+    });
+});
+
+describe('Telegram group send failure classification', () => {
+    test('should distinguish platform-wide interruption from target-specific restrictions', () => {
+        assert.equal(isFatalTelegramGroupSendError({ code: 'FLOOD_WAIT_10' }), true);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'FLOOD_PREMIUM_WAIT_10' }), true);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'SESSION_REVOKED' }), true);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'TELEGRAM_WEB_K_RUNTIME_CALL_FAILED' }), true);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'SLOWMODE_WAIT_10' }), false);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'CHAT_WRITE_FORBIDDEN' }), false);
+        assert.equal(isFatalTelegramGroupSendError({ code: 'USER_BANNED_IN_CHANNEL' }), false);
+    });
+});

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
@@ -4,6 +4,17 @@ import { sendMessageToOwnedTelegramGroups } from '#src/content/main/features/tel
 import { loadOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
 
+function isolateDialogKeyboardEvents(dialog) {
+    if (!dialog?.addEventListener) {
+        return;
+    }
+
+    dialog.addEventListener('keydown', (event) => {
+        dialog.handleKeydownBound?.(event);
+        event.stopPropagation();
+    });
+}
+
 function createTelegramOwnedGroupsFeature({
     adapter,
     documentApi = globalThis.document,
@@ -30,6 +41,7 @@ function createTelegramOwnedGroupsFeature({
         }
 
         dialog = documentApi.createElement(TELEGRAM_OWNED_GROUPS_DIALOG_TAG);
+        isolateDialogKeyboardEvents(dialog);
         dialog.configure({
             onClose: close,
             onDelete: (groups, options) => deleteOwnedTelegramGroups(adapter, groups, options),
@@ -62,5 +74,6 @@ const telegramOwnedGroupsFeatureDefinition = Object.freeze({
 
 export {
     createTelegramOwnedGroupsFeature,
+    isolateDialogKeyboardEvents,
     telegramOwnedGroupsFeatureDefinition
 };

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
@@ -2,6 +2,7 @@ import { deleteOwnedTelegramGroups } from '#src/content/main/features/telegram-o
 import { TELEGRAM_OWNED_GROUPS_DIALOG_TAG } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js';
 import { sendMessageToOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.js';
 import { loadOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
+import { registerTelegramWebKEscapeGuard } from '#src/content/main/infrastructure/telegram-web-k-navigation-guard.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
 
 function isolateDialogKeyboardEvents(dialog) {
@@ -28,8 +29,11 @@ function createTelegramOwnedGroupsFeature({
     }
 
     let dialog = null;
+    let unregisterEscapeGuard = null;
 
     function close() {
+        unregisterEscapeGuard?.();
+        unregisterEscapeGuard = null;
         dialog?.remove();
         dialog = null;
     }
@@ -42,6 +46,7 @@ function createTelegramOwnedGroupsFeature({
 
         dialog = documentApi.createElement(TELEGRAM_OWNED_GROUPS_DIALOG_TAG);
         isolateDialogKeyboardEvents(dialog);
+        unregisterEscapeGuard = registerTelegramWebKEscapeGuard(adapter);
         dialog.configure({
             onClose: close,
             onDelete: (groups, options) => deleteOwnedTelegramGroups(adapter, groups, options),

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.js
@@ -1,5 +1,6 @@
 import { deleteOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-deletion.js';
 import { TELEGRAM_OWNED_GROUPS_DIALOG_TAG } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-dialog.js';
+import { sendMessageToOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-messaging.js';
 import { loadOwnedTelegramGroups } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups-service.js';
 import { WINDOW_MESSAGE_TYPES } from '#src/shared/messaging/index.js';
 
@@ -32,7 +33,13 @@ function createTelegramOwnedGroupsFeature({
         dialog.configure({
             onClose: close,
             onDelete: (groups, options) => deleteOwnedTelegramGroups(adapter, groups, options),
-            onLoad: () => loadOwnedTelegramGroups(adapter)
+            onLoad: () => loadOwnedTelegramGroups(adapter),
+            onSend: (groups, text, options) => sendMessageToOwnedTelegramGroups(
+                adapter,
+                groups,
+                text,
+                options
+            )
         });
         (documentApi.body || documentApi.documentElement).append(dialog);
         logger.log('Telegram owned-group browser opened.');

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isolateDialogKeyboardEvents } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups.js';
+
+function createDialog() {
+    const listeners = new Map();
+    const handledKeys = [];
+    return {
+        handledKeys,
+        addEventListener(type, listener) {
+            listeners.set(type, listener);
+        },
+        dispatch(type, event) {
+            listeners.get(type)?.(event);
+        },
+        handleKeydownBound(event) {
+            handledKeys.push(event.key);
+        }
+    };
+}
+
+test('owned-group dialog keyboard events should not bubble into Telegram', () => {
+    const dialog = createDialog();
+    let propagationStopped = false;
+    const event = {
+        key: 'a',
+        stopPropagation() {
+            propagationStopped = true;
+        }
+    };
+
+    isolateDialogKeyboardEvents(dialog);
+    dialog.dispatch('keydown', event);
+
+    assert.equal(propagationStopped, true);
+    assert.deepEqual(dialog.handledKeys, ['a']);
+});
+
+test('owned-group dialog keyboard isolation should preserve dialog Escape handling', () => {
+    const dialog = createDialog();
+    let propagationStopped = false;
+    const event = {
+        key: 'Escape',
+        stopPropagation() {
+            propagationStopped = true;
+        }
+    };
+
+    isolateDialogKeyboardEvents(dialog);
+    dialog.dispatch('keydown', event);
+
+    assert.equal(propagationStopped, true);
+    assert.deepEqual(dialog.handledKeys, ['Escape']);
+});

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
@@ -18,6 +18,9 @@ function createDialog() {
         configure(options) {
             this.options = options;
         },
+        connect() {
+            this.isConnected = true;
+        },
         dispatch(type, event) {
             listeners.get(type)?.(event);
         },
@@ -83,7 +86,7 @@ test('owned-group feature should suppress Telegram Escape only while dialog is o
     const documentApi = {
         body: {
             append(element) {
-                element.isConnected = true;
+                element.connect();
             }
         },
         createElement() {
@@ -96,6 +99,7 @@ test('owned-group feature should suppress Telegram Escape only while dialog is o
 
     assert.equal(escapeHandler(), false);
     assert.equal(unregisterCalls, 0);
+    assert.equal(dialog.isConnected, true);
 
     dialog.options.onClose();
 

--- a/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
+++ b/src/content/main/features/telegram-owned-groups/telegram-owned-groups.test.js
@@ -1,21 +1,31 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { isolateDialogKeyboardEvents } from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups.js';
+import {
+    createTelegramOwnedGroupsFeature,
+    isolateDialogKeyboardEvents
+} from '#src/content/main/features/telegram-owned-groups/telegram-owned-groups.js';
 
 function createDialog() {
     const listeners = new Map();
     const handledKeys = [];
     return {
         handledKeys,
+        isConnected: false,
         addEventListener(type, listener) {
             listeners.set(type, listener);
+        },
+        configure(options) {
+            this.options = options;
         },
         dispatch(type, event) {
             listeners.get(type)?.(event);
         },
         handleKeydownBound(event) {
             handledKeys.push(event.key);
+        },
+        remove() {
+            this.isConnected = false;
         }
     };
 }
@@ -52,4 +62,43 @@ test('owned-group dialog keyboard isolation should preserve dialog Escape handli
 
     assert.equal(propagationStopped, true);
     assert.deepEqual(dialog.handledKeys, ['Escape']);
+});
+
+test('owned-group feature should suppress Telegram Escape only while dialog is open', () => {
+    let escapeHandler = null;
+    let unregisterCalls = 0;
+    const dialog = createDialog();
+    const adapter = {
+        globalObject: {
+            appNavigationController: {
+                registerEscapeHandler(handler) {
+                    escapeHandler = handler;
+                    return () => {
+                        unregisterCalls += 1;
+                    };
+                }
+            }
+        }
+    };
+    const documentApi = {
+        body: {
+            append(element) {
+                element.isConnected = true;
+            }
+        },
+        createElement() {
+            return dialog;
+        }
+    };
+    const feature = createTelegramOwnedGroupsFeature({ adapter, documentApi });
+
+    feature.open();
+
+    assert.equal(escapeHandler(), false);
+    assert.equal(unregisterCalls, 0);
+
+    dialog.options.onClose();
+
+    assert.equal(unregisterCalls, 1);
+    assert.equal(dialog.isConnected, false);
 });

--- a/src/content/main/infrastructure/telegram-web-k-navigation-guard.js
+++ b/src/content/main/infrastructure/telegram-web-k-navigation-guard.js
@@ -1,0 +1,15 @@
+function registerTelegramWebKEscapeGuard(adapter) {
+    const navigationController = adapter?.globalObject?.appNavigationController;
+    if (typeof navigationController?.registerEscapeHandler !== 'function') {
+        return null;
+    }
+
+    try {
+        const unregister = navigationController.registerEscapeHandler(() => false);
+        return typeof unregister === 'function' ? unregister : null;
+    } catch {
+        return null;
+    }
+}
+
+export { registerTelegramWebKEscapeGuard };

--- a/src/content/main/infrastructure/telegram-web-k-navigation-guard.test.js
+++ b/src/content/main/infrastructure/telegram-web-k-navigation-guard.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { registerTelegramWebKEscapeGuard } from '#src/content/main/infrastructure/telegram-web-k-navigation-guard.js';
+
+test('Telegram escape guard should block Telegram navigation and expose cleanup', () => {
+    let registeredHandler = null;
+    let unregisterCalls = 0;
+    const adapter = {
+        globalObject: {
+            appNavigationController: {
+                registerEscapeHandler(handler) {
+                    registeredHandler = handler;
+                    return () => {
+                        unregisterCalls += 1;
+                    };
+                }
+            }
+        }
+    };
+
+    const unregister = registerTelegramWebKEscapeGuard(adapter);
+
+    assert.equal(typeof unregister, 'function');
+    assert.equal(registeredHandler(), false);
+
+    unregister();
+    assert.equal(unregisterCalls, 1);
+});
+
+test('Telegram escape guard should degrade safely when navigation hook is unavailable', () => {
+    assert.equal(registerTelegramWebKEscapeGuard({ globalObject: {} }), null);
+    assert.equal(registerTelegramWebKEscapeGuard(null), null);
+});


### PR DESCRIPTION
## Summary

- add a sequential Telegram batch-send workflow with per-group progress/results and fatal queue interruption semantics
- reuse the owned-group selection mode for message targeting, preserving selections across filtering
- add text composition plus an explicit recipient/message review step before any send call
- prevent selecting groups that Telegram already reports as non-sendable and surface unknown sendability explicitly
- wire the workflow through the existing Telegram Web K adapter only

## Safety and failure semantics

- no send occurs without explicit confirmation
- the original text is passed unchanged to every attempted target
- sends run sequentially, never via a burst/`Promise.all`
- target-specific failures such as slow mode/write restrictions are recorded and the queue continues
- platform-wide failures such as flood waits/session/runtime failures stop the remaining queue and mark untouched targets as not attempted
- successful sends remain successful if a later target fails; there is no rollback claim

## Tests

Added coverage for validation, confirmation/cancellation, filter-stable selection, sequential ordering, unchanged message text, mixed success/failure, slow mode, flood-wait interruption, preflight blocked groups, progress snapshots, recipient/message review, and result formatting.

Closes #171