### PR TITLE
Fix Telegram dialog pagination for large accounts

### DIFF
--- a/docs/telegram-web-k-runtime-adapter.md
+++ b/docs/telegram-web-k-runtime-adapter.md
@@ -17,6 +17,7 @@ Reviewed against the current Telegram Web K source on 2026-09-03 (`morethanwords
 - `createProxiedManagersForAccount(accountNumber)` is mounted on the page global object by `src/lib/getProxiedManagers.ts`.
 - The active account number is derived from the `account` URL query parameter. Valid account numbers are `1` through `4`; absent or invalid values resolve to account `1`.
 - `dialogsStorage.getDialogs({ offsetIndex, limit })` returns a page containing `dialogs`; each normal dialog exposes `peerId` and `top_message` used by the adapter.
+- `offsetIndex` is a dialog-index cursor, not a positional array offset. Current Web K results expose `isEnd`; when more pages remain, Web K advances the cursor to the lowest dialog index in the returned page. The adapter derives that value through `dialogsStorage.getDialogIndex(dialog)`, whose default index key follows each dialog's folder.
 - `appPeersManager.getPeer(peerId)` resolves the current peer object.
 - Telegram group shapes used by Toolfox are:
   - basic group: peer `_ === 'chat'`;

--- a/src/content/main/infrastructure/telegram-web-k-adapter-pagination.test.js
+++ b/src/content/main/infrastructure/telegram-web-k-adapter-pagination.test.js
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createTelegramWebKAdapter } from '#src/content/main/infrastructure/telegram-web-k-adapter.js';
+
+function getDialogCursor(dialog) {
+    return dialog[`index_${dialog.folder_id ?? 0}`];
+}
+
+function createCursorRuntime() {
+    const calls = [];
+    const dialogs = [
+        { peerId: -10, top_message: 100, folder_id: 0, index_0: 9000 },
+        { peerId: -20, top_message: 200, folder_id: 1, index_1: 7000 },
+        { peerId: -30, top_message: 300, folder_id: 0, index_0: 5000 }
+    ];
+    const dialogsStorage = {
+        async getDialogIndex(dialog) {
+            const indexKey = `index_${dialog.folder_id ?? 0}`;
+            calls.push(['getDialogIndex', dialog.peerId, indexKey]);
+            return dialog[indexKey];
+        },
+        async getDialogs({ limit, offsetIndex }) {
+            calls.push(['getDialogs', { limit, offsetIndex }]);
+            const cursorStart = offsetIndex === 0
+                ? 0
+                : dialogs.findIndex((dialog) => getDialogCursor(dialog) < offsetIndex);
+            const start = cursorStart < 0 ? dialogs.length : cursorStart;
+            const page = dialogs.slice(start, start + limit);
+            return {
+                count: dialogs.length,
+                dialogs: page,
+                isEnd: start + page.length >= dialogs.length
+            };
+        }
+    };
+    const globalObject = {
+        createProxiedManagersForAccount() {
+            return { dialogsStorage };
+        }
+    };
+    return { calls, globalObject };
+}
+
+test('should follow Telegram dialog index cursors instead of treating offsets as positions', async () => {
+    const runtime = createCursorRuntime();
+    const adapter = createTelegramWebKAdapter({
+        globalObject: runtime.globalObject,
+        location: new URL('https://web.telegram.org/k/')
+    });
+
+    const firstPage = await adapter.listDialogs({ limit: 2, offset: 0 });
+    const secondPage = await adapter.listDialogs({ limit: 2, offset: firstPage.nextOffset });
+
+    assert.deepEqual(firstPage, {
+        count: 3,
+        items: [
+            { peerId: -10, topMessageId: 100 },
+            { peerId: -20, topMessageId: 200 }
+        ],
+        nextOffset: 7000
+    });
+    assert.deepEqual(secondPage, {
+        count: 3,
+        items: [{ peerId: -30, topMessageId: 300 }],
+        nextOffset: null
+    });
+    assert.deepEqual(
+        runtime.calls.filter(([name]) => name === 'getDialogs'),
+        [
+            ['getDialogs', { limit: 2, offsetIndex: 0 }],
+            ['getDialogs', { limit: 2, offsetIndex: 7000 }]
+        ]
+    );
+    assert.ok(runtime.calls.some((call) => (
+        call[0] === 'getDialogIndex'
+        && call[1] === -20
+        && call[2] === 'index_1'
+    )));
+    assert.equal('folder_id' in firstPage.items[1], false);
+    assert.equal('index_1' in firstPage.items[1], false);
+});
+
+test('should reject a Telegram dialog page whose cursor cannot advance', async () => {
+    const dialogsStorage = {
+        async getDialogIndex(dialog) {
+            return dialog.index_0;
+        },
+        async getDialogs() {
+            return {
+                count: 2,
+                dialogs: [{ peerId: -10, top_message: 100, index_0: 7000 }],
+                isEnd: false
+            };
+        }
+    };
+    const adapter = createTelegramWebKAdapter({
+        globalObject: {
+            createProxiedManagersForAccount() {
+                return { dialogsStorage };
+            }
+        },
+        location: new URL('https://web.telegram.org/k/')
+    });
+
+    await assert.rejects(
+        () => adapter.listDialogs({ limit: 1, offset: 7000 }),
+        (error) => {
+            assert.equal(error.operation, 'list-dialogs');
+            assert.match(error.cause?.message || '', /did not advance/);
+            return true;
+        }
+    );
+});

--- a/src/content/main/infrastructure/telegram-web-k-adapter.js
+++ b/src/content/main/infrastructure/telegram-web-k-adapter.js
@@ -93,6 +93,25 @@ function normalizeDialogSummary(dialog) {
     });
 }
 
+async function resolveDialogPaginationCursor(dialogsStorage, dialogs, currentOffset) {
+    if (typeof dialogsStorage?.getDialogIndex !== 'function') {
+        throw new TypeError('Telegram dialog cursor helper is unavailable.');
+    }
+
+    const indexes = await Promise.all(dialogs.map((dialog) => (
+        dialogsStorage.getDialogIndex(dialog)
+    )));
+    const nextOffset = indexes.reduce((lowest, value) => {
+        const index = toFiniteNumber(value);
+        return index !== null && index < lowest ? index : lowest;
+    }, currentOffset || Infinity);
+
+    if (!Number.isFinite(nextOffset) || nextOffset === currentOffset) {
+        throw new TypeError('Telegram dialog pagination did not advance.');
+    }
+    return nextOffset;
+}
+
 function normalizePeerType(peer) {
     if (peer?._ === 'chat') {
         return 'group';
@@ -280,7 +299,8 @@ export class TelegramWebKAdapter {
         const safeOffset = Math.max(0, Math.trunc(offset));
         try {
             const managers = this.getManagers();
-            const result = await managers.dialogsStorage.getDialogs({
+            const dialogsStorage = managers.dialogsStorage;
+            const result = await dialogsStorage.getDialogs({
                 limit: safeLimit,
                 offsetIndex: safeOffset
             });
@@ -293,10 +313,18 @@ export class TelegramWebKAdapter {
                 .map(normalizeDialogSummary)
                 .filter(Boolean);
             const count = toFiniteNumber(result.count);
-            const nextOffset = rawPageSize === 0
-                || (count !== null && safeOffset + rawPageSize >= count)
-                ? null
-                : safeOffset + rawPageSize;
+            let nextOffset = null;
+            if (rawPageSize > 0 && result.isEnd === false) {
+                nextOffset = await resolveDialogPaginationCursor(
+                    dialogsStorage,
+                    result.dialogs,
+                    safeOffset
+                );
+            } else if (rawPageSize > 0 && typeof result.isEnd !== 'boolean') {
+                nextOffset = count !== null && safeOffset + rawPageSize >= count
+                    ? null
+                    : safeOffset + rawPageSize;
+            }
 
             return Object.freeze({
                 count,


### PR DESCRIPTION
## Summary

- follow Telegram Web K's dialog-index cursor instead of incrementing `offsetIndex` by page size
- use `isEnd` as the current runtime's pagination termination signal
- keep the previous count/positional behavior only as a compatibility fallback when `isEnd` is absent
- fail explicitly if the current cursor-based runtime cannot advance its cursor
- document the verified Web K pagination contract
- add regression coverage with non-positional cursors (`9000 → 7000 → 5000`)

## Why

Toolfox could stop effectively at the recently loaded portion of a large Telegram account because it treated `offsetIndex` as an array position. Web K uses it as an opaque-ish dialog-index cursor, so values such as `100`, `200`, ... are not valid page numbers.

## Validation

The regression tests model Web K's source-verified cursor semantics and ensure normalized dialog summaries do not leak Telegram index fields.

Live validation on the affected large account is still useful after CI, because the bug only becomes visible with enough dialogs to cross multiple real Web K pages.